### PR TITLE
Redo using actix-0.8 and add GSB binding

### DIFF
--- a/exe-unit/api/Cargo.toml
+++ b/exe-unit/api/Cargo.toml
@@ -5,9 +5,16 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-futures = "0.3"
+actix = "0.8.3"
+futures = "0.1"
 log = "0.4"
-tokio = { version = "0.2", features = ["full"] }
 thiserror = "1.0"
-serde = "1.0"
 serde_json = "1.0"
+
+[dependencies.serde]
+version = "1.0"
+features = ["derive"]
+
+[dependencies.bus]
+path = "../../service-bus/bus"
+package = "ya-service-bus"

--- a/exe-unit/api/src/command/from_json.rs
+++ b/exe-unit/api/src/command/from_json.rs
@@ -1,0 +1,90 @@
+use crate::{
+    command::{many::StreamResponse, one::Command, Dispatcher},
+    Error, Result,
+};
+use actix::{dev::ToEnvelope, prelude::*};
+use futures::{
+    future,
+    stream::{self, Stream},
+};
+use serde::de::DeserializeOwned;
+use std::marker::PhantomData;
+
+pub struct CommandFromJson<M, R, Ctx>
+where
+    M: Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M>,
+{
+    json: String,
+    p1: PhantomData<M>,
+    p2: PhantomData<R>,
+    p3: PhantomData<Ctx>,
+}
+
+impl<M, R, Ctx> CommandFromJson<M, R, Ctx>
+where
+    M: Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M>,
+{
+    pub fn new(json: String) -> Self {
+        Self {
+            json,
+            p1: PhantomData,
+            p2: PhantomData,
+            p3: PhantomData,
+        }
+    }
+}
+
+impl<M, R, Ctx> Message for CommandFromJson<M, R, Ctx>
+where
+    M: Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M>,
+{
+    type Result = StreamResponse<Result<R>, ()>;
+}
+
+impl<M, R, Ctx> Handler<CommandFromJson<M, R, Ctx>> for Dispatcher<Ctx>
+where
+    M: Message<Result = R> + DeserializeOwned + Send + 'static,
+    R: Send + 'static,
+    Ctx: Actor + Handler<M> + Send + 'static,
+    <Ctx as Actor>::Context: AsyncContext<Ctx> + ToEnvelope<Ctx, M>,
+{
+    type Result = StreamResponse<Result<R>, ()>;
+
+    fn handle(&mut self, msg: CommandFromJson<M, R, Ctx>, ctx: &mut Self::Context) -> Self::Result {
+        // we expect input to be a JSON Array even if it consists of one element
+        match serde_json::from_str(&msg.json).map_err(Into::into) {
+            // OK, we got a JSON array, now interpret Values as strongly typed Cmd
+            // in case we cannot interpret any command, throw an error but do not
+            // interrupt the flow
+            Ok(serde_json::Value::Array(cmds)) => {
+                let dispatcher = ctx.address();
+                let cmds: Vec<_> = cmds
+                    .into_iter()
+                    .map(|cmd| (dispatcher.clone(), cmd))
+                    .collect();
+                StreamResponse::new(stream::iter_ok(cmds).and_then(|(dispatcher, cmd)| {
+                    let cmd: Result<M> = serde_json::from_value(cmd).map_err(Into::into);
+                    match cmd {
+                        Ok(cmd) => {
+                            future::Either::A(dispatcher.send(Command::new(cmd)).then(|res| {
+                                match res {
+                                    Err(e) => future::ok(Err(Error::from(e))),
+                                    Ok(res) => future::ok(res),
+                                }
+                            }))
+                        }
+                        Err(e) => future::Either::B(future::ok(Err(e))),
+                    }
+                }))
+            }
+            Ok(value) => StreamResponse::new(stream::once(Ok(Err(Error::WrongJson(value))))),
+            Err(e) => StreamResponse::new(stream::once(Ok(Err(e)))),
+        }
+    }
+}

--- a/exe-unit/api/src/command/many.rs
+++ b/exe-unit/api/src/command/many.rs
@@ -1,0 +1,106 @@
+use crate::{
+    command::{one::Command, Dispatcher},
+    Error, Result,
+};
+use actix::{
+    dev::{MessageResponse, ResponseChannel, ToEnvelope},
+    prelude::*,
+};
+use futures::{
+    future,
+    stream::{self, Stream},
+};
+use std::marker::PhantomData;
+
+type BoxStream<I, E> = Box<dyn Stream<Item = I, Error = E> + Send>;
+
+pub struct StreamResponse<I, E>(BoxStream<I, E>)
+where
+    I: 'static,
+    E: 'static;
+
+impl<I, E> StreamResponse<I, E>
+where
+    I: 'static,
+    E: 'static,
+{
+    pub fn new(inner: impl Stream<Item = I, Error = E> + Send + 'static) -> Self {
+        Self(Box::new(inner))
+    }
+
+    pub fn into_inner(self) -> impl Stream<Item = I, Error = E> + Send {
+        self.0
+    }
+}
+
+impl<A, M, I, E> MessageResponse<A, M> for StreamResponse<I, E>
+where
+    A: Actor,
+    M: Message<Result = Self>,
+    I: 'static,
+    E: 'static,
+{
+    fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
+        if let Some(tx) = tx {
+            tx.send(self)
+        }
+    }
+}
+
+pub struct Commands<M, R, Ctx>
+where
+    M: Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M> + 'static,
+{
+    inner: Vec<M>,
+    phantom: PhantomData<Ctx>,
+}
+
+impl<M, R, Ctx> Commands<M, R, Ctx>
+where
+    M: Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M> + 'static,
+{
+    pub fn new(inner: Vec<M>) -> Self {
+        Self {
+            inner,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<M, R, Ctx> Message for Commands<M, R, Ctx>
+where
+    M: Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M> + 'static,
+{
+    type Result = StreamResponse<Result<R>, ()>;
+}
+
+impl<M, R, Ctx> Handler<Commands<M, R, Ctx>> for Dispatcher<Ctx>
+where
+    M: Message<Result = R> + Send + 'static,
+    R: Send + 'static,
+    Ctx: Actor + Handler<M> + Send + 'static,
+    <Ctx as Actor>::Context: AsyncContext<Ctx> + ToEnvelope<Ctx, M>,
+{
+    type Result = StreamResponse<Result<R>, ()>;
+
+    fn handle(&mut self, msg: Commands<M, R, Ctx>, ctx: &mut Self::Context) -> Self::Result {
+        let dispatcher = ctx.address();
+        let cmds: Vec<_> = msg
+            .inner
+            .into_iter()
+            .map(|cmd| (dispatcher.clone(), cmd))
+            .collect();
+        StreamResponse::new(stream::iter_ok(cmds).and_then(|(dispatcher, cmd)| {
+            dispatcher.send(Command::new(cmd)).then(|res| match res {
+                Err(e) => future::ok(Err(Error::from(e))),
+                Ok(res) => future::ok(res),
+            })
+        }))
+    }
+}

--- a/exe-unit/api/src/command/mod.rs
+++ b/exe-unit/api/src/command/mod.rs
@@ -1,0 +1,28 @@
+pub mod from_json;
+pub mod many;
+pub mod one;
+
+use actix::prelude::*;
+
+pub struct Dispatcher<Ctx>
+where
+    Ctx: Actor,
+{
+    pub(crate) worker: Addr<Ctx>,
+}
+
+impl<Ctx> Dispatcher<Ctx>
+where
+    Ctx: Actor,
+{
+    pub fn new(worker: Addr<Ctx>) -> Self {
+        Self { worker }
+    }
+}
+
+impl<Ctx> Actor for Dispatcher<Ctx>
+where
+    Ctx: Actor,
+{
+    type Context = Context<Self>;
+}

--- a/exe-unit/api/src/command/one.rs
+++ b/exe-unit/api/src/command/one.rs
@@ -1,0 +1,62 @@
+use crate::{command::Dispatcher, Error, Result};
+use actix::{dev::ToEnvelope, prelude::*};
+use futures::{
+    future::{self, Future},
+    sync::oneshot,
+};
+use std::marker::PhantomData;
+
+pub struct Command<M, R, Ctx>
+where
+    M: Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M> + 'static,
+{
+    inner: M,
+    phantom: PhantomData<Ctx>,
+}
+
+impl<M, R, Ctx> Command<M, R, Ctx>
+where
+    M: Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M> + 'static,
+{
+    pub fn new(inner: M) -> Self {
+        Self {
+            inner,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<M, R, Ctx> Message for Command<M, R, Ctx>
+where
+    M: Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M> + 'static,
+{
+    type Result = Result<M::Result>;
+}
+
+impl<M, R, Ctx> Handler<Command<M, R, Ctx>> for Dispatcher<Ctx>
+where
+    M: Message<Result = R> + Send + 'static,
+    R: Send + 'static,
+    Ctx: Actor + Handler<M> + Send + 'static,
+    <Ctx as Actor>::Context: AsyncContext<Ctx> + ToEnvelope<Ctx, M>,
+{
+    type Result = ActorResponse<Self, M::Result, Error>;
+
+    fn handle(&mut self, msg: Command<M, R, Ctx>, _: &mut Self::Context) -> Self::Result {
+        let (tx, rx) = oneshot::channel();
+        let recipient = self.worker.clone();
+        Arbiter::new().send(recipient.send(msg.inner).map_err(Error::from).then(|res| {
+            if let Err(_) = tx.send(res) {
+                log::error!("send should succeed");
+            }
+            future::ok(())
+        }));
+        ActorResponse::r#async(rx.flatten().into_actor(self))
+    }
+}

--- a/exe-unit/api/src/golem/mod.rs
+++ b/exe-unit/api/src/golem/mod.rs
@@ -1,0 +1,1 @@
+pub mod service_bus;

--- a/exe-unit/api/src/golem/service_bus.rs
+++ b/exe-unit/api/src/golem/service_bus.rs
@@ -1,0 +1,214 @@
+use crate::{
+    command::{many::Commands, Dispatcher},
+    Error,
+};
+use actix::{
+    dev::{AsyncContext, ToEnvelope},
+    prelude::*,
+};
+use bus::{actix_rpc, Handle, RpcEnvelope, RpcMessage};
+use serde::{
+    de::{self, DeserializeOwned, Deserializer, SeqAccess, Visitor},
+    Deserialize, Serialize,
+};
+use std::{fmt, marker::PhantomData};
+
+pub struct BusEntrypoint<M, R, Ctx>
+where
+    M: Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M>,
+{
+    service_id: String,
+    handle: Option<Handle>,
+    recipient: Addr<Dispatcher<Ctx>>,
+    p1: PhantomData<M>,
+    p2: PhantomData<R>,
+}
+
+impl<M, R, Ctx> BusEntrypoint<M, R, Ctx>
+where
+    M: Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M>,
+{
+    pub fn new(service_id: &str, recipient: Addr<Dispatcher<Ctx>>) -> Self {
+        Self {
+            service_id: service_id.to_owned(),
+            handle: None,
+            recipient,
+            p1: PhantomData,
+            p2: PhantomData,
+        }
+    }
+}
+
+impl<M, R, Ctx> Actor for BusEntrypoint<M, R, Ctx>
+where
+    M: Message<Result = R> + Serialize + DeserializeOwned + Send + Sync + 'static,
+    R: Serialize + Send + Sync + 'static,
+    Ctx: Actor + Handler<M> + Send + Sync + 'static,
+    <Ctx as Actor>::Context: AsyncContext<Ctx> + ToEnvelope<Ctx, M>,
+{
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        self.handle = Some(actix_rpc::bind::<Execute<M, R, Ctx>>(
+            &self.service_id,
+            ctx.address().recipient(),
+        ));
+        log::info!("listening on {}", &self.service_id);
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct Execute<M, R, Ctx>
+where
+    M: Serialize + DeserializeOwned + Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M> + 'static,
+{
+    cmds: Vec<M>,
+    p1: PhantomData<R>,
+    p2: PhantomData<Ctx>,
+}
+
+impl<'de, M, R, Ctx> Deserialize<'de> for Execute<M, R, Ctx>
+where
+    M: Serialize + DeserializeOwned + Message<Result = R>,
+    R: 'static,
+    Ctx: Actor + Handler<M> + 'static,
+{
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct ExecuteVisitor<M, R, Ctx>
+        where
+            M: Serialize + DeserializeOwned + Message<Result = R>,
+            R: 'static,
+            Ctx: Actor + Handler<M> + 'static,
+        {
+            p1: PhantomData<M>,
+            p2: PhantomData<R>,
+            p3: PhantomData<Ctx>,
+        }
+
+        impl<'de, M, R, Ctx> Visitor<'de> for ExecuteVisitor<M, R, Ctx>
+        where
+            M: Serialize + DeserializeOwned + Message<Result = R>,
+            R: 'static,
+            Ctx: Actor + Handler<M> + 'static,
+        {
+            type Value = Execute<M, R, Ctx>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Execute")
+            }
+
+            #[inline]
+            fn visit_newtype_struct<D>(
+                self,
+                deserializer: D,
+            ) -> std::result::Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let cmds: Vec<M> = match <Vec<M> as Deserialize>::deserialize(deserializer) {
+                    Ok(val) => val,
+                    Err(err) => return Err(err),
+                };
+                Ok(Execute {
+                    cmds,
+                    p1: PhantomData,
+                    p2: PhantomData,
+                })
+            }
+
+            #[inline]
+            fn visit_seq<A>(self, mut seq: A) -> std::result::Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let cmds = match match SeqAccess::next_element::<Vec<M>>(&mut seq) {
+                    Ok(val) => val,
+                    Err(err) => return Err(err),
+                } {
+                    Some(value) => value,
+                    None => {
+                        return Err(de::Error::invalid_length(
+                            0usize,
+                            &"struct Execute with 1 element",
+                        ));
+                    }
+                };
+                Ok(Execute {
+                    cmds,
+                    p1: PhantomData,
+                    p2: PhantomData,
+                })
+            }
+        }
+
+        deserializer.deserialize_newtype_struct(
+            "execute",
+            ExecuteVisitor {
+                p1: PhantomData,
+                p2: PhantomData,
+                p3: PhantomData,
+            },
+        )
+    }
+}
+
+impl<M, R, Ctx> RpcMessage for Execute<M, R, Ctx>
+where
+    M: Serialize + DeserializeOwned + Message<Result = R> + Send + Sync + 'static,
+    R: Send + Sync + 'static,
+    Ctx: Actor + Handler<M> + Send + Sync + 'static,
+{
+    const ID: &'static str = "execute";
+    type Item = String; // TODO this probably should not be a String, but need to discuss with MF
+    type Error = Error;
+}
+
+impl<M, R, Ctx> Handler<RpcEnvelope<Execute<M, R, Ctx>>> for BusEntrypoint<M, R, Ctx>
+where
+    M: Message<Result = R> + Serialize + DeserializeOwned + Send + Sync + 'static,
+    R: Serialize + Send + Sync + 'static,
+    Ctx: Actor + Handler<M> + Send + Sync + 'static,
+    <Ctx as Actor>::Context: AsyncContext<Ctx> + ToEnvelope<Ctx, M>,
+{
+    type Result = ActorResponse<Self, String, Error>;
+
+    fn handle(
+        &mut self,
+        msg: RpcEnvelope<Execute<M, R, Ctx>>,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        let dispatcher = self.recipient.clone();
+        let fut = dispatcher
+            .send(Commands::new(msg.into_inner().cmds))
+            .from_err()
+            .and_then(|res| {
+                res.into_inner().collect().then(|res| {
+                    let res: Vec<_> = res
+                        .unwrap()
+                        .into_iter()
+                        .filter_map(|resp| {
+                            if let Ok(resp) = resp {
+                                Some(resp)
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    match serde_json::to_string(&res) {
+                        Ok(res) => Ok(res),
+                        Err(e) => Err(Error::from(e)),
+                    }
+                })
+            });
+        ActorResponse::r#async(fut.into_actor(self))
+    }
+}

--- a/exe-unit/api/src/lib.rs
+++ b/exe-unit/api/src/lib.rs
@@ -1,97 +1,71 @@
-use futures::{
-    channel::oneshot,
-    future::{BoxFuture, Future},
-    stream::{self, BoxStream, Stream, StreamExt},
-};
-use serde::de::DeserializeOwned;
-use thiserror::Error;
+pub mod command;
+pub mod golem;
 
-#[derive(Error, Debug)]
-pub enum ApiError {
+pub mod prelude {
+    pub use super::command::{from_json::CommandFromJson, many::StreamResponse, Dispatcher};
+    pub use super::Error;
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+use serde::{
+    de::{Deserialize, Deserializer, Visitor},
+    Serialize,
+};
+use std::fmt;
+
+#[derive(thiserror::Error, Debug, Serialize)]
+pub enum Error {
+    #[error("this value was deserialized")]
+    Deserialized,
     #[error("oneshot channel Sender prematurely dropped")]
-    OneshotCanceled(#[from] oneshot::Canceled),
-    #[error("deserializing command failed with {0:?}")]
-    SerdeJson(#[from] serde_json::Error),
+    OneshotCanceled(
+        #[serde(skip)]
+        #[from]
+        futures::sync::oneshot::Canceled,
+    ),
+    #[error("actix mailbox error occurred {0}")]
+    MailboxError(
+        #[serde(skip)]
+        #[from]
+        actix::prelude::MailboxError,
+    ),
     #[error("expected a JSON array object; got {0}")]
     WrongJson(serde_json::Value),
+    #[error("deserializing command failed with {0}")]
+    SerdeJson(
+        #[serde(skip)]
+        #[from]
+        serde_json::Error,
+    ),
 }
 
-pub trait Context: Clone + Send + Sync {}
+impl<'de> Deserialize<'de> for Error {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Vis;
 
-pub trait Command<Ctx>
-where
-    Self: Send + Sync,
-    Ctx: Context + 'static,
-{
-    type Response: Send + 'static;
+        impl<'de> Visitor<'de> for Vis {
+            type Value = Error;
 
-    fn action(self, ctx: Ctx) -> BoxFuture<'static, Self::Response>;
-}
-
-pub trait Handle<Cmd>
-where
-    Self: Context + 'static,
-    Cmd: Command<Self> + 'static,
-{
-    type Result: Future<Output = Result<Cmd::Response, ApiError>> + Send;
-
-    fn handle(&mut self, cmd: Cmd) -> Self::Result;
-}
-
-impl<Ctx, Cmd> Handle<Cmd> for Ctx
-where
-    Ctx: Context + 'static,
-    Cmd: Command<Ctx> + 'static,
-{
-    type Result = BoxFuture<'static, Result<Cmd::Response, ApiError>>;
-
-    fn handle(&mut self, cmd: Cmd) -> Self::Result {
-        let (tx, rx) = oneshot::channel();
-        let ctx = self.clone();
-        tokio::spawn(async move {
-            let res = cmd.action(ctx).await;
-            if let Err(_) = tx.send(res) {
-                log::error!("send should succeed")
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("enum Error")
             }
-        });
-        Box::pin(async move { rx.await.map_err(Into::into) })
-    }
-}
 
-pub trait Exec<Cmd>
-where
-    Self: Context + 'static,
-    Cmd: Command<Self> + DeserializeOwned + 'static,
-{
-    type Result: Stream<Item = Result<Cmd::Response, ApiError>>;
-
-    fn exec(&mut self, cmd_json: String) -> Self::Result;
-}
-
-impl<Ctx, Cmd> Exec<Cmd> for Ctx
-where
-    Ctx: Context + Handle<Cmd> + 'static,
-    Cmd: Command<Ctx> + DeserializeOwned + 'static,
-{
-    type Result = BoxStream<'static, Result<Cmd::Response, ApiError>>;
-
-    fn exec(&mut self, cmd_json: String) -> Self::Result {
-        // we expect input to be a JSON Array even if it consists of one element
-        match serde_json::from_str(&cmd_json) {
-            Err(e) => Box::pin(stream::once(async { Err(e.into()) })),
-            // OK, we got a JSON array, now interpret Values as strongly typed Cmd
-            // in case we cannot interpret any command, throw an error but do not
-            // interrupt the flow
-            Ok(serde_json::Value::Array(cmds)) => {
-                let cmds: Vec<_> = cmds.into_iter().map(|cmd| (self.clone(), cmd)).collect();
-                Box::pin(stream::iter(cmds).then(|(mut ctx, cmd)| {
-                    async move {
-                        let cmd = serde_json::from_value(cmd)?;
-                        ctx.handle(cmd).await.map_err(Into::into)
-                    }
-                }))
+            #[inline]
+            fn visit_newtype_struct<D>(
+                self,
+                _deserializer: D,
+            ) -> std::result::Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Ok(Error::Deserialized)
             }
-            Ok(other) => Box::pin(stream::once(async { Err(ApiError::WrongJson(other)) })),
         }
+
+        deserializer.deserialize_newtype_struct("Error", Vis)
     }
 }

--- a/exe-unit/dummy/Cargo.toml
+++ b/exe-unit/dummy/Cargo.toml
@@ -5,10 +5,19 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-api = { path = "../api", package = "ya-exe-api" }
-futures = "0.3"
-tokio = { version = "0.2", features = ["full"] }
+futures = "0.1"
 anyhow = "1.0"
-serde = { version = "1.0", features = ["derive"] }
+thiserror = "1.0"
 serde_json = "1.0"
 structopt = "0.3"
+actix = "0.8.3"
+tokio = "0.1"
+pretty_env_logger = "0.3"
+
+[dependencies.api]
+path = "../api"
+package = "ya-exe-api"
+
+[dependencies.serde]
+version = "1.0"
+features = ["derive"]

--- a/exe-unit/dummy/README.md
+++ b/exe-unit/dummy/README.md
@@ -9,28 +9,10 @@ execute foreign, untrusted on the host.
 DummyExeUnit currently supports 5 types of commands: `DEPLOY`, `START`, `RUN`, `TRANSFER`,
 and `STOP`. The structure of each command is presented in the example usage below.
 
-DummyExeUnit can be used in two ways: either executing a batch of commands encoded as JSON
-from file, or interactively, using a rudimentary CLI.
-
-## Running from JSON file input
-
-Example JSON input which contains all supported commands has the following structure:
-
-```json
-[
-  { "deploy": { "params": [] } },
-  { "start": { "params": [] } },
-  { "run": { "cmd": "hello" } },
-  { "transfer": { "from": "dummy_src", "to": "dummy_dst" } },
-  { "stop": {} }
-]
-```
-
-The specified set of commands can then be executed by DummyExeUnit as follows:
-
-```shell
-cargo run --bin ya-exe-dummy -- example.json
-```
+DummyExeUnit can be used in three ways:
+1. running interactively using a rudimentary CLI,
+2. executing a batch of commands from JSON file, and
+3. binding to Golem Service Bus at a specified Service ID
 
 ## Running interactively
 
@@ -39,19 +21,68 @@ entering an interactive CLI mode which is done automatically if no JSON file inp
 is specified:
 
 ```shell
-cargo run --bin ya-exe-dummy
+cargo run --bin ya-exe-dummy -- cli
 ```
 
 Then, one can specify any set of commands that will be sent to the unit in sequence,
 and the response to each will be printed back to the screen:
 
 ```shell
-> [ { "start": { "params": [] } } ]
-received response = Ok(Ok((Active, "params={}")))
+> [ { "start": { "args": [] } } ]
+received response = Ok(Ok((Active, "args={}")))
 ```
 
 The CLI can be exited at any time by issuing an `exit` command:
 
 ```shell
 > exit
+```
+
+## Executing a batch of commands from JSON file
+
+Example JSON input which contains all supported commands has the following structure:
+
+```json
+[
+  { "deploy": {} },
+  { "start": { "args": [] } },
+  { "run": { "entry_point": "", "args": [] } },
+  { "transfer": { "from": "dummy_src", "to": "dummy_dst" } },
+  { "stop": {} }
+]
+```
+
+The specified set of commands can then be executed by DummyExeUnit as follows:
+
+```shell
+cargo run --bin ya-exe-dummy -- from-file example.json
+```
+
+## Binding to Golem Service Bus at a specified Service ID
+
+Assuming you have GSB Router up and running, you can hook up to the GSB with
+the following command:
+
+```shell
+cargo run --bin ya-exe-dummy -- gsb /local/dummy
+```
+
+### Testing over GSB
+
+For testing, you can firstly launch the GSB Router like so:
+
+```shell
+cargo run --bin ya-sb-router
+```
+
+Then, you can bind the DummyExeUnit to the GSB like so:
+
+```shell
+cargo run --bin ya-exe-dummy -- gsb /local/exeunit
+```
+
+You can send example commands like so:
+
+```shell
+cargo run --example test_actix_service -- client service-bus/bus/examples/data/script.json
 ```

--- a/exe-unit/dummy/src/lib.rs
+++ b/exe-unit/dummy/src/lib.rs
@@ -1,295 +1,33 @@
-use anyhow::{bail, Result};
-use api::{Command, Context};
-use futures::{future::BoxFuture, lock::Mutex};
-use serde::Deserialize;
-use std::{collections::HashMap, sync::Arc, time::Duration};
-use tokio::time::delay_for;
+pub mod state;
+pub mod worker;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum State {
-    Init,
-    Deployed,
-    Active,
-    Terminated,
-}
+type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-enum Transition {
-    Deploy,
-    Start,
-    Run,
-    Stop,
-    Transfer,
-}
+use serde::Serialize;
 
-#[derive(Debug)]
-struct StateMachine {
-    current_state: State,
-    table: HashMap<(State, Transition), State>,
-}
-
-impl StateMachine {
-    fn new() -> Self {
-        // Set the start state.
-        let current_state = State::Init;
-        // The transition table; we let it be incomplete --
-        // if the transition doesn't exist, we simply state in
-        // the current state. One caveat of this approach is
-        // that we lose finer error control and propagation.
-        // TODO refactor state transition table
-        let mut table = HashMap::new();
-        table.insert((State::Init, Transition::Deploy), State::Deployed);
-        table.insert((State::Deployed, Transition::Start), State::Active);
-        table.insert((State::Active, Transition::Run), State::Active);
-        table.insert((State::Active, Transition::Transfer), State::Active);
-        table.insert((State::Active, Transition::Stop), State::Terminated);
-        table.insert((State::Terminated, Transition::Transfer), State::Terminated);
-
-        Self {
-            current_state,
-            table,
-        }
-    }
-
-    fn next_state(&self, transition: Transition) -> Option<State> {
-        self.table
-            .get(&(self.current_state, transition))
-            .map(|&x| x)
-    }
-}
-
-#[derive(Clone)]
-pub struct DummyExeUnit {
-    inner: Arc<Mutex<StateMachine>>,
-}
-
-impl DummyExeUnit {
-    pub fn spawn() -> Self {
-        Self {
-            inner: Arc::new(Mutex::new(StateMachine::new())),
-        }
-    }
-}
-
-impl Context for DummyExeUnit {}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum DummyCmd {
-    Deploy { params: Vec<String> },
-    Start { params: Vec<String> },
-    Run { cmd: String },
-    Transfer { from: String, to: String },
-    Stop {},
-}
-
-macro_rules! lock_or_bail {
-    ($ctx:ident) => {
-        match $ctx.inner.try_lock() {
-            None => bail!("couldn't acquire lock; another Op in progress"),
-            Some(inner) => inner,
-        }
-    };
-}
-
-macro_rules! transition_or_bail {
-    ($inner:ident, $transition:ident) => {
-        match $inner.next_state($transition) {
-            None => bail!(
-                "transition {:?} from {:?} is invalid",
-                $transition,
-                $inner.current_state,
-            ),
-            Some(state) => state,
-        }
-    };
-}
-
-impl DummyCmd {
-    // TODO the logic for state transitioning and Mutex locking is common;
-    // find a way to refactor and create a re-usable API
-    async fn deploy(ctx: DummyExeUnit, params: Vec<String>) -> Result<(State, String)> {
-        let transition = Transition::Deploy;
-        let mut inner = lock_or_bail!(ctx);
-        let state = transition_or_bail!(inner, transition);
-        delay_for(Duration::from_secs(5)).await;
-        inner.current_state = state;
-        Ok((state, format!("params={{{}}}", params.join(","))))
-    }
-
-    async fn start(ctx: DummyExeUnit, params: Vec<String>) -> Result<(State, String)> {
-        let transition = Transition::Start;
-        let mut inner = lock_or_bail!(ctx);
-        let state = transition_or_bail!(inner, transition);
-        delay_for(Duration::from_secs(2)).await;
-        inner.current_state = state;
-        Ok((state, format!("params={{{}}}", params.join(","))))
-    }
-
-    async fn run(ctx: DummyExeUnit, cmd: String) -> Result<(State, String)> {
-        let transition = Transition::Run;
-        let mut inner = lock_or_bail!(ctx);
-        let state = transition_or_bail!(inner, transition);
-        delay_for(Duration::from_secs(3)).await;
-        inner.current_state = state;
-        Ok((state, format!("cmd={}", cmd)))
-    }
-
-    async fn transfer(ctx: DummyExeUnit, from: String, to: String) -> Result<(State, String)> {
-        let transition = Transition::Transfer;
-        let mut inner = lock_or_bail!(ctx);
-        let state = transition_or_bail!(inner, transition);
-        delay_for(Duration::from_secs(3)).await;
-        inner.current_state = state;
-        Ok((state, format!("from={},to={}", from, to)))
-    }
-
-    async fn stop(ctx: DummyExeUnit) -> Result<(State, String)> {
-        let transition = Transition::Stop;
-        let mut inner = lock_or_bail!(ctx);
-        let state = transition_or_bail!(inner, transition);
-        delay_for(Duration::from_secs(2)).await;
-        inner.current_state = state;
-        Ok((state, "".to_owned()))
-    }
-}
-
-impl Command<DummyExeUnit> for DummyCmd {
-    type Response = Result<(State, String)>;
-
-    fn action(self, ctx: DummyExeUnit) -> BoxFuture<'static, Self::Response> {
-        match self {
-            Self::Deploy { params } => Box::pin(Self::deploy(ctx, params)),
-            Self::Start { params } => Box::pin(Self::start(ctx, params)),
-            Self::Run { cmd } => Box::pin(Self::run(ctx, cmd)),
-            Self::Transfer { from, to } => Box::pin(Self::transfer(ctx, from, to)),
-            Self::Stop {} => Box::pin(Self::stop(ctx)),
-        }
-    }
-}
-
-#[cfg(test)]
-mod dummy_exe_unit {
-    use super::*;
-
-    #[test]
-    fn transition_table() {
-        let mut state_machine = StateMachine::new();
-        // From State::Init, only Transition::Deploy is valid
-        assert!(state_machine.next_state(Transition::Start).is_none());
-        assert!(state_machine.next_state(Transition::Run).is_none());
-        assert!(state_machine.next_state(Transition::Transfer).is_none());
-        assert!(state_machine.next_state(Transition::Stop).is_none());
-        assert_eq!(
-            state_machine.next_state(Transition::Deploy),
-            Some(State::Deployed)
-        );
-
-        state_machine.current_state = State::Deployed;
-        // From State::Deployed, only Transition::Start is valid
-        assert!(state_machine.next_state(Transition::Deploy).is_none());
-        assert!(state_machine.next_state(Transition::Run).is_none());
-        assert!(state_machine.next_state(Transition::Transfer).is_none());
-        assert!(state_machine.next_state(Transition::Stop).is_none());
-        assert_eq!(
-            state_machine.next_state(Transition::Start),
-            Some(State::Active)
-        );
-
-        state_machine.current_state = State::Active;
-        // From State::Active, only Transition::Run, Transition::Transfer,
-        // Transition::Stop are valid
-        assert!(state_machine.next_state(Transition::Deploy).is_none());
-        assert!(state_machine.next_state(Transition::Start).is_none());
-        assert_eq!(
-            state_machine.next_state(Transition::Run),
-            Some(State::Active)
-        );
-        assert_eq!(
-            state_machine.next_state(Transition::Transfer),
-            Some(State::Active)
-        );
-        assert_eq!(
-            state_machine.next_state(Transition::Stop),
-            Some(State::Terminated)
-        );
-
-        state_machine.current_state = State::Terminated;
-        // From State::Terminated, only Transition::Transfer is valid
-        assert!(state_machine.next_state(Transition::Deploy).is_none());
-        assert!(state_machine.next_state(Transition::Start).is_none());
-        assert!(state_machine.next_state(Transition::Run).is_none());
-        assert!(state_machine.next_state(Transition::Stop).is_none());
-        assert_eq!(
-            state_machine.next_state(Transition::Transfer),
-            Some(State::Terminated)
-        );
-    }
-
-    #[tokio::test]
-    async fn locking_inbetween_states() {
-        use api::Handle;
-        use futures::future::{select, FutureExt};
-
-        let mut unit = DummyExeUnit::spawn();
-        let mut unit2 = unit.clone();
-        let t1 =
-            tokio::spawn(async move { unit.handle(DummyCmd::Deploy { params: vec![] }).await });
-        let t2 =
-            tokio::spawn(async move { unit2.handle(DummyCmd::Deploy { params: vec![] }).await });
-        let mut results = Vec::new();
-        let res = select(t1, t2).then(|either| {
-            let (res, either) = either.factor_first();
-            results.push(res.unwrap().unwrap());
-            either
-        });
-        let res = res.await.unwrap().unwrap();
-        results.push(res);
-        assert_eq!(results.len(), 2);
-        assert_eq!(
-            format!("{}", results[0].as_ref().unwrap_err()),
-            "couldn't acquire lock; another Op in progress",
-        );
-        let res = results[1].as_ref().unwrap();
-        assert_eq!(res.0, State::Deployed);
-        assert_eq!(res.1, "params={}".to_owned());
-    }
-
-    #[tokio::test]
-    async fn json_cmds() {
-        use api::Exec;
-        use futures::stream::StreamExt;
-
-        let json = r#"
-[
-	{"deploy": { "params": [] }},
-	{"start": { "params": [] }},
-	{"run": { "cmd": "hello" }},
-	{"transfer": {"from": "dummy-src", "to": "dummy-dst"}},
-    {"stop": {}},
-	{"transfer": {"from": "dummy-src", "to": "dummy-dst"}}
-]
-        "#;
-
-        let mut unit = DummyExeUnit::spawn();
-        let mut stream = <DummyExeUnit as Exec<DummyCmd>>::exec(&mut unit, json.to_string());
-        let state = stream.next().await.unwrap().unwrap();
-        assert_eq!(state.unwrap(), (State::Deployed, "params={}".to_owned()));
-        let state = stream.next().await.unwrap().unwrap();
-        assert_eq!(state.unwrap(), (State::Active, "params={}".to_owned()));
-        let state = stream.next().await.unwrap().unwrap();
-        assert_eq!(state.unwrap(), (State::Active, "cmd=hello".to_owned()));
-        let state = stream.next().await.unwrap().unwrap();
-        assert_eq!(
-            state.unwrap(),
-            (State::Active, "from=dummy-src,to=dummy-dst".to_owned())
-        );
-        let state = stream.next().await.unwrap().unwrap();
-        assert_eq!(state.unwrap(), (State::Terminated, "".to_owned()));
-        let state = stream.next().await.unwrap().unwrap();
-        assert_eq!(
-            state.unwrap(),
-            (State::Terminated, "from=dummy-src,to=dummy-dst".to_owned())
-        );
-    }
+#[derive(Debug, thiserror::Error, Serialize)]
+pub enum Error {
+    #[error("actix mailbox error {0}")]
+    MailboxError(
+        #[serde(skip)]
+        #[from]
+        actix::prelude::MailboxError,
+    ),
+    #[error("ExeUnit API error {0}")]
+    ApiError(
+        #[serde(skip)]
+        #[from]
+        api::prelude::Error,
+    ),
+    #[error("received tokio timer error {0}")]
+    TokioTimer(
+        #[serde(skip)]
+        #[from]
+        tokio::timer::Error,
+    ),
+    #[error("invalid transition {transition:?} from state {state:?}")]
+    InvalidTransition {
+        transition: state::Transition,
+        state: state::State,
+    },
 }

--- a/exe-unit/dummy/src/main.rs
+++ b/exe-unit/dummy/src/main.rs
@@ -1,65 +1,92 @@
+use actix::prelude::*;
 use anyhow::{Context, Result};
-use api::Exec;
-use futures::stream::StreamExt;
+use api::{golem::service_bus::BusEntrypoint, prelude::*};
+use futures::future;
 use std::{
     fs,
     io::{self, Write},
     path::PathBuf,
 };
 use structopt::StructOpt;
-use ya_exe_dummy::{DummyCmd, DummyExeUnit};
+use ya_exe_dummy::worker::{Command, Worker};
 
 #[derive(StructOpt, Debug)]
 #[structopt(name = "dummy")]
-struct Opt {
-    #[structopt(parse(from_os_str))]
-    input: Option<PathBuf>,
+enum Opt {
+    /// Run interactively in CLI mode
+    CLI,
+    /// Execute commands from JSON file
+    FromFile { input: PathBuf },
+    /// Bind to the Golem Service Bus
+    Gsb { service_id: String },
 }
 
-async fn send_cmd(exe_unit: &mut DummyExeUnit, cmd: String) -> Result<()> {
-    let mut stream = <DummyExeUnit as Exec<DummyCmd>>::exec(exe_unit, cmd);
-    while let Some(res) = stream.next().await {
-        println!("received response = {:?}", res);
-    }
-    Ok(())
-}
-
-async fn run_interactive() -> Result<()> {
-    let mut exe_unit = DummyExeUnit::spawn();
-    loop {
-        print!("> ");
-        io::stdout().flush().context("failed to flush stdout")?;
-        let mut cmd = String::new();
-        io::stdin()
-            .read_line(&mut cmd)
-            .context("failed to read line from stdin")?;
-        let cmd: String = cmd.split_whitespace().collect();
-        if cmd.is_empty() {
-            println!(
+fn main() -> Result<()> {
+    pretty_env_logger::init();
+    let opt = Opt::from_args();
+    match opt {
+        Opt::CLI => {
+            let mut sys = System::new("dummy");
+            let worker = Worker::default().start();
+            let dispatcher = Dispatcher::new(worker).start();
+            loop {
+                print!("> ");
+                io::stdout().flush().context("failed to flush stdout")?;
+                let mut cmd = String::new();
+                io::stdin()
+                    .read_line(&mut cmd)
+                    .context("failed to read line from stdin")?;
+                let cmd: String = cmd.split_whitespace().collect();
+                if cmd.is_empty() {
+                    println!(
                 "you need to specify either a valid JSON command or 'exit' to exit the console"
             );
-            continue;
-        } else if &cmd == "exit" {
-            break;
+                    continue;
+                } else if &cmd == "exit" {
+                    break;
+                }
+                // send to the ExeUnit
+                let _res = sys.block_on(
+                    dispatcher
+                        .send(CommandFromJson::<Command, _, _>::new(cmd))
+                        .then(|stream| match stream {
+                            Ok(stream) => future::Either::A(stream.into_inner().for_each(|x| {
+                                println!("{:?}", x);
+                                future::ok(())
+                            })),
+                            Err(_) => future::Either::B(future::err(())),
+                        }),
+                );
+            }
         }
-        // send to the ExeUnit
-        send_cmd(&mut exe_unit, cmd).await?;
+        Opt::FromFile { input } => {
+            // read JSON
+            let cmd = fs::read_to_string(&input)
+                .with_context(|| format!("failed to read contents of {}", input.display()))?;
+            let mut sys = System::new("dummy");
+            let worker = Worker::default().start();
+            let dispatcher = Dispatcher::new(worker).start();
+            // send to the ExeUnit
+            let _res = sys.block_on(
+                dispatcher
+                    .send(CommandFromJson::<Command, _, _>::new(cmd))
+                    .then(|stream| match stream {
+                        Ok(stream) => future::Either::A(stream.into_inner().for_each(|x| {
+                            println!("{:?}", x);
+                            future::ok(())
+                        })),
+                        Err(_) => future::Either::B(future::err(())),
+                    }),
+            );
+        }
+        Opt::Gsb { service_id } => {
+            let sys = System::new("dummy");
+            let worker = Worker::default().start();
+            let dispatcher = Dispatcher::new(worker).start();
+            let _bus = BusEntrypoint::<Command, _, _>::new(&service_id, dispatcher).start();
+            sys.run()?;
+        }
     }
 
     Ok(())
-}
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    let opt = Opt::from_args();
-    if let Some(input) = opt.input {
-        // read JSON
-        let cmd = fs::read_to_string(&input)
-            .with_context(|| format!("failed to read contents of {}", input.display()))?;
-        // send to ExeUnit
-        let mut exe_unit = DummyExeUnit::spawn();
-        send_cmd(&mut exe_unit, cmd).await
-    } else {
-        run_interactive().await
-    }
 }

--- a/exe-unit/dummy/src/state.rs
+++ b/exe-unit/dummy/src/state.rs
@@ -1,0 +1,63 @@
+use serde::Serialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize)]
+pub enum State {
+    Init,
+    Deployed,
+    Active,
+    Terminated,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State::Init
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Serialize)]
+pub enum Transition {
+    Deploy,
+    Start,
+    Run,
+    Stop,
+    Transfer,
+}
+
+#[derive(Debug)]
+pub(super) struct StateMachine {
+    pub(super) current_state: State,
+    table: HashMap<(State, Transition), State>,
+}
+
+impl Default for StateMachine {
+    fn default() -> Self {
+        // Set the start state.
+        let current_state = State::Init;
+        // The transition table; we let it be incomplete --
+        // if the transition doesn't exist, we simply state in
+        // the current state. One caveat of this approach is
+        // that we lose finer error control and propagation.
+        // TODO refactor state transition table
+        let mut table = HashMap::new();
+        table.insert((State::Init, Transition::Deploy), State::Deployed);
+        table.insert((State::Deployed, Transition::Start), State::Active);
+        table.insert((State::Active, Transition::Run), State::Active);
+        table.insert((State::Active, Transition::Transfer), State::Active);
+        table.insert((State::Active, Transition::Stop), State::Terminated);
+        table.insert((State::Terminated, Transition::Transfer), State::Terminated);
+
+        Self {
+            current_state,
+            table,
+        }
+    }
+}
+
+impl StateMachine {
+    pub(super) fn next_state(&self, transition: Transition) -> Option<State> {
+        self.table
+            .get(&(self.current_state, transition))
+            .map(|&x| x)
+    }
+}

--- a/exe-unit/dummy/src/worker.rs
+++ b/exe-unit/dummy/src/worker.rs
@@ -1,0 +1,153 @@
+use super::{
+    state::{State, StateMachine, Transition},
+    Error, Result,
+};
+use actix::prelude::*;
+use futures::future::{self, Future};
+use serde::{Deserialize, Serialize};
+use std::time::{Duration, Instant};
+use tokio::timer::Delay;
+
+#[derive(Default)]
+pub struct Worker {
+    states: StateMachine,
+}
+
+impl Actor for Worker {
+    type Context = Context<Self>;
+}
+
+#[derive(Message)]
+struct UpdateState {
+    state: State,
+}
+
+impl Handler<UpdateState> for Worker {
+    type Result = ();
+
+    fn handle(&mut self, msg: UpdateState, _ctx: &mut Self::Context) -> Self::Result {
+        self.states.current_state = msg.state;
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Command {
+    Deploy {},
+    Start {
+        #[serde(default)]
+        args: Vec<String>,
+    },
+    Run {
+        entry_point: String,
+        #[serde(default)]
+        args: Vec<String>,
+    },
+    Stop {},
+    Transfer {
+        from: String,
+        to: String,
+    },
+}
+
+impl Message for Command {
+    type Result = Result<(State, String)>;
+}
+
+impl Handler<Command> for Worker {
+    type Result = ActorResponse<Self, (State, String), Error>;
+
+    fn handle(&mut self, msg: Command, ctx: &mut Self::Context) -> Self::Result {
+        match msg {
+            Command::Deploy {} => {
+                let transition = Transition::Deploy;
+                let state = self.states.current_state;
+                let fut = if let Some(state) = self.states.next_state(transition) {
+                    let addr = ctx.address().clone();
+                    let when = Instant::now() + Duration::from_secs(5);
+                    future::Either::A(Delay::new(when).map_err(Into::into).and_then(move |_| {
+                        addr.send(UpdateState { state })
+                            .map_err(Into::into)
+                            .and_then(move |_| Ok((state, "".to_owned())))
+                    }))
+                } else {
+                    future::Either::B(future::err(Error::InvalidTransition { transition, state }))
+                };
+                ActorResponse::r#async(fut.into_actor(self))
+            }
+            Command::Start { args } => {
+                let transition = Transition::Start;
+                let state = self.states.current_state;
+                let fut = if let Some(state) = self.states.next_state(Transition::Start) {
+                    let addr = ctx.address().clone();
+                    let when = Instant::now() + Duration::from_secs(2);
+                    future::Either::A(Delay::new(when).map_err(Into::into).and_then(move |_| {
+                        addr.send(UpdateState { state })
+                            .map_err(Into::into)
+                            .and_then(move |_| Ok((state, format!("args={{{}}}", args.join(",")))))
+                    }))
+                } else {
+                    future::Either::B(future::err(Error::InvalidTransition { transition, state }))
+                };
+                ActorResponse::r#async(fut.into_actor(self))
+            }
+            Command::Run { entry_point, args } => {
+                let transition = Transition::Run;
+                let state = self.states.current_state;
+                let fut = if let Some(state) = self.states.next_state(transition) {
+                    let addr = ctx.address().clone();
+                    let when = Instant::now() + Duration::from_secs(3);
+                    future::Either::A(Delay::new(when).map_err(Into::into).and_then(move |_| {
+                        addr.send(UpdateState { state })
+                            .map_err(Into::into)
+                            .and_then(move |_| {
+                                Ok((
+                                    state,
+                                    format!(
+                                        "entry_point={},args={{{}}}",
+                                        entry_point,
+                                        args.join(",")
+                                    ),
+                                ))
+                            })
+                    }))
+                } else {
+                    future::Either::B(future::err(Error::InvalidTransition { transition, state }))
+                };
+                ActorResponse::r#async(fut.into_actor(self))
+            }
+            Command::Transfer { from, to } => {
+                let transition = Transition::Transfer;
+                let state = self.states.current_state;
+                let fut = if let Some(state) = self.states.next_state(transition) {
+                    let addr = ctx.address().clone();
+                    let when = Instant::now() + Duration::from_secs(3);
+                    future::Either::A(Delay::new(when).map_err(Into::into).and_then(move |_| {
+                        addr.send(UpdateState { state })
+                            .map_err(Into::into)
+                            .and_then(move |_| Ok((state, format!("from={},to={}", from, to))))
+                    }))
+                } else {
+                    future::Either::B(future::err(Error::InvalidTransition { transition, state }))
+                };
+                ActorResponse::r#async(fut.into_actor(self))
+            }
+            Command::Stop {} => {
+                let transition = Transition::Transfer;
+                let state = self.states.current_state;
+                let fut = if let Some(state) = self.states.next_state(transition) {
+                    let addr = ctx.address().clone();
+                    let when = Instant::now() + Duration::from_secs(2);
+                    future::Either::A(Delay::new(when).map_err(Into::into).and_then(move |_| {
+                        addr.send(UpdateState { state })
+                            .map_err(Into::into)
+                            .and_then(move |_| Ok((state, "".to_owned())))
+                    }))
+                } else {
+                    future::Either::B(future::err(Error::InvalidTransition { transition, state }))
+                };
+                ActorResponse::r#async(fut.into_actor(self))
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces major refactoring effort in that, the
core ExeUnit API (`ya-exe-api`) is now fully rewritten using
`actix-0.8.3` and `futures-0.1` in order to be compatible
with `ya-service-bus`.