### PR TITLE
WebClient with convenient methods compatible with async/await

### DIFF
--- a/interfaces/client/Cargo.toml
+++ b/interfaces/client/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 [dependencies]
 ya-model = { path = "../model" }
 
-actix-http = "0.2"
 async-trait = "0.1"
 awc = "0.2"
+backtrace = "0.3"
 bytes = "0.4"
 failure = "0.1.6"
 futures = { version = "0.3", features = ["compat"] }

--- a/interfaces/client/examples/market_interaction.rs
+++ b/interfaces/client/examples/market_interaction.rs
@@ -87,5 +87,9 @@ async fn interact() -> Result<()> {
 fn main() {
     actix_rt::System::new("test")
         .block_on(interact().boxed_local().compat())
+        .map_err(|e| {
+            println!("{}", e);
+            e
+        })
         .expect("Runtime error");
 }

--- a/interfaces/client/src/error.rs
+++ b/interfaces/client/src/error.rs
@@ -1,14 +1,24 @@
 //! Error definitions and mappings
+use backtrace::Backtrace;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
-    #[error("AWC sending request error: {0}")]
-    SendRequestError(awc::error::SendRequestError),
-    #[error("AWC payload error: {0}")]
-    PayloadError(awc::error::PayloadError),
-    #[error("AWC JSON payload error: {0}")]
-    JsonPayloadError(awc::error::JsonPayloadError),
+    #[error("AWC sending request error: {e}, {url}")]
+    SendRequestError {
+        e: awc::error::SendRequestError,
+        url: String,
+    },
+    #[error("AWC payload error: {e}, {b}")]
+    PayloadError {
+        e: awc::error::PayloadError,
+        b: String,
+    },
+    #[error("AWC JSON payload error: {e}, {b}")]
+    JsonPayloadError {
+        e: awc::error::JsonPayloadError,
+        b: String,
+    },
     #[error("serde JSON error: {0}")]
     SerdeJsonError(serde_json::Error),
     #[error("invalid address: {0}")]
@@ -25,18 +35,27 @@ pub enum Error {
 
 impl From<awc::error::SendRequestError> for Error {
     fn from(e: awc::error::SendRequestError) -> Self {
-        Error::SendRequestError(e)
+        Error::SendRequestError {
+            e,
+            url: format!("{:#?}", Backtrace::new()),
+        }
     }
 }
 
 impl From<awc::error::PayloadError> for Error {
     fn from(e: awc::error::PayloadError) -> Self {
-        Error::PayloadError(e)
+        Error::PayloadError {
+            e,
+            b: format!("{:#?}", Backtrace::new()),
+        }
     }
 }
 
 impl From<awc::error::JsonPayloadError> for Error {
     fn from(e: awc::error::JsonPayloadError) -> Self {
-        Error::JsonPayloadError(e)
+        Error::JsonPayloadError {
+            e,
+            b: format!("{:#?}", Backtrace::new()),
+        }
     }
 }


### PR DESCRIPTION
As an example, Market Provider API was rewritten using WebClient (w/o "magic" macro)