### PR TITLE
[gsb] caller support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5006,6 +5006,7 @@ dependencies = [
  "thiserror",
  "ya-client-model",
  "ya-core-model",
+ "ya-sb-proto",
  "ya-sb-router",
  "ya-service-api",
  "ya-service-api-interfaces",

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -30,8 +30,10 @@ name="test_net_mk1"
 required-features = ["service"]
 
 [dev-dependencies]
+ya-sb-proto = "0.1"
+ya-sb-router = "0.1"
+
 actix-rt = "1.0"
 env_logger = "0.7"
-structopt = "0.3"
 serde = "1.0"
-ya-sb-router = "0.1"
+structopt = "0.3"

--- a/core/net/examples/test_net_mk1.rs
+++ b/core/net/examples/test_net_mk1.rs
@@ -38,6 +38,7 @@ struct Options {
 enum Side {
     Listener,
     Sender,
+    Other,
 }
 
 impl Options {
@@ -45,6 +46,7 @@ impl Options {
         match side {
             Side::Listener => "0xbabe000000000000000000000000000000000000",
             Side::Sender => "0xfeed000000000000000000000000000000000000",
+            Side::Other => "0xbeef000000000000000000000000000000000000",
         }
         .parse()
         .unwrap()
@@ -93,11 +95,12 @@ async fn main() -> Result<()> {
             let listener_id = Options::id(&Side::Listener);
             let r = listener_id
                 .try_service(net::PUBLIC_PREFIX)?
-                .send(Test("Test msg".into()))
+                .send_as(Options::id(&Side::Other), Test("Test msg".into()))
                 .map_err(Error::msg)
                 .await?;
             log::info!("Sending Result: {:?}", r);
         }
+        _ => unimplemented!(),
     }
 
     Ok(())

--- a/core/net/examples/test_net_mk1.rs
+++ b/core/net/examples/test_net_mk1.rs
@@ -6,7 +6,7 @@ use structopt::StructOpt;
 
 use ya_client_model::NodeId;
 use ya_core_model::net;
-use ya_net::TryRemoteEndpoint;
+use ya_net::{RemoteEndpoint, TryRemoteEndpoint};
 use ya_service_bus::{typed as bus, RpcEndpoint, RpcMessage};
 
 #[derive(Serialize, Deserialize)]
@@ -96,10 +96,27 @@ async fn main() -> Result<()> {
                 .unwrap();
             let r = listener_id
                 .try_service(net::PUBLIC_PREFIX)?
-                .send_as(caller_id, Test("Test msg".into()))
+                .send_as(caller_id, Test("Test 1 msg".into()))
                 .map_err(Error::msg)
                 .await?;
-            log::info!("Sending Result: {:?}", r);
+            assert!(r.is_ok());
+            log::info!("Sending 1 Result: {:?}", r);
+            let r = ya_net::from("0xdad0000000000000000000000000000000000000".parse()?)
+                .to(listener_id)
+                .service(net::PUBLIC_PREFIX)
+                .send_as(caller_id, Test("Test 2 msg".into()))
+                .map_err(Error::msg)
+                .await;
+            assert!(r.is_err());
+            log::info!("Sending 2 Result should be err: {:?}", r);
+            let r = ya_net::from(options.my_id())
+                .to(listener_id)
+                .service(net::PUBLIC_PREFIX)
+                .send_as(caller_id, Test("Test 3 msg".into()))
+                .map_err(Error::msg)
+                .await;
+            assert!(r.is_ok());
+            log::info!("Sending 3 Result: {:?}", r);
         }
     }
 

--- a/core/net/examples/test_net_mk1.rs
+++ b/core/net/examples/test_net_mk1.rs
@@ -38,7 +38,6 @@ struct Options {
 enum Side {
     Listener,
     Sender,
-    Other,
 }
 
 impl Options {
@@ -46,7 +45,6 @@ impl Options {
         match side {
             Side::Listener => "0xbabe000000000000000000000000000000000000",
             Side::Sender => "0xfeed000000000000000000000000000000000000",
-            Side::Other => "0xbeef000000000000000000000000000000000000",
         }
         .parse()
         .unwrap()
@@ -93,14 +91,16 @@ async fn main() -> Result<()> {
         }
         Side::Sender => {
             let listener_id = Options::id(&Side::Listener);
+            let caller_id: NodeId = "0xbeef000000000000000000000000000000000000"
+                .parse()
+                .unwrap();
             let r = listener_id
                 .try_service(net::PUBLIC_PREFIX)?
-                .send_as(Options::id(&Side::Other), Test("Test msg".into()))
+                .send_as(caller_id, Test("Test msg".into()))
                 .map_err(Error::msg)
                 .await?;
             log::info!("Sending Result: {:?}", r);
         }
-        _ => unimplemented!(),
     }
 
     Ok(())

--- a/core/net/examples/test_net_mk1.rs
+++ b/core/net/examples/test_net_mk1.rs
@@ -22,7 +22,7 @@ impl RpcMessage for Test {
 #[structopt(name = "Provider", about = "Networked Provider Example")]
 struct Options {
     /// remote bus addr (Mk1 centralised net router)
-    #[structopt(long, default_value = "hub:9000")]
+    #[structopt(long, default_value = "127.0.0.1:9000")]
     hub_addr: String,
 
     /// Log verbosity
@@ -36,6 +36,7 @@ struct Options {
 
 #[derive(StructOpt, Debug)]
 enum Side {
+    Hub,
     Listener,
     Sender,
 }
@@ -45,6 +46,7 @@ impl Options {
         match side {
             Side::Listener => "0xbabe000000000000000000000000000000000000",
             Side::Sender => "0xfeed000000000000000000000000000000000000",
+            _ => unimplemented!(),
         }
         .parse()
         .unwrap()
@@ -64,12 +66,38 @@ async fn main() -> Result<()> {
     );
     env_logger::init();
 
+    match options.side {
+        Side::Hub => {
+            ya_sb_router::bind_gsb_router(Some(format!("tcp://{}", options.hub_addr).parse()?))
+                .await?;
+            actix_rt::signal::ctrl_c().await?;
+            println!();
+            log::info!("SIGINT received, exiting");
+            return Ok(());
+        }
+        Side::Listener => {
+            // will use default GSB_URL
+        }
+        Side::Sender => {
+            // redefine GSB_URL not to make bind conflict
+            std::env::set_var(ya_sb_proto::GSB_URL_ENV_VAR, "tcp://127.0.0.1:7777");
+        }
+    }
+
+    // code below is only for Listener and Sender
+
     ya_sb_router::bind_gsb_router(None)
         .await
         .context(format!("Error binding local router"))?;
 
     std::env::set_var(ya_net::CENTRAL_ADDR_ENV_VAR, &options.hub_addr);
-    ya_net::bind_remote(options.my_id(), vec![options.my_id()])
+    let registered_id: NodeId = "0xdad0000000000000000000000000000000000000".parse()?;
+    let unregistered_id: NodeId = "0xbed0000000000000000000000000000000000000".parse()?;
+    let registered_net_ids = match options.side {
+        Side::Sender => vec![options.my_id(), registered_id],
+        _ => vec![options.my_id()],
+    };
+    ya_net::bind_remote(options.my_id(), registered_net_ids)
         .await
         .context(format!(
             "Error binding service at {} for {}",
@@ -79,6 +107,7 @@ async fn main() -> Result<()> {
     log::info!("Started listening on the centralised Hub");
 
     match options.side {
+        Side::Hub => unimplemented!(),
         Side::Listener => {
             let _ = bus::bind(net::PUBLIC_PREFIX, |p: Test| async move {
                 log::info!("test called!!");
@@ -91,32 +120,48 @@ async fn main() -> Result<()> {
         }
         Side::Sender => {
             let listener_id = Options::id(&Side::Listener);
-            let caller_id: NodeId = "0xbeef000000000000000000000000000000000000"
-                .parse()
-                .unwrap();
+
+            let caller_id: NodeId = "0xbeef000000000000000000000000000000000000".parse()?;
             let r = listener_id
                 .try_service(net::PUBLIC_PREFIX)?
                 .send_as(caller_id, Test("Test 1 msg".into()))
                 .map_err(Error::msg)
                 .await?;
             assert!(r.is_ok());
-            log::info!("Sending 1 Result: {:?}", r);
-            let r = ya_net::from("0xdad0000000000000000000000000000000000000".parse()?)
+            log::info!(
+                "should ignore send_as and allow sending as default identity: {:?}",
+                r
+            );
+
+            let r = ya_net::from(unregistered_id)
                 .to(listener_id)
                 .service(net::PUBLIC_PREFIX)
-                .send_as(caller_id, Test("Test 2 msg".into()))
+                .send(Test("Test 2 msg".into()))
                 .map_err(Error::msg)
                 .await;
             assert!(r.is_err());
-            log::info!("Sending 2 Result should be err: {:?}", r);
-            let r = ya_net::from(options.my_id())
+            log::info!(
+                "should disallow sending as node id not registered with `bind_remote`: {:?}",
+                r
+            );
+
+            let r = ya_net::from(unregistered_id)
                 .to(listener_id)
                 .service(net::PUBLIC_PREFIX)
-                .send_as(caller_id, Test("Test 3 msg".into()))
+                .send_as(registered_id, Test("Test 3 msg".into()))
+                .map_err(Error::msg)
+                .await;
+            assert!(r.is_err());
+            log::info!("should ignore send_as and disallow sending as node id not registered with `bind_remote`: {:?}", r);
+
+            let r = ya_net::from(registered_id)
+                .to(listener_id)
+                .service(net::PUBLIC_PREFIX)
+                .send_as(unregistered_id, Test("Test 4 msg".into()))
                 .map_err(Error::msg)
                 .await;
             assert!(r.is_ok());
-            log::info!("Sending 3 Result: {:?}", r);
+            log::info!("should ignore send_as and allow sending as node id registered with `bind_remote`: {:?}", r);
         }
     }
 

--- a/core/net/src/api.rs
+++ b/core/net/src/api.rs
@@ -46,6 +46,11 @@ pub struct NetDst {
     dst: NodeId,
 }
 
+#[inline]
+pub(crate) fn net_service(service: impl ToString) -> String {
+    format!("{}/{}", net::BUS_ID, service.to_string())
+}
+
 pub fn from(src: NodeId) -> NetSrc {
     NetSrc { src }
 }
@@ -61,7 +66,11 @@ pub trait RemoteEndpoint {
 
 impl RemoteEndpoint for NodeId {
     fn service(&self, bus_addr: &str) -> bus::Endpoint {
-        bus::service(format!("/net/{}/{}", self, extract_exported_part(bus_addr)))
+        bus::service(format!(
+            "{}/{}",
+            net_service(self),
+            extract_exported_part(bus_addr)
+        ))
     }
 }
 

--- a/core/net/src/api.rs
+++ b/core/net/src/api.rs
@@ -1,6 +1,10 @@
+use anyhow::bail;
+
 use ya_client_model::node_id::{NodeId, ParseError};
 use ya_core_model::net;
 use ya_service_bus::typed as bus;
+
+pub(crate) const FROM_BUS_ID: &str = "/from";
 
 #[derive(thiserror::Error, Debug)]
 pub enum NetApiError {
@@ -35,24 +39,24 @@ pub struct NetSrc {
     src: NodeId,
 }
 
+pub struct NetDst {
+    src: NodeId,
+    dst: NodeId,
+}
+
+pub fn from(src: NodeId) -> NetSrc {
+    NetSrc { src }
+}
+
 impl NetSrc {
     pub fn to(&self, dst: NodeId) -> NetDst {
         NetDst { src: self.src, dst }
     }
 }
 
-pub struct NetDst {
-    src: NodeId,
-    dst: NodeId,
-}
-
 #[inline]
 pub(crate) fn net_service(service: impl ToString) -> String {
     format!("{}/{}", net::BUS_ID, service.to_string())
-}
-
-pub fn from(src: NodeId) -> NetSrc {
-    NetSrc { src }
 }
 
 fn extract_exported_part(local_service_addr: &str) -> &str {
@@ -83,6 +87,21 @@ impl RemoteEndpoint for NetDst {
             extract_exported_part(bus_addr)
         ))
     }
+}
+
+pub(crate) fn parse_from_addr(from_addr: &str) -> anyhow::Result<(NodeId, String)> {
+    let mut it = from_addr.split("/").fuse();
+    if let (Some(""), Some("from"), Some(from_node_id), Some("to"), Some(to_node_id)) =
+        (it.next(), it.next(), it.next(), it.next(), it.next())
+    {
+        to_node_id.parse::<NodeId>()?;
+        let prefix = 10 + from_node_id.len();
+        let service_id = &from_addr[prefix..];
+        if let Some(_) = it.next() {
+            return Ok((from_node_id.parse()?, net_service(service_id)));
+        }
+    }
+    bail!("invalid net-from destination: {}", from_addr)
 }
 
 #[cfg(test)]
@@ -125,5 +144,48 @@ mod tests {
             .parse()
             .unwrap();
         assert!(node_id.try_service("/zima/x").is_err());
+    }
+
+    #[test]
+    fn parse_generated_from_to_service_should_pass() {
+        let from_id = "0xe93ab94a2095729ad0b7cfa5bfd7d33e1b44d6df"
+            .parse::<NodeId>()
+            .unwrap();
+        let dst = "0x99402605903da83901151b0871ebeae9296ef66b"
+            .parse::<NodeId>()
+            .unwrap();
+
+        let remote_service = crate::from(from_id).to(dst).service("/public/test/echo");
+        let addr = remote_service.addr();
+        eprintln!("from/to service address: {}", addr);
+        let (parsed_from, parsed_to) = parse_from_addr(addr).unwrap();
+        assert_eq!(parsed_from, from_id);
+        assert_eq!(
+            parsed_to,
+            "/net/0x99402605903da83901151b0871ebeae9296ef66b/test/echo"
+        );
+    }
+
+    #[test]
+    fn parse_no_service_should_fail() {
+        let out = parse_from_addr("/from/0xe93ab94a2095729ad0b7cfa5bfd7d33e1b44d6df/to/0x99402605903da83901151b0871ebeae9296ef66b");
+        assert!(out.is_err())
+    }
+
+    #[test]
+    fn parse_with_service_should_pass() {
+        let out = parse_from_addr("/from/0xe93ab94a2095729ad0b7cfa5bfd7d33e1b44d6df/to/0x99402605903da83901151b0871ebeae9296ef66b/x");
+        assert!(out.is_ok())
+    }
+
+    #[test]
+    fn ok_net_node_id() {
+        let node_id: NodeId = "0xbabe000000000000000000000000000000000000"
+            .parse()
+            .unwrap();
+        assert_eq!(
+            net_service(&node_id),
+            "/net/0xbabe000000000000000000000000000000000000".to_string()
+        );
     }
 }

--- a/core/net/src/service.rs
+++ b/core/net/src/service.rs
@@ -133,8 +133,8 @@ pub async fn bind_remote(default_node_id: NodeId, nodes: Vec<NodeId>) -> std::io
             log::debug!("{} is calling {}", from_node, to_addr);
             if !nodes.contains(&from_node) {
                 return future::err(Error::GsbBadRequest(format!(
-                    "invalid src node: {:?}",
-                    from_node
+                    "caller: {:?} is not on src list: {:?}",
+                    from_node, nodes,
                 )))
                 .left_future();
             }

--- a/service-bus/bus/src/lib.rs
+++ b/service-bus/bus/src/lib.rs
@@ -87,12 +87,12 @@ pub struct RpcRawCall {
     pub body: Vec<u8>,
 }
 
-impl<T: Serialize> From<(RpcEnvelope<T>, String)> for RpcRawCall {
-    fn from((envelope, addr): (RpcEnvelope<T>, String)) -> Self {
+impl RpcRawCall {
+    fn from_envelope_addr<T: Serialize>(envelope: RpcEnvelope<T>, addr: String) -> Self {
         RpcRawCall {
-            body: crate::serialization::to_vec(&envelope.body).unwrap(),
             caller: envelope.caller,
             addr,
+            body: crate::serialization::to_vec(&envelope.body).unwrap(),
         }
     }
 }

--- a/service-bus/bus/src/local_router.rs
+++ b/service-bus/bus/src/local_router.rs
@@ -458,12 +458,12 @@ impl Router {
     pub fn forward_bytes(
         &mut self,
         addr: &str,
-        from: &str,
+        caller: &str,
         msg: Vec<u8>,
     ) -> impl Future<Output = Result<Vec<u8>, Error>> + Unpin {
         if let Some(slot) = self.handlers.get_mut(addr) {
             slot.send(RpcRawCall {
-                caller: from.into(),
+                caller: caller.into(),
                 addr: addr.into(),
                 body: msg,
             })
@@ -471,7 +471,7 @@ impl Router {
         } else {
             RemoteRouter::from_registry()
                 .send(RpcRawCall {
-                    caller: from.into(),
+                    caller: caller.into(),
                     addr: addr.into(),
                     body: msg,
                 })
@@ -486,12 +486,12 @@ impl Router {
     pub fn forward_bytes_local(
         &mut self,
         addr: &str,
-        from: &str,
+        caller: &str,
         msg: &[u8],
     ) -> impl Stream<Item = Result<ResponseChunk, Error>> {
         if let Some(slot) = self.handlers.get_mut(addr) {
             slot.send_streaming(RpcRawCall {
-                caller: from.into(),
+                caller: caller.into(),
                 addr: addr.into(),
                 body: msg.into(),
             })

--- a/service-bus/bus/src/local_router.rs
+++ b/service-bus/bus/src/local_router.rs
@@ -387,7 +387,7 @@ impl Router {
             (if let Some(h) = slot.recipient() {
                 h.send(msg).map_err(Error::from).left_future()
             } else {
-                slot.send(RpcRawCall::from((msg, addr)))
+                slot.send(RpcRawCall::from_envelope_addr(msg, addr))
                     .then(|b| {
                         future::ready(match b {
                             Ok(b) => crate::serialization::from_read(std::io::Cursor::new(&b))
@@ -400,7 +400,7 @@ impl Router {
             .left_future()
         } else {
             RemoteRouter::from_registry()
-                .send(RpcRawCall::from((msg, addr)))
+                .send(RpcRawCall::from_envelope_addr(msg, addr))
                 .then(|v| {
                     future::ready(match v {
                         Ok(v) => v,

--- a/service-bus/bus/src/untyped.rs
+++ b/service-bus/bus/src/untyped.rs
@@ -6,13 +6,13 @@ use futures::Future;
 
 pub fn send(
     addr: &str,
-    from: &str,
+    caller: &str,
     bytes: &[u8],
 ) -> impl Future<Output = Result<Vec<u8>, Error>> + Unpin {
     router()
         .lock()
         .unwrap()
-        .forward_bytes(addr, from, bytes.into())
+        .forward_bytes(addr, caller, bytes.into())
 }
 
 pub trait RawHandler {

--- a/service-bus/proto/protos/gsb_api.proto
+++ b/service-bus/proto/protos/gsb_api.proto
@@ -115,8 +115,9 @@ message UnsubscribeReply {
 }
 
 message BroadcastRequest {
-  string topic = 1;
+  string caller = 1;
   bytes data = 2;
+  string topic = 3;
 }
 
 message BroadcastReply {

--- a/service-bus/router/examples/broadcast.rs
+++ b/service-bus/router/examples/broadcast.rs
@@ -33,6 +33,7 @@ async fn run_client() {
     println!("Sending broadcast request...");
     let broadcast_data = "broadcast";
     let broadcast_request = BroadcastRequest {
+        caller: "some_id".into(),
         topic: topic.to_string(),
         data: broadcast_data.to_string().into_bytes(),
     };

--- a/service-bus/router/src/lib.rs
+++ b/service-bus/router/src/lib.rs
@@ -382,9 +382,10 @@ where
 
     fn broadcast(&mut self, addr: &A, msg: BroadcastRequest) -> anyhow::Result<()> {
         log::debug!(
-            "Received BroadcastRequest from {} topic = {}",
+            "Received BroadcastRequest from {} topic = {} caller = {}",
             addr,
-            &msg.topic
+            &msg.topic,
+            &msg.caller,
         );
         let reply = if is_valid_topic_id(&msg.topic) {
             BroadcastReply {


### PR DESCRIPTION
~This will register all unlocked identities on the central network instance (as opposite to registering only default one).~

~All incoming traffic will be handled out of the box.~
Outgoing traffic is more tricky, as it needs to have GSB caller properly set. 

EDIT: added ability to specify caller on service bus endpoints

EDIT2: after @prekucki has introduced from/to/service net addressing in #262 I've stripped this PR to only address adding caller on for GSB (also for bcasts)