### PR TITLE
Service bus API - new header type

### DIFF
--- a/service-bus/api/Cargo.toml
+++ b/service-bus/api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "0.4.12"
+failure = "0.1.6"
 prost = "0.5.0"
 
 [build-dependencies]

--- a/service-bus/api/protos/gsb_api.proto
+++ b/service-bus/api/protos/gsb_api.proto
@@ -71,19 +71,3 @@ message CallReply {
   CallReplyType reply_type = 3;
   bytes data = 4;
 }
-
-// Plumbing
-
-enum MessageType {
-  REGISTER_REQUEST = 0;
-  REGISTER_REPLY = 1;
-  UNREGISTER_REQUEST = 2;
-  UNREGISTER_REPLY = 3;
-  CALL_REQUEST = 4;
-  CALL_REPLY = 5;
-}
-
-message MessageHeader {
-  MessageType msg_type = 1;
-  uint32 msg_length = 2;
-}

--- a/service-bus/api/src/gsb_api.rs
+++ b/service-bus/api/src/gsb_api.rs
@@ -1,0 +1,77 @@
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RegisterRequest {
+    #[prost(string, tag = "1")]
+    pub service_id: std::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RegisterReply {
+    #[prost(enumeration = "RegisterReplyCode", tag = "1")]
+    pub code: i32,
+    /// in case of errors
+    #[prost(string, tag = "2")]
+    pub message: std::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnregisterRequest {
+    #[prost(string, tag = "1")]
+    pub service_id: std::string::String,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct UnregisterReply {
+    #[prost(enumeration = "UnregisterReplyCode", tag = "1")]
+    pub code: i32,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CallRequest {
+    #[prost(string, tag = "1")]
+    pub caller: std::string::String,
+    #[prost(string, tag = "2")]
+    pub address: std::string::String,
+    #[prost(string, tag = "3")]
+    pub request_id: std::string::String,
+    #[prost(bytes, tag = "4")]
+    pub data: std::vec::Vec<u8>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CallReply {
+    #[prost(string, tag = "1")]
+    pub request_id: std::string::String,
+    #[prost(enumeration = "CallReplyCode", tag = "2")]
+    pub code: i32,
+    #[prost(enumeration = "CallReplyType", tag = "3")]
+    pub reply_type: i32,
+    #[prost(bytes, tag = "4")]
+    pub data: std::vec::Vec<u8>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum RegisterReplyCode {
+    RegisteredOk = 0,
+    /// e.g. invalid name
+    RegisterBadRequest = 400,
+    /// already registered
+    RegisterConflict = 409,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum UnregisterReplyCode {
+    UnregisteredOk = 0,
+    NotRegistered = 404,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum CallReplyCode {
+    CallReplyOk = 0,
+    /// eg. duplicate request ID, service not found etc.
+    CallReplyBadRequest = 400,
+    /// e.g. service did not respond in time
+    ServiceFailure = 500,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum CallReplyType {
+    /// a single response or end of stream
+    Full = 0,
+    /// i.e. a streaming response
+    Partial = 1,
+}

--- a/service-bus/api/src/lib.rs
+++ b/service-bus/api/src/lib.rs
@@ -2,4 +2,50 @@ mod gsb_api {
     include!(concat!(env!("OUT_DIR"), "/gsb_api.rs"));
 }
 
+use bytes::BytesMut;
+use failure;
+use std::mem::size_of;
+
 pub use gsb_api::*;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum MessageType {
+    RegisterRequest = 0,
+    RegisterReply = 1,
+    UnregisterRequest = 2,
+    UnregisterReply = 3,
+    CallRequest = 4,
+    CallReply = 5,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct MessageHeader {
+    pub msg_type: i32,
+    pub msg_length: u32,
+}
+
+impl MessageHeader {
+    pub fn encode(&self, buf: &mut BytesMut) {
+        buf.extend_from_slice(&self.msg_type.to_be_bytes());
+        buf.extend_from_slice(&self.msg_length.to_be_bytes());
+    }
+
+    pub fn decode(mut src: BytesMut) -> failure::Fallible<Self> {
+        if src.len() < size_of::<MessageHeader>() {
+            return Err(failure::err_msg(
+                "Cannot decode message header: not enough bytes",
+            ));
+        }
+
+        let mut msg_type: [u8; 4] = [0; 4];
+        let mut msg_length: [u8; 4] = [0; 4];
+        msg_type.copy_from_slice(src.split_to(size_of::<i32>()).as_ref());
+        msg_length.copy_from_slice(src.split_to(size_of::<u32>()).as_ref());
+
+        Ok(MessageHeader {
+            msg_type: i32::from_be_bytes(msg_type),
+            msg_length: u32::from_be_bytes(msg_length),
+        })
+    }
+}


### PR DESCRIPTION
Protobuf doesn't support fixed-length messages so a different approach was needed to have a proper message header.