### PR TITLE
Payment events timeout parameter added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4806,7 +4806,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=baf7d33ad728b485dba555f65f517c433ffa435a#baf7d33ad728b485dba555f65f517c433ffa435a"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=019969221449dd16694d07e574b9588cd6d3f19c#019969221449dd16694d07e574b9588cd6d3f19c"
 dependencies = [
  "awc",
  "backtrace",
@@ -4826,7 +4826,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=baf7d33ad728b485dba555f65f517c433ffa435a#baf7d33ad728b485dba555f65f517c433ffa435a"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=019969221449dd16694d07e574b9588cd6d3f19c#019969221449dd16694d07e574b9588cd6d3f19c"
 dependencies = [
  "bigdecimal 0.1.2",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,6 +1330,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "envy"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f938a4abd5b75fe3737902dbc2e79ca142cc1526827a9e40b829a086758531a9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "errno"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4806,12 +4815,13 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=019969221449dd16694d07e574b9588cd6d3f19c#019969221449dd16694d07e574b9588cd6d3f19c"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=2b74beab942223d01272c411cc565106fa53d13a#2b74beab942223d01272c411cc565106fa53d13a"
 dependencies = [
  "awc",
  "backtrace",
  "bytes 0.5.4",
  "chrono",
+ "envy",
  "failure",
  "futures 0.3.4",
  "log 0.4.8",
@@ -4826,7 +4836,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=019969221449dd16694d07e574b9588cd6d3f19c#019969221449dd16694d07e574b9588cd6d3f19c"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=2b74beab942223d01272c411cc565106fa53d13a#2b74beab942223d01272c411cc565106fa53d13a"
 dependencies = [
  "bigdecimal 0.1.2",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "019969221449dd16694d07e574b9588cd6d3f19c"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "019969221449dd16694d07e574b9588cd6d3f19c"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "2b74beab942223d01272c411cc565106fa53d13a" }
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "2b74beab942223d01272c411cc565106fa53d13a" }
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "baf7d33ad728b485dba555f65f517c433ffa435a"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "baf7d33ad728b485dba555f65f517c433ffa435a"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "019969221449dd16694d07e574b9588cd6d3f19c"}
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "019969221449dd16694d07e574b9588cd6d3f19c"}
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/agent/provider/src/payments/payments.rs
+++ b/agent/provider/src/payments/payments.rs
@@ -633,7 +633,12 @@ impl Handler<CheckInvoicePayments> for Payments {
         let self_addr = ctx.address();
 
         let future = async move {
-            let payments = match pay_ctx.payment_api.get_payments(Some(&msg.since)).await {
+            let timeout = Some(Duration::from_secs(60));
+            let payments = match pay_ctx
+                .payment_api
+                .get_payments(Some(&msg.since), timeout)
+                .await
+            {
                 Ok(payments) => payments,
                 Err(error) => {
                     log::error!("Can't query payments. Error: {}", error);

--- a/agent/requestor/src/payment.rs
+++ b/agent/requestor/src/payment.rs
@@ -38,9 +38,13 @@ pub(crate) async fn log_and_ignore_debit_notes(
 ) {
     // FIXME: should be persisted and restored upon next ya-requestor start
     let mut events_after = started_at.clone();
+    let timeout = Some(Duration::from_secs(60));
 
     loop {
-        match payment_api.get_debit_note_events(Some(&events_after)).await {
+        match payment_api
+            .get_debit_note_events(Some(&events_after), timeout)
+            .await
+        {
             Err(e) => {
                 log::error!("getting debit notes events error: {}", e);
                 tokio::time::delay_for(Duration::from_secs(5)).await;
@@ -63,9 +67,13 @@ pub(crate) async fn process_payments(
     log::info!("\n\n INVOICES processing start");
     // FIXME: should be persisted and restored upon next ya-requestor start
     let mut events_after = started_at;
+    let timeout = Some(Duration::from_secs(60));
 
     loop {
-        let events = match payment_api.get_invoice_events(Some(&events_after)).await {
+        let events = match payment_api
+            .get_invoice_events(Some(&events_after), timeout)
+            .await
+        {
             Err(e) => {
                 log::error!("getting invoice events error: {}", e);
                 tokio::time::delay_for(Duration::from_secs(5)).await;

--- a/core/payment/src/api.rs
+++ b/core/payment/src/api.rs
@@ -23,16 +23,16 @@ pub fn web_scope(db: &DbExecutor) -> Scope {
         .service(requestor_scope())
 }
 
-pub const DEFAULT_ACK_TIMEOUT: u32 = 60; // seconds
-pub const DEFAULT_EVENT_TIMEOUT: u32 = 0; // seconds
+pub const DEFAULT_ACK_TIMEOUT: f64 = 60.0; // seconds
+pub const DEFAULT_EVENT_TIMEOUT: f64 = 0.0; // seconds
 
 #[inline(always)]
-pub(crate) fn default_ack_timeout() -> u32 {
+pub(crate) fn default_ack_timeout() -> f64 {
     DEFAULT_ACK_TIMEOUT
 }
 
 #[inline(always)]
-pub(crate) fn default_event_timeout() -> u32 {
+pub(crate) fn default_event_timeout() -> f64 {
     DEFAULT_EVENT_TIMEOUT
 }
 
@@ -59,13 +59,13 @@ pub struct PaymentId {
 #[derive(Deserialize)]
 pub struct Timeout {
     #[serde(default = "default_ack_timeout")]
-    pub timeout: u32,
+    pub timeout: f64,
 }
 
 #[derive(Deserialize)]
 pub struct EventParams {
     #[serde(default = "default_event_timeout")]
-    pub timeout: u32,
+    pub timeout: f64,
     #[serde(rename = "laterThan")]
     pub later_than: Option<DateTime<Utc>>,
 }


### PR DESCRIPTION
Adjusted provider and requestor agent to incorporate the change in payment API client which introduced timeout parameter for event-listening methods. Timeout was set to 1 minute -- long enough to avoid 'get events' messages constantly popping out in logs.