### PR TITLE
New type for transaction signing function

### DIFF
--- a/core/payment-driver/examples/gnt_driver.rs
+++ b/core/payment-driver/examples/gnt_driver.rs
@@ -95,7 +95,7 @@ fn main() {
 
     let mut gnt_driver = GntDriver::new(address, ethereum_client, gnt_contract_address).unwrap();
 
-    block_on(gnt_driver.init_funds(ETH_FAUCET_ADDRESS, gnt_faucet_address, sign_tx)).unwrap();
+    block_on(gnt_driver.init_funds(ETH_FAUCET_ADDRESS, gnt_faucet_address, &sign_tx)).unwrap();
 
     wait_for_confirmations();
     show_balance(&gnt_driver);
@@ -110,7 +110,7 @@ fn main() {
         payment_amount,
         address,
         due_date,
-        sign_tx,
+        &sign_tx,
     ));
     transfer.map_or_else(
         |e| println!("Unexpected error while sending Gnt: {:?}", e),

--- a/core/payment-driver/src/dummy.rs
+++ b/core/payment-driver/src/dummy.rs
@@ -1,6 +1,6 @@
 use crate::{
     AccountBalance, Balance, Currency, PaymentAmount, PaymentConfirmation, PaymentDetails,
-    PaymentDriver, PaymentDriverError, PaymentStatus,
+    PaymentDriver, PaymentDriverError, PaymentStatus, SignTx,
 };
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -36,17 +36,14 @@ impl PaymentDriver for DummyDriver {
         })
     }
 
-    async fn schedule_payment<F>(
+    async fn schedule_payment(
         &mut self,
         invoice_id: &str,
         amount: PaymentAmount,
         recipient: Address,
         _due_date: DateTime<Utc>,
-        _sign_tx: F,
-    ) -> Result<(), PaymentDriverError>
-    where
-        F: 'static + FnOnce(Vec<u8>) -> Vec<u8> + Sync + Send,
-    {
+        _sign_tx: SignTx<'_>,
+    ) -> Result<(), PaymentDriverError> {
         match self.payments.entry(invoice_id.to_string()) {
             Entry::Occupied(_) => Err(PaymentDriverError::AlreadyScheduled),
             Entry::Vacant(entry) => {

--- a/core/payment-driver/src/lib.rs
+++ b/core/payment-driver/src/lib.rs
@@ -24,22 +24,22 @@ pub use payment::{PaymentAmount, PaymentConfirmation, PaymentDetails, PaymentSta
 
 pub type PaymentDriverResult<T> = Result<T, PaymentDriverError>;
 
+pub type SignTx<'a> = &'a (dyn Fn(Vec<u8>) -> Vec<u8> + Send + Sync);
+
 #[async_trait]
 pub trait PaymentDriver {
     /// Returns account balance
     async fn get_account_balance(&self) -> PaymentDriverResult<AccountBalance>;
 
     /// Schedules payment
-    async fn schedule_payment<F>(
+    async fn schedule_payment(
         &mut self,
         invoice_id: &str,
         amount: PaymentAmount,
         recipient: Address,
         due_date: DateTime<Utc>,
-        sign_tx: F,
-    ) -> PaymentDriverResult<()>
-    where
-        F: 'static + FnOnce(Vec<u8>) -> Vec<u8> + Sync + Send;
+        sign_tx: SignTx<'_>,
+    ) -> PaymentDriverResult<()>;
 
     /// Returns payment status
     async fn get_payment_status(&self, invoice_id: &str) -> PaymentDriverResult<PaymentStatus>;


### PR DESCRIPTION
The reason for this change is to get rid of template methods from PaymentDriver. Template methods prevented making this trait into an object.