### PR TITLE
ExeUnit - missing await in shutdown process

### DIFF
--- a/exe-unit/src/handlers/local.rs
+++ b/exe-unit/src/handlers/local.rs
@@ -82,7 +82,9 @@ impl<R: Runtime> Handler<Shutdown> for ExeUnit<R> {
             let _ = address.send(SetState::from(state)).await;
 
             Self::stop_runtime(runtime, msg.0).await;
-            services.into_iter().for_each(|mut svc| svc.stop());
+            for mut service in services.into_iter() {
+                service.stop().await;
+            }
 
             let _ = address.send(SetState::from(State::Terminated)).await;
 

--- a/exe-unit/src/runtime/process.rs
+++ b/exe-unit/src/runtime/process.rs
@@ -99,6 +99,7 @@ impl Handler<ExecCmd> for RuntimeProcess {
 
                 let fut = async move {
                     let child = Command::new(binary)
+                        .kill_on_drop(true)
                         .args(args?)
                         .stdout(Stdio::piped())
                         .stderr(Stdio::piped())

--- a/exe-unit/src/service/mod.rs
+++ b/exe-unit/src/service/mod.rs
@@ -4,9 +4,11 @@ pub mod transfer;
 
 use crate::message::{Shutdown, ShutdownReason};
 use actix::prelude::*;
+use futures::future::LocalBoxFuture;
+use futures::FutureExt;
 
 pub trait ServiceControl {
-    fn stop(&mut self);
+    fn stop(&mut self) -> LocalBoxFuture<()>;
 }
 
 pub(crate) struct ServiceAddr<Svc>
@@ -29,7 +31,11 @@ impl<Svc> ServiceControl for ServiceAddr<Svc>
 where
     Svc: Actor<Context = Context<Svc>> + Handler<Shutdown>,
 {
-    fn stop(&mut self) {
-        self.addr.do_send(Shutdown(ShutdownReason::Finished))
+    fn stop(&mut self) -> LocalBoxFuture<()> {
+        let addr = self.addr.clone();
+        async move {
+            let _ = addr.send(Shutdown(ShutdownReason::Finished)).await;
+        }
+        .boxed_local()
     }
 }


### PR DESCRIPTION
+ `kill_on_drop`