### PR TITLE
Add RpcStreamHandler trait

### DIFF
--- a/service-bus/bus/src/lib.rs
+++ b/service-bus/bus/src/lib.rs
@@ -1,3 +1,4 @@
+use futures::prelude::Stream;
 use serde::{de::DeserializeOwned, Serialize};
 use std::future::Future;
 
@@ -28,6 +29,12 @@ pub trait RpcHandler<T: RpcMessage> {
     fn handle(&mut self, caller: BusPath, msg: T) -> Self::Result;
 }
 
+pub trait RpcStreamHandler<T: RpcMessage> {
+    type Result: Stream<Item = T::Reply>;
+
+    fn handle(&mut self, caller: BusPath, msgs: Vec<T>) -> Self::Result;
+}
+
 pub struct Handle;
 
 pub fn bind<T: RpcMessage>(addr: &BusPath, endpoint: impl RpcHandler<T>) -> Handle {
@@ -40,7 +47,7 @@ pub fn service<T: RpcMessage>(addr: &BusPath) -> impl RpcEndpoint<T> {
 
 struct MockEndpoint<T>(T);
 
-impl<M: RpcMessage> RpcEndpoint<M> for MockEndpoint<M> where {
+impl<M: RpcMessage> RpcEndpoint<M> for MockEndpoint<M> {
     type Result = futures::future::Ready<M::Reply>;
 
     fn send(&self, msg: M) -> Self::Result {


### PR DESCRIPTION
This commit adds trait `RpcStreamHandler` which generates an
asynchronous stream in response to a `Vec` of `RpcMessage`s.
This trait is a collection parallel to `RpcHandler`.