### PR TITLE
SignTx made async + public key retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5009,6 +5009,7 @@ dependencies = [
  "libsqlite3-sys 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1 0.15.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/identity/src/id_key.rs
+++ b/core/identity/src/id_key.rs
@@ -49,6 +49,7 @@ impl IdentityKey {
         Ok(true)
     }
 
+    /// Sign given 32-byte message with the key.
     pub fn sign(&self, data: &[u8]) -> Option<Vec<u8>> {
         let s = match &self.secret {
             Some(secret) => secret,

--- a/core/payment-driver/Cargo.toml
+++ b/core/payment-driver/Cargo.toml
@@ -24,4 +24,5 @@ reqwest = { version = "0.10", features = ["blocking", "json"] }
 ethkey = "0.3.1"
 hex = "0.4"
 r2d2 = "0.8"
+secp256k1 = "0.15"
 tokio = "0.2"

--- a/core/payment-driver/examples/gnt_driver.rs
+++ b/core/payment-driver/examples/gnt_driver.rs
@@ -10,6 +10,7 @@ use futures::executor::block_on;
 
 use std::{thread, time};
 
+use futures::{future, Future};
 use ya_payment_driver::account::{AccountBalance, Chain};
 use ya_payment_driver::ethereum::EthereumClient;
 use ya_payment_driver::gnt::GntDriver;
@@ -29,7 +30,7 @@ const PASSWORD: &str = "";
 
 const SLEEP_TIME: u64 = 60;
 
-fn sign_tx(bytes: Vec<u8>) -> Vec<u8> {
+fn sign_tx(bytes: Vec<u8>) -> Box<dyn Future<Output = Vec<u8>> + Send + Sync + Unpin> {
     let secret = get_secret_key(KEYSTORE, PASSWORD);
 
     // Sign the message
@@ -41,7 +42,7 @@ fn sign_tx(bytes: Vec<u8>) -> Vec<u8> {
     v.extend_from_slice(&signature.r[..]);
     v.extend_from_slice(&signature.s[..]);
 
-    v
+    Box::new(future::ready(v))
 }
 
 fn load_or_generate_account(keystore: &str, password: &str) {

--- a/core/payment-driver/src/error.rs
+++ b/core/payment-driver/src/error.rs
@@ -16,6 +16,12 @@ pub enum PaymentDriverError {
     LibraryError { msg: String },
 }
 
+impl From<secp256k1::Error> for PaymentDriverError {
+    fn from(e: secp256k1::Error) -> Self {
+        PaymentDriverError::LibraryError { msg: e.to_string() }
+    }
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum DbError {
     #[error("Database connection error: {0}")]

--- a/core/payment-driver/src/gnt.rs
+++ b/core/payment-driver/src/gnt.rs
@@ -106,7 +106,7 @@ impl GntDriver {
             (recipient, gnt_amount),
         )?;
 
-        let tx_hash = self.send_raw_transaction(&tx, sign_tx)?;
+        let tx_hash = self.send_raw_transaction(&tx, sign_tx).await?;
         Ok(tx_hash)
     }
 
@@ -190,19 +190,19 @@ impl GntDriver {
 
         let tx = self.prepare_raw_tx(U256::from(GNT_FAUCET_GAS), &contract, "create", ())?;
 
-        let tx_hash = self.send_raw_transaction(&tx, sign_tx)?;
+        let tx_hash = self.send_raw_transaction(&tx, sign_tx).await?;
 
         println!("Tx hash: {:?}", tx_hash);
         Ok(())
     }
 
-    fn send_raw_transaction(
+    async fn send_raw_transaction(
         &self,
         raw_tx: &RawTransaction,
         sign_tx: SignTx<'_>,
     ) -> PaymentDriverResult<H256> {
         let chain_id = self.get_chain_id();
-        let signature = sign_tx(raw_tx.hash(chain_id));
+        let signature = sign_tx(raw_tx.hash(chain_id)).await;
         let signed_tx = raw_tx.encode_signed_tx(signature, chain_id);
 
         // TODO persistence

--- a/core/payment-driver/src/lib.rs
+++ b/core/payment-driver/src/lib.rs
@@ -19,12 +19,14 @@ pub mod schema;
 pub use account::{AccountBalance, Balance, Chain, Currency};
 pub use dummy::DummyDriver;
 pub use error::PaymentDriverError;
+use futures::Future;
 pub use gnt::GntDriver;
 pub use payment::{PaymentAmount, PaymentConfirmation, PaymentDetails, PaymentStatus};
 
 pub type PaymentDriverResult<T> = Result<T, PaymentDriverError>;
 
-pub type SignTx<'a> = &'a (dyn Fn(Vec<u8>) -> Vec<u8> + Send + Sync);
+pub type SignTx<'a> =
+    &'a (dyn Fn(Vec<u8>) -> Box<dyn Future<Output = Vec<u8>> + Unpin + Send + Sync> + Send + Sync);
 
 #[async_trait]
 pub trait PaymentDriver {

--- a/core/payment-driver/src/payment.rs
+++ b/core/payment-driver/src/payment.rs
@@ -26,6 +26,7 @@ pub enum PaymentStatus {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PaymentDetails {
     pub recipient: Address,
+    pub sender: Address,
     pub amount: U256,
     pub date: Option<DateTime<Utc>>,
 }


### PR DESCRIPTION
1. Changed SignTx return type to a boxed future to allow asynchronous signing functions.
2. DummyDriver now retrieves public key from the provided signing function so that providing address during initialization is no longer needed. This allows single driver to handle multiple addresses.