### PR TITLE
[market-fwd] central market testbed url configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=f1d8ef0#f1d8ef0e6ef9052ea5e3e21b7fe46da1308761d3"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=493461d#493461d5e64d0eea28e333c2888f4af68c1c38b0"
 dependencies = [
  "awc",
  "backtrace",
@@ -4837,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=f1d8ef0#f1d8ef0e6ef9052ea5e3e21b7fe46da1308761d3"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=493461d#493461d5e64d0eea28e333c2888f4af68c1c38b0"
 dependencies = [
  "bigdecimal 0.1.2",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=159a3cb#159a3cbf6af4cbe62ea9bd895f0d1f1985b763e0"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=f1d8ef0#f1d8ef0e6ef9052ea5e3e21b7fe46da1308761d3"
 dependencies = [
  "awc",
  "backtrace",
@@ -4837,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=159a3cb#159a3cbf6af4cbe62ea9bd895f0d1f1985b763e0"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=f1d8ef0#f1d8ef0e6ef9052ea5e3e21b7fe46da1308761d3"
 dependencies = [
  "bigdecimal 0.1.2",
  "chrono",
@@ -5302,7 +5302,7 @@ dependencies = [
  "serde",
  "structopt",
  "url 2.1.1",
- "ya-client-model",
+ "ya-client",
  "ya-core-model",
  "ya-identity",
  "ya-persistence",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "f1d8ef0"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "f1d8ef0"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "493461d"}
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "493461d"}
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "159a3cb"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "159a3cb"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "f1d8ef0"}
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "f1d8ef0"}
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/agent/provider/examples/mock_requestor.rs
+++ b/agent/provider/examples/mock_requestor.rs
@@ -83,5 +83,5 @@ async fn simulate_requestor(client: MarketRequestorApi) -> Result<()> {
 
 #[actix_rt::main]
 async fn main() -> Result<()> {
-    simulate_requestor(WebClient::builder().build()?.interface()?).await
+    simulate_requestor(WebClient::builder().build().interface()?).await
 }

--- a/core/market/forwarding/src/api.rs
+++ b/core/market/forwarding/src/api.rs
@@ -8,8 +8,16 @@ use ya_client::model::NodeId;
 use ya_persistence::executor::DbExecutor;
 use ya_service_api_web::middleware::Identity;
 
+pub const CENTRAL_MARKET_URL_ENV_VAR: &str = "YAGNA_API_URL";
+pub const DEFAULT_CENTRAL_MARKET_URL: &str = "http://34.244.4.185:8080/market-api/v1/";
+
 lazy_static::lazy_static! {
-    pub(crate) static ref CENTRAL_MARKET_URL: Url = "http://34.244.4.185:8080/market-api/v1/".parse().unwrap();
+    pub(crate) static ref CENTRAL_MARKET_URL: Url =
+        std::env::var(CENTRAL_MARKET_URL_ENV_VAR)
+            .unwrap_or(DEFAULT_CENTRAL_MARKET_URL.into())
+            .parse()
+            .unwrap();
+
     static ref FORWARD_CLIENT_TIMEOUT: Duration = Duration::from_secs(60);
 }
 

--- a/core/market/forwarding/src/api.rs
+++ b/core/market/forwarding/src/api.rs
@@ -8,7 +8,7 @@ use ya_client::model::NodeId;
 use ya_persistence::executor::DbExecutor;
 use ya_service_api_web::middleware::Identity;
 
-pub const CENTRAL_MARKET_URL_ENV_VAR: &str = "YAGNA_API_URL";
+pub const CENTRAL_MARKET_URL_ENV_VAR: &str = "CENTRAL_MARKET_URL";
 pub const DEFAULT_CENTRAL_MARKET_URL: &str = "http://34.244.4.185:8080/market-api/v1/";
 
 lazy_static::lazy_static! {

--- a/core/market/forwarding/src/service.rs
+++ b/core/market/forwarding/src/service.rs
@@ -20,9 +20,7 @@ impl MarketService {
     pub async fn gsb<Context: Provider<Self, DbExecutor>>(ctx: &Context) -> anyhow::Result<()> {
         let db = ctx.component();
         crate::dao::init(&db)?;
-        let client = WebClient::builder()
-            .timeout(Duration::from_secs(5))
-            .build()?;
+        let client = WebClient::builder().timeout(Duration::from_secs(5)).build();
 
         let _ = bus::bind(market::BUS_ID, move |get: market::GetAgreement| {
             let market_api: MarketProviderApi = client

--- a/core/payment/examples/invoice_flow.rs
+++ b/core/payment/examples/invoice_flow.rs
@@ -2,21 +2,14 @@ use bigdecimal::BigDecimal;
 use chrono::Utc;
 use std::time::Duration;
 use ya_client::payment::{PaymentProviderApi, PaymentRequestorApi};
-use ya_client::web::{WebClient, WebInterface};
+use ya_client::web::WebClient;
 use ya_client_model::payment::{Acceptance, DocumentStatus, NewAllocation, NewInvoice};
 
 #[actix_rt::main]
 async fn main() -> anyhow::Result<()> {
-    let provider = PaymentProviderApi::from_client(
-        WebClient::builder()
-            .host_port("127.0.0.1:7465/payment-api/v1/")
-            .build()?,
-    );
-    let requestor = PaymentRequestorApi::from_client(
-        WebClient::builder()
-            .host_port("127.0.0.1:7465/payment-api/v1/")
-            .build()?,
-    );
+    let client = WebClient::builder().build();
+    let provider: PaymentProviderApi = client.interface()?;
+    let requestor: PaymentRequestorApi = client.interface()?;
     let invoice = provider
         .issue_invoice(&NewInvoice {
             agreement_id: "agreement_id".to_string(),

--- a/core/serv-api/src/lib.rs
+++ b/core/serv-api/src/lib.rs
@@ -6,17 +6,13 @@ use std::path::PathBuf;
 #[derive(Debug, Default)]
 pub struct CliCtx {
     pub data_dir: PathBuf,
-    pub http_address: (String, u16),
+    pub api_host_port: String,
     pub gsb_url: Option<url::Url>,
     pub json_output: bool,
     pub interactive: bool,
 }
 
 impl CliCtx {
-    pub fn http_address(&self) -> (&str, u16) {
-        (&self.http_address.0, self.http_address.1)
-    }
-
     pub fn output(&self, output: CommandOutput) {
         output.print(self.json_output)
     }

--- a/core/serv-api/src/lib.rs
+++ b/core/serv-api/src/lib.rs
@@ -6,7 +6,6 @@ use std::path::PathBuf;
 #[derive(Debug, Default)]
 pub struct CliCtx {
     pub data_dir: PathBuf,
-    pub api_host_port: String,
     pub gsb_url: Option<url::Url>,
     pub json_output: bool,
     pub interactive: bool,

--- a/core/serv-api/web/Cargo.toml
+++ b/core/serv-api/web/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-ya-client-model = "0.1"
+ya-client = "0.3"
 ya-core-model = { version = "0.1", features = ["appkey"] }
 ya-service-api = "0.1"
 ya-service-api-cache = "0.1"

--- a/core/serv-api/web/examples/auth_middleware.rs
+++ b/core/serv-api/web/examples/auth_middleware.rs
@@ -91,7 +91,7 @@ async fn main() -> anyhow::Result<()> {
                 }
                 ClientCommand::Request { key } => {
                     let mut resp = Client::default()
-                        .get(format!("{}", rest_api_url()))
+                        .get(rest_api_url().into_string())
                         .header(header::AUTHORIZATION, key)
                         .send()
                         .map_err(map_err)

--- a/core/serv-api/web/examples/auth_middleware.rs
+++ b/core/serv-api/web/examples/auth_middleware.rs
@@ -91,7 +91,7 @@ async fn main() -> anyhow::Result<()> {
                 }
                 ClientCommand::Request { key } => {
                     let mut resp = Client::default()
-                        .get(rest_api_url())
+                        .get(format!("{}", rest_api_url()))
                         .header(header::AUTHORIZATION, key)
                         .send()
                         .map_err(map_err)

--- a/core/serv-api/web/src/lib.rs
+++ b/core/serv-api/web/src/lib.rs
@@ -1,28 +1,20 @@
-use std::net::SocketAddr;
-use url::Url;
-
 pub mod middleware;
 pub mod scope;
 
-pub const YAGNA_API_URL_ENV_VAR: &str = "YAGNA_API_URL";
-pub const DEFAULT_YAGNA_API_URL: &str = "http://127.0.0.1:7465";
+pub use ya_client::web::{rest_api_url, DEFAULT_YAGNA_API_URL, YAGNA_API_URL_ENV_VAR};
 
-pub fn rest_api_addr() -> SocketAddr {
-    let api_url = Url::parse(&rest_api_url()).expect("provide API URL in format http://<ip:port>");
-
-    let ip_addr = api_url
-        .host_str()
-        .expect("need IP address for API URL")
-        .parse()
-        .expect("only IP address supported for API URL");
-
-    let port = api_url
-        .port()
-        .unwrap_or_else(|| Url::parse(DEFAULT_YAGNA_API_URL).unwrap().port().unwrap());
-
-    SocketAddr::new(ip_addr, port)
+pub fn rest_api_addr() -> String {
+    rest_api_host_port(rest_api_url())
 }
 
-pub fn rest_api_url() -> String {
-    std::env::var(YAGNA_API_URL_ENV_VAR).unwrap_or(DEFAULT_YAGNA_API_URL.into())
+pub fn rest_api_host_port(api_url: url::Url) -> String {
+    let host = api_url
+        .host()
+        .expect(&format!("invalid API URL - no host: {}", api_url))
+        .to_string();
+    let port = api_url
+        .port_or_known_default()
+        .expect(&format!("invalid API URL - no port: {}", api_url));
+
+    format!("{}:{}", host, port)
 }

--- a/core/serv-api/web/src/middleware/auth/ident.rs
+++ b/core/serv-api/web/src/middleware/auth/ident.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use std::cell::Ref;
 use std::convert::TryFrom;
 use std::pin::Pin;
-use ya_client_model::NodeId;
+use ya_client::model::NodeId;
 use ya_core_model::appkey::AppKey;
 
 #[derive(Clone, Debug, Serialize)]


### PR DESCRIPTION
To enable fully isolated integration tests we need configurable URL of central Market instance.

I'm also fixing and simplifying current default API URL by moving it definition to ya-client
related PR https://github.com/golemfactory/ya-client/pull/17