### PR TITLE
Payment API: Debit note events

### DIFF
--- a/core/payment/examples/README.md
+++ b/core/payment/examples/README.md
@@ -54,6 +54,12 @@ Payload:
 }
 ```
 
+To listen for requestor's debit note events:
+`GET` `http://127.0.0.1:8465/payment-api/v1/requestor/debitNoteEvents?timeout=<seconds>`
+
+To listen for provider's debit note events:
+`GET` `http://127.0.0.1:8465/payment-api/v1/provider/debitNoteEvents?timeout=<seconds>`
+
 #### Invoice flow
 
 To issue an invoice:  

--- a/core/payment/src/api/provider.rs
+++ b/core/payment/src/api/provider.rs
@@ -1,8 +1,5 @@
 use crate::api::*;
-use crate::dao::debit_note::DebitNoteDao;
-use crate::dao::invoice::InvoiceDao;
-use crate::dao::invoice_event::InvoiceEventDao;
-use crate::dao::payment::PaymentDao;
+use crate::dao::*;
 use crate::error::{DbError, Error};
 use crate::models as db_models;
 use crate::utils::*;
@@ -181,8 +178,27 @@ async fn cancel_debit_note(
     response::not_implemented() // TODO
 }
 
-async fn get_debit_note_events(db: Data<DbExecutor>, query: Query<EventParams>) -> HttpResponse {
-    response::not_implemented() // TODO
+async fn get_debit_note_events(
+    db: Data<DbExecutor>,
+    query: Query<EventParams>,
+    id: Identity,
+) -> HttpResponse {
+    let issuer_id = id.identity.to_string();
+    let timeout_secs = query.timeout;
+    let later_than = query.later_than.map(|d| d.naive_utc());
+
+    let dao: DebitNoteEventDao = db.as_dao();
+    let getter = || async {
+        dao.get_for_issuer(issuer_id.clone(), later_than.clone())
+            .await
+    };
+
+    match listen_for_events(getter, timeout_secs).await {
+        Err(e) => response::server_error(&e),
+        Ok(events) => {
+            response::ok::<Vec<DebitNoteEvent>>(events.into_iter().map(Into::into).collect())
+        }
+    }
 }
 
 // *************************** INVOICE ****************************

--- a/core/payment/src/api/requestor.rs
+++ b/core/payment/src/api/requestor.rs
@@ -1,9 +1,5 @@
 use crate::api::*;
-use crate::dao::allocation::AllocationDao;
-use crate::dao::debit_note::DebitNoteDao;
-use crate::dao::invoice::InvoiceDao;
-use crate::dao::invoice_event::InvoiceEventDao;
-use crate::dao::payment::PaymentDao;
+use crate::dao::*;
 use crate::error::{DbError, Error};
 use crate::models as db_models;
 use crate::utils::{listen_for_events, response, with_timeout};
@@ -166,8 +162,27 @@ async fn reject_debit_note(
     response::not_implemented() // TODO
 }
 
-async fn get_debit_note_events(db: Data<DbExecutor>, query: Query<EventParams>) -> HttpResponse {
-    response::not_implemented() // TODO
+async fn get_debit_note_events(
+    db: Data<DbExecutor>,
+    query: Query<EventParams>,
+    id: Identity,
+) -> HttpResponse {
+    let recipient_id = id.identity.to_string();
+    let timeout_secs = query.timeout;
+    let later_than = query.later_than.map(|d| d.naive_utc());
+
+    let dao: DebitNoteEventDao = db.as_dao();
+    let getter = || async {
+        dao.get_for_recipient(recipient_id.clone(), later_than.clone())
+            .await
+    };
+
+    match listen_for_events(getter, timeout_secs).await {
+        Err(e) => response::server_error(&e),
+        Ok(events) => {
+            response::ok::<Vec<DebitNoteEvent>>(events.into_iter().map(Into::into).collect())
+        }
+    }
 }
 
 // *************************** INVOICE ****************************

--- a/core/payment/src/dao.rs
+++ b/core/payment/src/dao.rs
@@ -1,11 +1,13 @@
-pub mod allocation;
-pub mod debit_note;
-pub mod debit_note_event;
-pub mod invoice;
-pub mod invoice_event;
-pub mod payment;
+mod allocation;
+mod debit_note;
+mod debit_note_event;
+mod invoice;
+mod invoice_event;
+mod payment;
 
-pub use self::{
-    allocation::AllocationDao, debit_note::DebitNoteDao, debit_note_event::DebitNoteEventDao,
-    invoice::InvoiceDao, payment::PaymentDao,
-};
+pub use self::allocation::AllocationDao;
+pub use self::debit_note::DebitNoteDao;
+pub use self::debit_note_event::DebitNoteEventDao;
+pub use self::invoice::InvoiceDao;
+pub use self::invoice_event::InvoiceEventDao;
+pub use self::payment::PaymentDao;

--- a/core/payment/src/processor.rs
+++ b/core/payment/src/processor.rs
@@ -1,6 +1,4 @@
-use crate::dao::debit_note::DebitNoteDao;
-use crate::dao::invoice::InvoiceDao;
-use crate::dao::payment::PaymentDao;
+use crate::dao::{DebitNoteDao, InvoiceDao, PaymentDao};
 use crate::error::{Error, PaymentError, PaymentResult};
 use crate::models as db_models;
 use crate::utils::get_sign_tx;


### PR DESCRIPTION
Enabled listening for debit note events. Implemented endpoints:
* `GET` `/requestor/debitNoteEvents`
* `GET` `/provider/debitNoteEvents`

Currently, two event types are emitted for debit notes:
* `Accepted`
* `Received`