### PR TITLE
Drop the rest_interface! macro in activity client

### DIFF
--- a/agent/provider/src/provider_agent.rs
+++ b/agent/provider/src/provider_agent.rs
@@ -31,7 +31,8 @@ impl ProviderAgent {
         let client = ApiClient::new(webclient)?;
         let market = ProviderMarketActor::new(client, "AcceptAll").start();
 
-        let client = ProviderApiClient::new(Arc::new(config.activity_client().build()?));
+        let activity_client = Arc::new(config.activity_client().build()?);
+        let client = ProviderApiClient::new(&activity_client);
         let runner = TaskRunnerActor::new(client).start();
 
         let node_info = ProviderAgent::create_node_info();

--- a/agent/requestor/src/main.rs
+++ b/agent/requestor/src/main.rs
@@ -59,7 +59,7 @@ impl AppSettings {
             .build()?;
         let client = std::sync::Arc::new(connection);
 
-        Ok(ya_client::activity::RequestorControlApiClient::new(client))
+        Ok(ya_client::activity::RequestorControlApiClient::new(&client))
     }
 }
 

--- a/interfaces/client/examples/activity_interaction.rs
+++ b/interfaces/client/examples/activity_interaction.rs
@@ -17,7 +17,8 @@ fn new_client() -> Result<Arc<WebClient>> {
 }
 
 async fn provider(activity_id: &str) -> Result<()> {
-    let client = ProviderApiClient::new(new_client()?);
+    let web_client = new_client()?;
+    let client = ProviderApiClient::new(&web_client);
 
     println!("[?] Events for activity {}", activity_id);
     let activity_events = client.get_activity_events(Some(60i32)).await.unwrap();
@@ -41,7 +42,8 @@ async fn requestor(agreement_id: &str) -> Result<()> {
 }
 
 async fn requestor_start(agreement_id: &str) -> Result<String> {
-    let client = RequestorControlApiClient::new(new_client()?);
+    let web_client = new_client()?;
+    let client = RequestorControlApiClient::new(&web_client);
 
     println!("[+] Activity, agreement {}", agreement_id);
     let activity_id = client.create_activity(agreement_id).await?;
@@ -51,7 +53,8 @@ async fn requestor_start(agreement_id: &str) -> Result<String> {
 }
 
 async fn requestor_stop(activity_id: &str) -> Result<()> {
-    let client = RequestorControlApiClient::new(new_client()?);
+    let web_client = new_client()?;
+    let client = RequestorControlApiClient::new(&web_client);
 
     println!("[-] Activity {}", activity_id);
     client.destroy_activity(&activity_id).await?;
@@ -60,7 +63,8 @@ async fn requestor_stop(activity_id: &str) -> Result<()> {
 }
 
 async fn requestor_exec(activity_id: &str) -> Result<()> {
-    let client = RequestorControlApiClient::new(new_client()?);
+    let web_client = new_client()?;
+    let client = RequestorControlApiClient::new(&web_client);
 
     let exe_request = ExeScriptRequest::new("STOP".to_string());
     println!("[+] Batch exe script:{:?}", exe_request);
@@ -76,7 +80,8 @@ async fn requestor_exec(activity_id: &str) -> Result<()> {
 }
 
 async fn requestor_state(activity_id: &str) -> Result<()> {
-    let client = RequestorStateApiClient::new(new_client()?);
+    let web_client = new_client()?;
+    let client = RequestorStateApiClient::new(&web_client);
 
     println!("[?] State for activity {}", activity_id);
     let state = client.get_state(activity_id).await?;

--- a/interfaces/client/src/activity/provider.rs
+++ b/interfaces/client/src/activity/provider.rs
@@ -1,50 +1,47 @@
 //! Provider part of Activity API
-use crate::Result;
-use awc::http::StatusCode;
+use crate::web::WebClient;
+use crate::{Error, Result};
+use std::sync::Arc;
 use ya_model::activity::{ActivityState, ActivityUsage, ProviderEvent};
 
-rest_interface! {
-    /// Bindings for Provider part of the Activity API.
-    impl ProviderApiClient {
+pub struct ProviderApiClient {
+    client: Arc<WebClient>,
+}
 
-        /// Fetch activity state (which may include error details)
-        pub async fn get_activity_state(
-            &self,
-            #[path] activity_id: &str
-        ) -> Result<ActivityState> {
-            let response = get("activity/{activity_id}/state/").send().json();
-
-            response
-        }
-
-        /// Fetch current activity usage (which may include error details)
-        pub async fn get_activity_usage(
-            &self,
-            #[path] activity_id: &str
-        ) -> Result<ActivityUsage> {
-            let response = get("activity/{activity_id}/usage/").send().json();
-
-            response
+/// Bindings for Provider part of the Activity API.
+impl ProviderApiClient {
+    pub fn new(client: &Arc<WebClient>) -> Self {
+        Self {
+            client: client.clone(),
         }
     }
-}
-/*
-/// Fetch Requestor command events.
-*/
-impl ProviderApiClient {
+
+    /// Fetch activity state (which may include error details)
+    pub async fn get_activity_state(&self, activity_id: &str) -> Result<ActivityState> {
+        let uri = url_format!("activity/{activity_id}/state", activity_id);
+        self.client.get(&uri).send().json().await
+    }
+
+    /// Fetch current activity usage (which may include error details)
+    pub async fn get_activity_usage(&self, activity_id: &str) -> Result<ActivityUsage> {
+        let uri = url_format!("activity/{activity_id}/usage", activity_id);
+        self.client.get(&uri).send().json().await
+    }
+
+    /// Fetch Requestor command events.
     pub async fn get_activity_events(&self, timeout: Option<i32>) -> Result<Vec<ProviderEvent>> {
-        let url = self.url(url_format!(
+        let url = url_format!(
             "events",
             #[query]
             timeout
-        ));
-        let client: std::sync::Arc<_> = self.client.clone();
+        );
 
-        let mut resp = client.awc.get(url.as_str()).send().await?;
-        if resp.status() == StatusCode::REQUEST_TIMEOUT {
-            Ok(Vec::new())
-        } else {
-            Ok(resp.json().await?)
+        match self.client.get(&url).send().json().await {
+            Ok(v) => Ok(v),
+            Err(e) => match e {
+                Error::TimeoutError { .. } => Ok(Vec::new()),
+                _ => Err(e),
+            },
         }
     }
 }

--- a/interfaces/client/src/activity/requestor/control.rs
+++ b/interfaces/client/src/activity/requestor/control.rs
@@ -1,52 +1,60 @@
 //! Requestor control part of Activity API
+use crate::web::WebClient;
 use crate::Result;
+use std::sync::Arc;
 use ya_model::activity::{ExeScriptCommandResult, ExeScriptRequest};
 
-rest_interface! {
-    /// Bindings for Requestor Control part of the Activity API.
-    impl RequestorControlApiClient {
-        /// Creates new Activity based on given Agreement.
-        pub async fn create_activity(
-            &self,
-            agreement_id: &str
-        ) -> Result<String> {
-            let response = post("activity").send_json( &agreement_id ).json();
+/// Bindings for Requestor Control part of the Activity API.
+pub struct RequestorControlApiClient {
+    client: Arc<WebClient>,
+}
 
-            response
+impl RequestorControlApiClient {
+    pub fn new(client: &Arc<WebClient>) -> Self {
+        Self {
+            client: client.clone(),
         }
+    }
 
-        /// Destroys given Activity.
-        pub async fn destroy_activity(
-            &self,
-            #[path] activity_id: &str
-        ) -> Result<()> {
-            let response = delete("activity/{activity_id}").send().body();
+    /// Creates new Activity based on given Agreement.
+    pub async fn create_activity(&self, agreement_id: &str) -> Result<String> {
+        self.client
+            .post("activity")
+            .send_json(&agreement_id)
+            .json()
+            .await
+    }
 
-            { response.map(|_| ()) }
-        }
+    /// Destroys given Activity.
+    pub async fn destroy_activity(&self, activity_id: &str) -> Result<()> {
+        let uri = url_format!("activity/{activity_id}", activity_id);
+        self.client.delete(&uri).send().json().await?;
+        Ok(())
+    }
 
-        /// Executes an ExeScript batch within a given Activity.
-        pub async fn exec(
-            &self,
-            script: ExeScriptRequest,
-            #[path] activity_id: &str
-        ) -> Result<String> {
-            let response = post("activity/{activity_id}/state").send_json( &script ).json();
+    /// Executes an ExeScript batch within a given Activity.
+    pub async fn exec(&self, script: ExeScriptRequest, activity_id: &str) -> Result<String> {
+        let uri = url_format!("activity/{activity_id}/exec", activity_id);
+        self.client.post(&uri).send_json(&script).json().await
+    }
 
-            response
-        }
-
-        /// Queries for ExeScript batch results.
-        pub async fn get_exec_batch_results(
-            &self,
-            #[path] activity_id: &str,
-            #[path] batch_id: &str,
-            #[query] timeout: Option<i32>,
-            #[query] max_count: Option<i32>
-        ) -> Result<Vec<ExeScriptCommandResult>> {
-            let response = get("activity/{activity_id}/exec/{batch_id}").send().json();
-
-            response
-        }
+    /// Queries for ExeScript batch results.
+    #[rustfmt::skip]
+    pub async fn get_exec_batch_results(
+        &self,
+        activity_id: &str,
+        batch_id: &str,
+        timeout: Option<i32>,
+        #[allow(non_snake_case)]
+        maxCount: Option<i32>,
+    ) -> Result<Vec<ExeScriptCommandResult>> {
+        let uri = url_format!(
+            "activity/{activity_id}/exec/{batch_id}",
+            activity_id,
+            batch_id,
+            #[query] timeout,
+            #[query] maxCount
+        );
+        self.client.get(&uri).send().json().await
     }
 }

--- a/interfaces/client/src/activity/requestor/state.rs
+++ b/interfaces/client/src/activity/requestor/state.rs
@@ -1,38 +1,36 @@
 //! Requestor state part of Activity API
+use crate::web::WebClient;
 use crate::Result;
+use std::sync::Arc;
 use ya_model::activity::{ActivityState, ExeScriptCommandState};
 
-rest_interface! {
-    /// Bindings for Requestor State part of the Activity API.
-    impl RequestorStateApiClient {
-        /// Get running command for a specified Activity.
-        pub async fn get_running_command(
-            &self,
-            #[path] activity_id: &str
-        ) -> Result<ExeScriptCommandState> {
-            let response = get("activity/{activity_id}/command/").send().json();
+/// Bindings for Requestor State part of the Activity API.
+pub struct RequestorStateApiClient {
+    client: Arc<WebClient>,
+}
 
-            response
+impl RequestorStateApiClient {
+    pub fn new(client: &Arc<WebClient>) -> Self {
+        Self {
+            client: client.clone(),
         }
+    }
 
-        /// Get state of specified Activity.
-        pub async fn get_state(
-            &self,
-            #[path] activity_id: &str
-        ) -> Result<ActivityState> {
-            let response = get("activity/{activity_id}/state/").send().json();
+    /// Get running command for a specified Activity.
+    pub async fn get_running_command(&self, activity_id: &str) -> Result<ExeScriptCommandState> {
+        let uri = url_format!("activity/{activity_id}/command", activity_id);
+        self.client.get(&uri).send().json().await
+    }
 
-            response
-        }
+    /// Get state of specified Activity.
+    pub async fn get_state(&self, activity_id: &str) -> Result<ActivityState> {
+        let uri = url_format!("activity/{activity_id}/state", activity_id);
+        self.client.get(&uri).send().json().await
+    }
 
-        /// Get usage of specified Activity.
-        pub async fn get_usage(
-            &self,
-            #[path] activity_id: &str
-        ) -> Result<Vec<f64>> {
-            let response = get("activity/{activity_id}/usage/").send().json();
-
-            response
-        }
+    /// Get usage of specified Activity.
+    pub async fn get_usage(&self, activity_id: &str) -> Result<Vec<f64>> {
+        let uri = url_format!("activity/{activity_id}/usage", activity_id);
+        self.client.get(&uri).send().json().await
     }
 }


### PR DESCRIPTION
Additionally:
- fix the `uri` in `RequestorControlApiClient::exec`
- remove trailing slashes from `uri`s