### PR TITLE
Payment API: Accept debit note (dummy implementation)

### DIFF
--- a/core/payment/examples/README.md
+++ b/core/payment/examples/README.md
@@ -43,6 +43,17 @@ To see debit notes issued by the provider:
 To see debit notes received by the requestor:  
 `GET` `http://127.0.0.1:8465/payment-api/v1/requestor/debitNotes`
 
+To accept a debit note:
+`POST` `http://127.0.0.1:8465/payment-api/v1/requestor/debitNotes/<debitNoteId>/accept`
+
+Payload:
+```json
+{
+  "totalAmountAccepted": "1.123456789012345678",
+  "allocationId": "<allocationId>"
+}
+```
+
 #### Invoice flow
 
 To issue an invoice:  

--- a/core/payment/src/api/requestor.rs
+++ b/core/payment/src/api/requestor.rs
@@ -12,7 +12,9 @@ use actix_web::{HttpResponse, Scope};
 use serde_json::value::Value::Null;
 use ya_core_model::ethaddr::NodeId;
 use ya_core_model::payment::local::{SchedulePayment, BUS_ID as LOCAL_SERVICE};
-use ya_core_model::payment::public::{AcceptInvoice, AcceptRejectError, BUS_ID as PUBLIC_SERVICE};
+use ya_core_model::payment::public::{
+    AcceptDebitNote, AcceptInvoice, AcceptRejectError, BUS_ID as PUBLIC_SERVICE,
+};
 use ya_core_model::payment::RpcMessageError;
 use ya_model::payment::*;
 use ya_net::TryRemoteEndpoint;
@@ -95,8 +97,64 @@ async fn accept_debit_note(
     path: Path<DebitNoteId>,
     query: Query<Timeout>,
     body: Json<Acceptance>,
+    id: Identity,
 ) -> HttpResponse {
-    response::not_implemented() // TODO
+    let debit_note_id = path.debit_note_id.clone();
+    let recipient_id = id.identity.to_string();
+    let acceptance = body.into_inner();
+    let allocation_id = acceptance.allocation_id.clone();
+
+    let dao: DebitNoteDao = db.as_dao();
+    let debit_note: DebitNote = match dao.get(debit_note_id.clone()).await {
+        Ok(Some(debit_note)) if debit_note.recipient_id == recipient_id => debit_note.into(),
+        Err(e) => return response::server_error(&e),
+        _ => return response::not_found(),
+    };
+
+    if debit_note.total_amount_due != acceptance.total_amount_accepted {
+        return response::bad_request(&"Invalid amount accepted");
+    }
+
+    match debit_note.status {
+        InvoiceStatus::Received => (),
+        InvoiceStatus::Rejected => (),
+        InvoiceStatus::Failed => (),
+        InvoiceStatus::Accepted => return response::ok(Null),
+        InvoiceStatus::Settled => return response::ok(Null),
+        InvoiceStatus::Issued => return response::server_error(&"Illegal status: issued"),
+        InvoiceStatus::Cancelled => return response::bad_request(&"Debit note cancelled"),
+    }
+
+    with_timeout(query.timeout, async move {
+        let issuer_id: NodeId = debit_note.issuer_id.parse().unwrap();
+        let msg = AcceptDebitNote {
+            debit_note_id: debit_note_id.clone(),
+            acceptance,
+        };
+        match async move {
+            issuer_id.try_service(PUBLIC_SERVICE)?.call(msg).await??;
+            Ok(())
+        }
+        .await
+        {
+            Err(Error::Rpc(RpcMessageError::AcceptReject(AcceptRejectError::BadRequest(e)))) => {
+                return response::bad_request(&e);
+            }
+            Err(e) => return response::server_error(&e),
+            _ => (),
+        }
+
+        // TODO: Compute amount to pay and schedule payment
+
+        match dao
+            .update_status(debit_note_id, InvoiceStatus::Accepted.into())
+            .await
+        {
+            Ok(_) => response::ok(Null),
+            Err(e) => response::server_error(&e),
+        }
+    })
+    .await
 }
 
 async fn reject_debit_note(
@@ -201,11 +259,7 @@ async fn accept_invoice(
             acceptance,
         };
         match async move {
-            issuer_id
-                .try_service(PUBLIC_SERVICE)
-                .unwrap() // FIXME
-                .call(msg)
-                .await??;
+            issuer_id.try_service(PUBLIC_SERVICE)?.call(msg).await??;
             Ok(())
         }
         .await

--- a/core/payment/src/dao.rs
+++ b/core/payment/src/dao.rs
@@ -1,9 +1,11 @@
 pub mod allocation;
 pub mod debit_note;
+pub mod debit_note_event;
 pub mod invoice;
 pub mod invoice_event;
 pub mod payment;
 
 pub use self::{
-    allocation::AllocationDao, debit_note::DebitNoteDao, invoice::InvoiceDao, payment::PaymentDao,
+    allocation::AllocationDao, debit_note::DebitNoteDao, debit_note_event::DebitNoteEventDao,
+    invoice::InvoiceDao, payment::PaymentDao,
 };

--- a/core/payment/src/dao/debit_note_event.rs
+++ b/core/payment/src/dao/debit_note_event.rs
@@ -1,0 +1,67 @@
+use crate::error::DbResult;
+use crate::models::*;
+use crate::schema::pay_debit_note::dsl as debit_note_dsl;
+use crate::schema::pay_debit_note_event::dsl;
+use chrono::NaiveDateTime;
+use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl};
+use ya_persistence::executor::{do_with_transaction, AsDao, PoolType};
+
+pub struct DebitNoteEventDao<'c> {
+    pool: &'c PoolType,
+}
+
+impl<'c> AsDao<'c> for DebitNoteEventDao<'c> {
+    fn as_dao(pool: &'c PoolType) -> Self {
+        Self { pool }
+    }
+}
+
+impl<'c> DebitNoteEventDao<'c> {
+    pub async fn create(&self, event: NewDebitNoteEvent) -> DbResult<()> {
+        do_with_transaction(self.pool, move |conn| {
+            diesel::insert_into(dsl::pay_debit_note_event)
+                .values(event)
+                .execute(conn)?;
+            Ok(())
+        })
+        .await
+    }
+
+    pub async fn get_for_recipient(
+        &self,
+        recipient_id: String,
+        later_than: Option<NaiveDateTime>,
+    ) -> DbResult<Vec<DebitNoteEvent>> {
+        do_with_transaction(self.pool, move |conn| {
+            let query = dsl::pay_debit_note_event
+                .inner_join(debit_note_dsl::pay_debit_note)
+                .filter(debit_note_dsl::recipient_id.eq(recipient_id))
+                .select(crate::schema::pay_debit_note_event::all_columns);
+            let events = match later_than {
+                Some(timestamp) => query.filter(dsl::timestamp.gt(timestamp)).load(conn)?,
+                None => query.load(conn)?,
+            };
+            Ok(events)
+        })
+        .await
+    }
+
+    pub async fn get_for_issuer(
+        &self,
+        issuer_id: String,
+        later_than: Option<NaiveDateTime>,
+    ) -> DbResult<Vec<DebitNoteEvent>> {
+        do_with_transaction(self.pool, move |conn| {
+            let query = dsl::pay_debit_note_event
+                .inner_join(debit_note_dsl::pay_debit_note)
+                .filter(debit_note_dsl::issuer_id.eq(issuer_id))
+                .select(crate::schema::pay_debit_note_event::all_columns);
+            let events = match later_than {
+                Some(timestamp) => query.filter(dsl::timestamp.gt(timestamp)).load(conn)?,
+                None => query.load(conn)?,
+            };
+            Ok(events)
+        })
+        .await
+    }
+}

--- a/core/payment/src/error.rs
+++ b/core/payment/src/error.rs
@@ -62,6 +62,8 @@ pub enum Error {
     Database(#[from] DbError),
     #[error("Service bus error: {0}")]
     ServiceBus(#[from] ya_service_bus::Error),
+    #[error("Network error: {0}")]
+    Network(#[from] ya_net::NetApiError),
     #[error("External service error: {0}")]
     ExtService(#[from] ExternalServiceError),
     #[error("Payment error: {0}")]

--- a/core/payment/src/models.rs
+++ b/core/payment/src/models.rs
@@ -172,6 +172,36 @@ pub struct DebitNoteEvent {
     pub details: Option<String>,
 }
 
+impl From<DebitNoteEvent> for api_model::DebitNoteEvent {
+    fn from(event: DebitNoteEvent) -> Self {
+        Self {
+            debit_note_id: event.debit_note_id,
+            timestamp: Utc.from_utc_datetime(&event.timestamp),
+            details: event.details.map(|s| serde_json::from_str(&s).unwrap()),
+            event_type: event.event_type.try_into().unwrap(),
+        }
+    }
+}
+
+#[derive(Debug, Identifiable, Insertable)]
+#[table_name = "pay_debit_note_event"]
+#[primary_key(debit_note_id, event_type)]
+pub struct NewDebitNoteEvent {
+    pub debit_note_id: String,
+    pub event_type: String,
+    pub details: Option<String>,
+}
+
+impl From<api_model::NewDebitNoteEvent> for NewDebitNoteEvent {
+    fn from(event: api_model::NewDebitNoteEvent) -> Self {
+        Self {
+            debit_note_id: event.debit_note_id,
+            event_type: event.event_type.into(),
+            details: event.details.map(|s| serde_json::to_string(&s).unwrap()),
+        }
+    }
+}
+
 #[derive(Queryable, QueryableByName, Debug, Identifiable, Insertable)]
 #[table_name = "pay_invoice"]
 pub struct BareInvoice {

--- a/interfaces/model/src/payment.rs
+++ b/interfaces/model/src/payment.rs
@@ -16,6 +16,7 @@ pub use self::allocation::NewAllocation;
 pub use self::debit_note::DebitNote;
 pub use self::debit_note::NewDebitNote;
 pub use self::debit_note_event::DebitNoteEvent;
+pub use self::debit_note_event::NewDebitNoteEvent;
 pub use self::event_type::EventType;
 pub use self::invoice::Invoice;
 pub use self::invoice::NewInvoice;

--- a/interfaces/model/src/payment/debit_note_event.rs
+++ b/interfaces/model/src/payment/debit_note_event.rs
@@ -1,10 +1,20 @@
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DebitNoteEvent {
     pub debit_note_id: String,
-    pub timestamp: String,
+    pub timestamp: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub details: Option<serde_json::Value>,
+    pub event_type: crate::payment::EventType,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewDebitNoteEvent {
+    pub debit_note_id: String,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub details: Option<serde_json::Value>,
     pub event_type: crate::payment::EventType,
@@ -13,7 +23,7 @@ pub struct DebitNoteEvent {
 impl DebitNoteEvent {
     pub fn new(
         debit_note_id: String,
-        timestamp: String,
+        timestamp: DateTime<Utc>,
         event_type: crate::payment::EventType,
     ) -> DebitNoteEvent {
         DebitNoteEvent {


### PR DESCRIPTION
Debit notes can be accepted now. It results in setting debit note status to `ACCEPTED` on both provider and requestor nodes, as well as emitting an event on the provider node.

There is **no checking** if the allocation used to accept the debit note has sufficient funds and the payment is **not scheduled**.