### PR TITLE
ExeUnit: introduce temp paths in deployment image cache

### DIFF
--- a/exe-unit/src/service/transfer.rs
+++ b/exe-unit/src/service/transfer.rs
@@ -177,9 +177,10 @@ impl Handler<DeployImage> for TransferService {
     fn handle(&mut self, _: DeployImage, ctx: &mut Self::Context) -> Self::Result {
         let source_url = actor_try!(TransferUrl::parse_with_hash(&self.task_package, "file"));
         let cache_name = actor_try!(Cache::name(&source_url));
+        let temp_path = self.cache.to_temp_path(&cache_name);
         let cache_path = self.cache.to_cache_path(&cache_name);
         let final_path = self.cache.to_final_path(&cache_name);
-        let cache_url = actor_try!(TransferUrl::try_from(cache_path.clone()));
+        let temp_url = actor_try!(TransferUrl::try_from(temp_path.clone()));
 
         log::info!(
             "Deploying from {:?} to {:?}",
@@ -188,7 +189,7 @@ impl Handler<DeployImage> for TransferService {
         );
 
         let source = actor_try!(self.source(&source_url));
-        let dest = actor_try!(self.destination(&cache_url));
+        let dest = actor_try!(self.destination(&temp_url));
 
         let address = ctx.address();
         let (handle, reg) = AbortHandle::new_pair();
@@ -196,9 +197,11 @@ impl Handler<DeployImage> for TransferService {
 
         let fut = async move {
             let final_path = final_path.to_path_buf();
+            let temp_path = temp_path.to_path_buf();
             let cache_path = cache_path.to_path_buf();
 
             if cache_path.exists() {
+                log::info!("Deploying cached image: {:?}", cache_path);
                 std::fs::copy(cache_path, &final_path)?;
                 return Ok(final_path);
             }
@@ -209,6 +212,7 @@ impl Handler<DeployImage> for TransferService {
                 .map_err(TransferError::from)??;
             address.send(RemoveAbortHandle(abort)).await?;
 
+            std::fs::rename(temp_path, &cache_path)?;
             std::fs::copy(cache_path, &final_path)?;
 
             log::info!("Deployment from {:?} finished", source_url.url);
@@ -306,18 +310,7 @@ impl Cache {
             None => return Err(TransferError::InvalidUrlError("hash required".to_owned()).into()),
         };
 
-        let path = transfer_url.url.path();
-        let name = match path.rfind("/") {
-            Some(idx) => {
-                if idx + 1 < path.len() - 1 {
-                    &path[idx + 1..]
-                } else {
-                    path
-                }
-            }
-            None => path,
-        };
-
+        let name = transfer_url.file_name();
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -325,6 +318,11 @@ impl Cache {
             .to_string();
 
         Ok(CachePath::new(name.into(), hash.val.clone(), nonce))
+    }
+
+    #[inline(always)]
+    fn to_temp_path(&self, path: &CachePath) -> ProjectedPath {
+        ProjectedPath::local(self.tmp_dir.clone(), path.temp_path_buf())
     }
 
     #[inline(always)]

--- a/exe-unit/src/util/path.rs
+++ b/exe-unit/src/util/path.rs
@@ -85,26 +85,33 @@ impl CachePath {
         CachePath { path, hash, nonce }
     }
 
-    /// Creates the long version of path, including the "random" token.
+    /// Creates the long version of path, including hash and the "random" token.
+    pub fn temp_path_buf(&self) -> PathBuf {
+        self.to_path_buf(true, true)
+    }
+
+    /// Creates the long version of path, including hash and the "random" token.
     pub fn cache_path_buf(&self) -> PathBuf {
-        self.to_path_buf(true)
+        self.to_path_buf(true, false)
     }
 
     /// Creates a shorter version of path, excluding the "random" token.
     pub fn final_path_buf(&self) -> PathBuf {
-        self.to_path_buf(false)
+        self.to_path_buf(false, false)
     }
 
-    fn to_path_buf(&self, with_nonce: bool) -> PathBuf {
+    fn to_path_buf(&self, with_hash: bool, with_nonce: bool) -> PathBuf {
         let stem = self.path.file_stem().unwrap();
         let extension = self.path.extension();
         let hash = hex::encode(&self.hash);
 
         let mut file_name = stem.to_os_string();
 
-        if with_nonce {
+        if with_hash {
             file_name.push("_");
             file_name.push(hash);
+        }
+        if with_nonce {
             file_name.push("_");
             file_name.push(&self.nonce);
         }

--- a/exe-unit/src/util/url.rs
+++ b/exe-unit/src/util/url.rs
@@ -17,6 +17,20 @@ pub struct TransferUrl {
 unsafe impl Send for TransferUrl {}
 
 impl TransferUrl {
+    pub fn file_name(&self) -> &str {
+        let path = self.url.path();
+        match path.rfind("/") {
+            Some(idx) => {
+                if idx + 1 < path.len() - 1 {
+                    &path[idx + 1..]
+                } else {
+                    path
+                }
+            }
+            None => path,
+        }
+    }
+
     pub fn parse(url: &str, fallback_scheme: &str) -> Result<Self, TransferError> {
         let url = url.trim();
         if url.len() == 0 {


### PR DESCRIPTION
Cached image path included a `timestamp` which made the download path unique and in turn the cached file never existed on disk. This PR adds an intermediary(temp) path for download paths