### PR TITLE
Payment API examples update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5042,6 +5042,7 @@ dependencies = [
  "tokio 0.2.20",
  "uint",
  "uuid 0.8.1",
+ "ya-client",
  "ya-client-model",
  "ya-core-model",
  "ya-net",

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -47,6 +47,7 @@ uuid = { version = "0.8", features = ["v4"] }
 structopt = "0.3"
 
 [dev-dependencies]
+ya-client = "0.3"
 ya-net = {version = "0.1", features=["service"]}
 ya-sb-router = "0.1"
 actix-rt = "1.0"

--- a/core/payment/examples/README.md
+++ b/core/payment/examples/README.md
@@ -2,15 +2,14 @@
 
 #### Startup
 
-To start the provider:
+To start the API server (both provider & requestor):
+1. Go to `core/payment`.
+2. Copy `.env-template` from root directory and rename to `.env`.
+3. Run the following command:
 ```shell script
-cargo run --example payment_api -- provider
+cargo run --features=dummy-driver --example payment_api
 ```
-
-To start the requestor:
-```shell script
-GSB_URL="tcp://127.0.0.1:8464" YAGNA_API_URL="http://127.0.0.1:8465" cargo run --example payment_api -- requestor
-```
+To use GNT instead of dummy driver add `-- --driver=gnt` at the end.
 
 #### Debit note flow
 
@@ -38,10 +37,10 @@ To see debit notes issued by the provider:
 `GET` `http://127.0.0.1:7465/payment-api/v1/provider/debitNotes`
 
 To see debit notes received by the requestor:  
-`GET` `http://127.0.0.1:8465/payment-api/v1/requestor/debitNotes`
+`GET` `http://127.0.0.1:7465/payment-api/v1/requestor/debitNotes`
 
 To accept a debit note:
-`POST` `http://127.0.0.1:8465/payment-api/v1/requestor/debitNotes/<debitNoteId>/accept`
+`POST` `http://127.0.0.1:7465/payment-api/v1/requestor/debitNotes/<debitNoteId>/accept`
 
 Payload:
 ```json
@@ -52,10 +51,10 @@ Payload:
 ```
 
 To listen for requestor's debit note events:
-`GET` `http://127.0.0.1:8465/payment-api/v1/requestor/debitNoteEvents?timeout=<seconds>`
+`GET` `http://127.0.0.1:7465/payment-api/v1/requestor/debitNoteEvents?timeout=<seconds>`
 
 To listen for provider's debit note events:
-`GET` `http://127.0.0.1:8465/payment-api/v1/provider/debitNoteEvents?timeout=<seconds>`
+`GET` `http://127.0.0.1:7465/payment-api/v1/provider/debitNoteEvents?timeout=<seconds>`
 
 #### Invoice flow
 
@@ -80,10 +79,10 @@ To see invoices issued by the provider:
 `GET` `http://127.0.0.1:7465/payment-api/v1/provider/invoices`
 
 To see invoices received by the requestor:  
-`GET` `http://127.0.0.1:8465/payment-api/v1/requestor/invoices`
+`GET` `http://127.0.0.1:7465/payment-api/v1/requestor/invoices`
 
 To accept an invoice:
-`POST` `http://127.0.0.1:8465/payment-api/v1/requestor/invoices/<invoiceId>/accept`
+`POST` `http://127.0.0.1:7465/payment-api/v1/requestor/invoices/<invoiceId>/accept`
 
 Payload:
 ```json
@@ -94,15 +93,15 @@ Payload:
 ```
 
 To listen for requestor's invoice events:
-`GET` `http://127.0.0.1:8465/payment-api/v1/requestor/invoiceEvents?timeout=<seconds>`
+`GET` `http://127.0.0.1:7465/payment-api/v1/requestor/invoiceEvents?timeout=<seconds>`
 
 To listen for provider's invoice events:
-`GET` `http://127.0.0.1:8465/payment-api/v1/provider/invoiceEvents?timeout=<seconds>`
+`GET` `http://127.0.0.1:7465/payment-api/v1/provider/invoiceEvents?timeout=<seconds>`
 
 #### Allocations
 
 To create an allocation:  
-`POST` `http://127.0.0.1:8465/payment-api/v1/requestor/allocations`
+`POST` `http://127.0.0.1:7465/payment-api/v1/requestor/allocations`
 
 Payload:
 ```json
@@ -115,15 +114,15 @@ Payload:
 Don't forget to copy `allocationId` from the response!
 
 To see all created allocations:
-`GET` `http://127.0.0.1:8465/payment-api/v1/requestor/allocations`
+`GET` `http://127.0.0.1:7465/payment-api/v1/requestor/allocations`
 
 To release an allocation:
-`DELETE` `http://127.0.0.1:8465/payment-api/v1/requestor/allocations/<allocationId>`
+`DELETE` `http://127.0.0.1:7465/payment-api/v1/requestor/allocations/<allocationId>`
 
 #### Payments
 
 To see requestor's (sent) payments:
-`GET` `http://127.0.0.1:8465/payment-api/v1/requestor/payments`
+`GET` `http://127.0.0.1:7465/payment-api/v1/requestor/payments`
 
 To see provider's (received) payments:
 `GET` `http://127.0.0.1:7465/payment-api/v1/provider/payments`

--- a/core/payment/examples/invoice_flow.rs
+++ b/core/payment/examples/invoice_flow.rs
@@ -1,0 +1,52 @@
+use bigdecimal::BigDecimal;
+use chrono::Utc;
+use ya_client::payment::{PaymentProviderApi, PaymentRequestorApi};
+use ya_client::web::{WebClient, WebInterface};
+use ya_client_model::payment::{Acceptance, DocumentStatus, NewAllocation, NewInvoice};
+
+#[actix_rt::main]
+async fn main() -> anyhow::Result<()> {
+    let provider = PaymentProviderApi::from_client(
+        WebClient::builder()
+            .host_port("127.0.0.1:7465/payment-api/v1/")
+            .build()?,
+    );
+    let requestor = PaymentRequestorApi::from_client(
+        WebClient::builder()
+            .host_port("127.0.0.1:7465/payment-api/v1/")
+            .build()?,
+    );
+    let invoice = provider
+        .issue_invoice(&NewInvoice {
+            agreement_id: "agreement_id".to_string(),
+            activity_ids: None,
+            amount: BigDecimal::from(1u64),
+            payment_due_date: Utc::now(),
+        })
+        .await?;
+    provider.send_invoice(&invoice.invoice_id).await?;
+
+    let allocation = requestor
+        .create_allocation(&NewAllocation {
+            total_amount: BigDecimal::from(10u64),
+            timeout: None,
+            make_deposit: false,
+        })
+        .await?;
+    requestor
+        .accept_invoice(
+            &invoice.invoice_id,
+            &Acceptance {
+                total_amount_accepted: invoice.amount,
+                allocation_id: allocation.allocation_id,
+            },
+        )
+        .await?;
+
+    // TODO: Listen for payment instead of sleeping
+    tokio::time::delay_for(std::time::Duration::from_secs(1)).await;
+    let invoice = provider.get_invoice(&invoice.invoice_id).await?;
+    assert_eq!(invoice.status, DocumentStatus::Settled);
+
+    Ok(())
+}


### PR DESCRIPTION
Adjusted the payment API example to serve both provider and requestor API on a single node (one process, one database).

Added a new example to test a simple invoice flow.