### PR TITLE
ExeUnit Supervisor: script termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,14 +12,14 @@ dependencies = [
  "bitflags 1.2.1",
  "bytes 0.5.4",
  "crossbeam-channel",
- "derive_more 0.99.5",
- "futures 0.3.4",
+ "derive_more 0.99.7",
+ "futures 0.3.5",
  "lazy_static",
  "log 0.4.8",
  "parking_lot 0.10.2",
  "pin-project",
  "smallvec 1.4.0",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-util 0.2.0",
  "trust-dns-proto",
  "trust-dns-resolver",
@@ -36,7 +36,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log 0.4.8",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-util 0.2.0",
 ]
 
@@ -50,9 +50,9 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "derive_more 0.99.5",
+ "derive_more 0.99.7",
  "either",
- "futures 0.3.4",
+ "futures 0.3.5",
  "http 0.2.1",
  "log 0.4.8",
  "trust-dns-proto",
@@ -61,17 +61,18 @@ dependencies = [
 
 [[package]]
 name = "actix-files"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301482841d3d74483a446ead63cb7d362e187d2c8b603f13d91995621ea53c46"
+checksum = "193b22cb1f7b4ff12a4eb2415d6d19e47e44ea93e05930b30d05375ea29d3529"
 dependencies = [
  "actix-http",
  "actix-service",
  "actix-web",
  "bitflags 1.2.1",
  "bytes 0.5.4",
- "derive_more 0.99.5",
- "futures 0.3.4",
+ "derive_more 0.99.7",
+ "futures-core",
+ "futures-util",
  "log 0.4.8",
  "mime 0.3.16",
  "mime_guess",
@@ -97,7 +98,7 @@ dependencies = [
  "bytes 0.5.4",
  "chrono",
  "copyless",
- "derive_more 0.99.5",
+ "derive_more 0.99.7",
  "either",
  "encoding_rs",
  "failure",
@@ -128,12 +129,12 @@ dependencies = [
 
 [[package]]
 name = "actix-macros"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21705adc76bbe4bc98434890e73a89cd00c6015e5704a60bb6eea6c3b72316b6"
+checksum = "a60f9ba7c4e6df97f3aacb14bb5c0cd7d98a49dcbaed0d7f292912ad9a6a3ed2"
 dependencies = [
- "quote 1.0.4",
- "syn 1.0.19",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -161,26 +162,27 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "smallvec 1.4.0",
- "tokio 0.2.20",
+ "tokio 0.2.21",
 ]
 
 [[package]]
 name = "actix-server"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "582a7173c281a4f46b5aa168a11e7f37183dcb71177a39312cc2264da7a632c9"
+checksum = "e6d74b464215a473c973a2d7d03a69cc10f4ce1f4b38a7659c5193dc5c675630"
 dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-utils",
- "futures 0.3.4",
+ "futures-channel",
+ "futures-util",
  "log 0.4.8",
  "mio",
  "mio-uds",
- "net2",
  "num_cpus",
  "slab 0.4.2",
+ "socket2",
 ]
 
 [[package]]
@@ -195,26 +197,25 @@ dependencies = [
 
 [[package]]
 name = "actix-testing"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48494745b72d0ea8ff0cf874aaf9b622a3ee03d7081ee0c04edea4f26d32c911"
+checksum = "47239ca38799ab74ee6a8a94d1ce857014b2ac36f242f70f3f75a66f691e791c"
 dependencies = [
  "actix-macros",
  "actix-rt",
  "actix-server",
  "actix-service",
- "futures 0.3.4",
  "log 0.4.8",
- "net2",
+ "socket2",
 ]
 
 [[package]]
 name = "actix-threadpool"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4082192601de5f303013709ff84d81ca6a1bc4af7fb24f367a500a23c6e84e"
+checksum = "91164716d956745c79dcea5e66d2aa04506549958accefcede5368c70f2fd4ff"
 dependencies = [
- "derive_more 0.99.5",
+ "derive_more 0.99.7",
  "futures-channel",
  "lazy_static",
  "log 0.4.8",
@@ -233,9 +234,9 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "derive_more 0.99.5",
+ "derive_more 0.99.7",
  "either",
- "futures 0.3.4",
+ "futures 0.3.5",
  "log 0.4.8",
 ]
 
@@ -251,7 +252,7 @@ dependencies = [
  "bitflags 1.2.1",
  "bytes 0.5.4",
  "either",
- "futures 0.3.4",
+ "futures 0.3.5",
  "log 0.4.8",
  "pin-project",
  "slab 0.4.2",
@@ -277,9 +278,9 @@ dependencies = [
  "actix-web-codegen",
  "awc",
  "bytes 0.5.4",
- "derive_more 0.99.5",
+ "derive_more 0.99.7",
  "encoding_rs",
- "futures 0.3.4",
+ "futures 0.3.5",
  "fxhash",
  "log 0.4.8",
  "mime 0.3.16",
@@ -295,13 +296,13 @@ dependencies = [
 
 [[package]]
 name = "actix-web-codegen"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f00371942083469785f7e28c540164af1913ee7c96a4534acb9cea92c39f057"
+checksum = "a71bf475cbe07281d0b3696abb48212db118e7e23219f13596ce865235ff5766"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -314,7 +315,7 @@ dependencies = [
  "actix-web",
  "base64 0.11.0",
  "bytes 0.5.4",
- "futures 0.3.4",
+ "futures 0.3.5",
 ]
 
 [[package]]
@@ -335,9 +336,18 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b95aceadaf327f18f0df5962fedc1bde2f870566a0b9f65c89508a3b1f79334c"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a49806b9dadc843c61e7c97e72490ad7f7220ae249012fbda9ad0609457c0543"
+dependencies = [
+ "gimli",
 ]
 
 [[package]]
@@ -411,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.28"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 
 [[package]]
 name = "appdirs"
@@ -475,20 +485,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da71fef07bc806586090247e971229289f64c210a278ee5ae419314eb386b31d"
+checksum = "26c4f3195085c36ea8d24d32b2f828d23296a9370a28aa39d111f6f16bef9f3b"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -526,7 +536,7 @@ dependencies = [
  "actix-service",
  "base64 0.11.0",
  "bytes 0.5.4",
- "derive_more 0.99.5",
+ "derive_more 0.99.7",
  "futures-core",
  "log 0.4.8",
  "mime 0.3.16",
@@ -539,24 +549,15 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.46"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
+checksum = "0df2f85c8a2abbe3b7d7e748052fdd9b76a0458fdeb16ad4223f5eca78c7c130"
 dependencies = [
- "backtrace-sys",
+ "addr2line",
  "cfg-if",
  "libc",
+ "object",
  "rustc-demangle",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -708,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2889e6d50f394968c8bf4240dc3f2a7eb4680844d27308f798229ac9d4725f41"
+checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -794,9 +795,9 @@ checksum = "5b89647f09b9f4c838cb622799b2843e4e13bff64661dab9a0362bb92985addd"
 
 [[package]]
 name = "clap"
-version = "2.33.0"
+version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
+checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
  "ansi_term",
  "atty",
@@ -863,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "copyless"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff9c56c9fb2a49c05ef0e431485a22400af20d33226dc0764d891d09e724127"
+checksum = "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536"
 
 [[package]]
 name = "core-foundation"
@@ -930,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
+checksum = "ab6bffe714b6bb07e42f201352c34f51fefd355ace793f9e638ebd52d23f98d2"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1025,10 +1026,10 @@ checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
  "strsim 0.9.3",
- "syn 1.0.19",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -1038,8 +1039,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
- "quote 1.0.4",
- "syn 1.0.19",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -1058,13 +1059,13 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.5"
+version = "0.99.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
+checksum = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -1098,9 +1099,9 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -1271,9 +1272,9 @@ checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.22"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
+checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
 dependencies = [
  "cfg-if",
 ]
@@ -1285,9 +1286,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc4bfcfacb61d231109d1d55202c1f33263319668b168843e02ad4652725ec9c"
 dependencies = [
  "heck",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -1355,7 +1356,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
 dependencies = [
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -1461,9 +1462,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
  "synstructure 0.12.3",
 ]
 
@@ -1520,9 +1521,9 @@ dependencies = [
 
 [[package]]
 name = "fnv"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
@@ -1569,9 +1570,9 @@ checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1584,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1594,9 +1595,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
 name = "futures-cpupool"
@@ -1610,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "futures-executor"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1621,39 +1622,42 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
 
 [[package]]
 name = "futures-task"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
  "futures 0.1.29",
  "futures-channel",
@@ -1663,6 +1667,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
+ "pin-project",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1716,7 +1721,7 @@ dependencies = [
  "digest 0.8.1",
  "dotenv 0.15.0",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "log 0.4.8",
  "rand 0.7.3",
  "sha3",
@@ -1730,6 +1735,12 @@ dependencies = [
  "ya-service-api-interfaces",
  "ya-service-bus",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "glob"
@@ -1770,7 +1781,7 @@ dependencies = [
  "indexmap",
  "log 0.4.8",
  "slab 0.4.2",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-util 0.3.1",
 ]
 
@@ -1794,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61565ff7aaace3525556587bd2dc31d4a07071957be715e63ce7b1eccf51a8f4"
+checksum = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 dependencies = [
  "libc",
 ]
@@ -2012,9 +2023,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076f042c5b7b98f31d205f1249267e12a6518c1481e9dae9764af19b707d2292"
+checksum = "c398b2b113b55809ceb9ee3e753fcbac793f1956663f3c36549c1346015c2afe"
 dependencies = [
  "autocfg 1.0.0",
 ]
@@ -2113,27 +2124,33 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.69"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
+checksum = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 
 [[package]]
 name = "libflate"
-version = "0.1.27"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9135df43b1f5d0e333385cb6e7897ecd1a43d7d11b91ac003f4d2c2d2401fdd"
+checksum = "784f4ec5908a9d7f4e53658906386667e8b02e9389a47cfebf45d324ba9e8d25"
 dependencies = [
  "adler32",
  "crc32fast",
+ "libflate_lz77",
  "rle-decode-fast",
- "take_mut",
 ]
 
 [[package]]
-name = "libproc"
-version = "0.7.1"
+name = "libflate_lz77"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b220bc8e4907c8b851ca767e0f9d10c75d1391a5bf0a5603fc9f94eae36598a"
+checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
+
+[[package]]
+name = "libproc"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba412294cf67e64a10b5d9f72844f109894de3fe288cd519eb429514c9ec63ad"
 dependencies = [
  "errno",
  "libc",
@@ -2199,9 +2216,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06da09a8b91f6c576b9575b326beae59be1df52967f2d4e5e8af67f2c458e737"
 dependencies = [
  "darling",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -2262,9 +2279,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c"
 dependencies = [
  "migrations_internals",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -2328,7 +2345,7 @@ checksum = "f5e374eff525ce1c5b7687c4cef63943e7686524a387933ad27ca7ec43779cb3"
 dependencies = [
  "log 0.4.8",
  "mio",
- "miow 0.3.3",
+ "miow 0.3.4",
  "winapi 0.3.8",
 ]
 
@@ -2357,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "396aa0f2003d7df8395cb93e09871561ccc3e785f0acb369170e8cc74ddf9226"
+checksum = "22dfdd1d51b2639a5abd17ed07005c3af05fb7a2a3b1a1d0d7af1000a520c1c7"
 dependencies = [
  "socket2",
  "winapi 0.3.8",
@@ -2480,6 +2497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cbca9424c482ee628fa549d9c812e2cd22f1180b9222c9200fdfa6eb31aecb2"
+
+[[package]]
 name = "ole32-sys"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,6 +2511,12 @@ dependencies = [
  "winapi 0.2.8",
  "winapi-build",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
 
 [[package]]
 name = "opaque-debug"
@@ -2526,9 +2555,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.56"
+version = "0.9.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02309a7f127000ed50594f0b50ecc69e7c654e16d41b4e8156d1b3df8e0b52e"
+checksum = "7410fef80af8ac071d4f63755c0ab89ac3df0fd1ea91f1d1f37cf5cec4395990"
 dependencies = [
  "autocfg 1.0.0",
  "cc",
@@ -2562,7 +2591,7 @@ dependencies = [
  "ring",
  "ripemd160",
  "scrypt 0.1.2",
- "sha2 0.8.1",
+ "sha2 0.8.2",
  "tiny-keccak",
 ]
 
@@ -2582,8 +2611,8 @@ dependencies = [
  "ripemd160",
  "rustc-hex",
  "scrypt 0.2.0",
- "sha2 0.8.1",
- "subtle 2.2.2",
+ "sha2 0.8.2",
+ "subtle 2.2.3",
  "tiny-keccak",
  "zeroize 0.9.3",
 ]
@@ -2693,7 +2722,7 @@ dependencies = [
  "crypto-mac 0.7.0",
  "hmac 0.7.1",
  "rand 0.5.6",
- "sha2 0.8.1",
+ "sha2 0.8.2",
  "subtle 1.0.0",
 ]
 
@@ -2720,29 +2749,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.13"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c3bfbfb5bb42f99498c7234bbd768c220eb0cea6818259d0d18a1aa3d2595d"
+checksum = "edc93aeee735e60ecb40cf740eb319ff23eab1c5748abfdb5c180e4ce49f7791"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.13"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccbf6449dcfb18562c015526b085b8df1aa3cdab180af8ec2ebd300a3bd28f63"
+checksum = "e58db2081ba5b4c93bd6be09c40fd36cb9193a8336c384f3b40012e531aa7e40"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7505eeebd78492e0f6108f7171c4948dbb120ee8119d9d77d0afa5469bef67f"
+checksum = "9df32da11d84f3a7d70205549562966279adb900e080fad3dccd8e64afccf0ad"
 
 [[package]]
 name = "pin-utils"
@@ -2758,9 +2787,9 @@ checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "pretty_env_logger"
@@ -2807,10 +2836,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
- "version_check 0.9.1",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -2819,18 +2848,18 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
  "syn-mid",
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro-nested"
@@ -2849,18 +2878,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8872cf6f48eee44265156c111456a700ab3483686b3f96df4cf5481c89157319"
+checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid 0.2.0",
 ]
 
 [[package]]
 name = "procfs"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe50036aa1b71e553a4a0c48ab7baabf8aa8c7a5a61aae06bf38c2eab7430475"
+checksum = "c434e93ef69c216e68e4f417c927b4f31502c3560b72cfdb6827e2321c5c6b3e"
 dependencies = [
  "bitflags 1.2.1",
  "byteorder",
@@ -2964,11 +2993,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1f4b0efa5fc5e8ceb705136bfee52cfdb6a4e3509f770b478cd6ed434232a7"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
- "proc-macro2 1.0.12",
+ "proc-macro2 1.0.18",
 ]
 
 [[package]]
@@ -3193,9 +3222,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.7"
+version = "1.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
+checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3214,9 +3243,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.17"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe5bd57d1d7414c6b5ed48563a2c855d995ff777729dcd91c369ec7fea395ae"
+checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
 
 [[package]]
 name = "remove_dir_all"
@@ -3372,9 +3401,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
 
 [[package]]
 name = "safemem"
@@ -3384,9 +3413,9 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "schannel"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
  "winapi 0.3.8",
@@ -3436,7 +3465,7 @@ dependencies = [
  "byteorder",
  "hmac 0.7.1",
  "pbkdf2 0.3.0",
- "sha2 0.8.1",
+ "sha2 0.8.2",
 ]
 
 [[package]]
@@ -3461,9 +3490,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f331b9025654145cd425b9ded0caf8f5ae0df80d418b326e2dc1c3dc5eb0620"
+checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
  "bitflags 1.2.1",
  "core-foundation",
@@ -3500,9 +3529,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.106"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df6ac6412072f67cf767ebbde4133a5b2e88e76dc6187fa7104cd16f783399"
+checksum = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
 dependencies = [
  "serde_derive",
 ]
@@ -3518,20 +3547,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.106"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e549e3abf4fb8621bd1609f11dfc9f5e50320802273b12f3811a67e6716ea6c"
+checksum = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.52"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
+checksum = "993948e75b189211a9b31a7528f950c6adc21f9720b6438ff80a7fa2f864cea2"
 dependencies = [
  "itoa",
  "ryu",
@@ -3552,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "691b17f19fc1ec9d94ec0b5864859290dff279dbd7b03f017afda54eb36c3c35"
+checksum = "16c7a592a1ec97c9c1c68d75b6e537dcbf60c7618e038e7841e00af1d9ccf0c4"
 dependencies = [
  "dtoa",
  "linked-hash-map",
@@ -3579,9 +3608,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08338d8024b227c62bd68a12c7c9883f5c66780abaef15c550dc56f46ee6515"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -3604,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27044adfd2e1f077f649f59deb9490d3941d674002f7d062870a60ebe9bd47a0"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
  "block-buffer 0.7.3",
  "digest 0.8.1",
@@ -3655,9 +3684,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0893246f276ba1aac4983fb8711dad108e2886fd76bf618a382ab4e30e5bec"
+checksum = "8ff2db2112d6c761e12522c65f7768548bd6e8cd23d2a9dae162520626629bd6"
 dependencies = [
  "futures 0.1.29",
  "libc",
@@ -3776,9 +3805,9 @@ checksum = "d239ca4b13aee7a2142e6795cbd69e457665ff8037aed33b3effdc430d2f927a"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -3794,9 +3823,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6e163a520367c465f59e0a61a23cfae3b10b6546d78b6f672a382be79f7110"
 dependencies = [
  "heck",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -3807,9 +3836,9 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c65d530b10ccaeac294f349038a597e435b18fb456aadd0840a623f83b9e941"
+checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
 
 [[package]]
 name = "syn"
@@ -3835,12 +3864,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.19"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e5aa70697bb26ee62214ae3288465ecec0000f05182f039b477001f08f5ae7"
+checksum = "93a56fabc59dce20fe48b6c832cc249c713e7ed88fa28b0ee0a3bfcaae5fe4e2"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
  "unicode-xid 0.2.0",
 ]
 
@@ -3850,9 +3879,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -3882,17 +3911,11 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
  "unicode-xid 0.2.0",
 ]
-
-[[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempdir"
@@ -3968,22 +3991,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d12a1dae4add0f0d568eebc7bf142f145ba1aa2544cafb195c76f0f409091b60"
+checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.16"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f34e0c1caaa462fd840ec6b768946ea1e7842620d94fe29d5b847138f521269"
+checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -3997,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "threadpool"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dae184447c15d5a6916d973c642aec485105a13cd238192a6927ae3e077d66"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
 ]
@@ -4049,9 +4072,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05c1d570eb1a36f0345a5ce9c6c6e665b70b73d11236912c0b477616aeec47b1"
+checksum = "d099fa27b9702bed751524694adbe393e18b36b204da91eb1cbbbbb4a5ee2d58"
 dependencies = [
  "bytes 0.5.4",
  "fnv",
@@ -4159,9 +4182,9 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
 dependencies = [
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -4318,7 +4341,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.20",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -4332,7 +4355,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.8",
  "pin-project-lite",
- "tokio 0.2.20",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -4350,14 +4373,14 @@ dependencies = [
  "async-trait",
  "enum-as-inner",
  "failure",
- "futures 0.3.4",
+ "futures 0.3.5",
  "idna 0.2.0",
  "lazy_static",
  "log 0.4.8",
  "rand 0.7.3",
  "smallvec 1.4.0",
  "socket2",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "url 2.1.1",
 ]
 
@@ -4369,14 +4392,14 @@ checksum = "6f90b1502b226f8b2514c6d5b37bafa8c200d7ca4102d57dc36ee0f3b7a04a2f"
 dependencies = [
  "cfg-if",
  "failure",
- "futures 0.3.4",
+ "futures 0.3.5",
  "ipconfig",
  "lazy_static",
  "log 0.4.8",
  "lru-cache",
  "resolv-conf",
  "smallvec 1.4.0",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "trust-dns-proto",
 ]
 
@@ -4425,7 +4448,7 @@ version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 dependencies = [
- "version_check 0.9.1",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -4558,9 +4581,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2ca2a14bc3fc5b64d188b087a7d3a927df87b152e941ccfbc66672e20c467ae"
 dependencies = [
  "nom",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
- "syn 1.0.19",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
 ]
 
 [[package]]
@@ -4575,9 +4598,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
+checksum = "55d1e41d56121e07f1e223db0a4def204e45c85425f6a16d462fd07c8d10d74c"
 
 [[package]]
 name = "vec_map"
@@ -4593,9 +4616,9 @@ checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "version_check"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "void"
@@ -4779,7 +4802,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "lazy_static",
  "libsqlite3-sys",
  "log 0.4.8",
@@ -4789,7 +4812,7 @@ dependencies = [
  "shlex",
  "structopt",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "uuid 0.8.1",
  "ya-client-model",
  "ya-core-model",
@@ -4816,7 +4839,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=493461d#493461d5e64d0eea28e333c2888f4af68c1c38b0"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=9a34fbe#9a34fbe6ce9d95439d5177c06e52b152011a1639"
 dependencies = [
  "awc",
  "backtrace",
@@ -4824,7 +4847,7 @@ dependencies = [
  "chrono",
  "envy",
  "failure",
- "futures 0.3.4",
+ "futures 0.3.5",
  "log 0.4.8",
  "serde",
  "serde_json",
@@ -4837,7 +4860,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=493461d#493461d5e64d0eea28e333c2888f4af68c1c38b0"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=9a34fbe#9a34fbe6ce9d95439d5177c06e52b152011a1639"
 dependencies = [
  "bigdecimal 0.1.2",
  "chrono",
@@ -4874,7 +4897,7 @@ dependencies = [
  "dotenv 0.15.0",
  "env_logger 0.7.1",
  "flexi_logger",
- "futures 0.3.4",
+ "futures 0.3.5",
  "hex",
  "lazy_static",
  "libproc",
@@ -4892,7 +4915,7 @@ dependencies = [
  "structopt",
  "tempdir",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-util 0.2.0",
  "url 2.1.1",
  "winapi 0.3.8",
@@ -4921,17 +4944,17 @@ dependencies = [
  "dotenv 0.15.0",
  "env_logger 0.7.1",
  "ethsign",
- "futures 0.3.4",
+ "futures 0.3.5",
  "log 0.4.8",
  "promptly",
  "r2d2",
  "rand 0.7.3",
  "rpassword",
  "serde_json",
- "sha2 0.8.1",
+ "sha2 0.8.2",
  "structopt",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "uuid 0.7.4",
  "ya-client-model",
  "ya-core-model",
@@ -4952,15 +4975,15 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "derive_more 0.99.5",
+ "derive_more 0.99.7",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "lazy_static",
  "log 0.4.8",
  "serde",
  "serde_json",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "ya-client",
  "ya-core-model",
  "ya-persistence",
@@ -4981,7 +5004,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "jsonwebtoken",
  "lazy_static",
  "libsqlite3-sys",
@@ -4990,7 +5013,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "url 2.1.1",
  "ya-client",
  "ya-core-model",
@@ -5009,7 +5032,7 @@ dependencies = [
  "actix-rt",
  "anyhow",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "log 0.4.8",
  "serde",
  "serde_json",
@@ -5040,7 +5063,7 @@ dependencies = [
  "env_logger 0.7.1",
  "ethkey",
  "ethsign",
- "futures 0.3.4",
+ "futures 0.3.5",
  "hex",
  "lazy_static",
  "libsqlite3-sys",
@@ -5051,7 +5074,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "uint",
  "uuid 0.8.1",
  "ya-client",
@@ -5085,7 +5108,7 @@ dependencies = [
  "ethereum-tx-sign",
  "ethereum-types",
  "ethkey",
- "futures 0.3.4",
+ "futures 0.3.5",
  "hex",
  "lazy_static",
  "libsqlite3-sys",
@@ -5097,7 +5120,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "uint",
  "ureq",
  "uuid 0.8.1",
@@ -5119,7 +5142,7 @@ dependencies = [
  "r2d2",
  "serde_json",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "ya-client-model",
  "ya-core-model",
 ]
@@ -5134,11 +5157,11 @@ dependencies = [
  "anyhow",
  "bigdecimal 0.1.2",
  "chrono",
- "derive_more 0.99.5",
+ "derive_more 0.99.7",
  "dialoguer",
  "dotenv 0.15.0",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "futures-util",
  "humantime 2.0.0",
  "libc",
@@ -5151,7 +5174,7 @@ dependencies = [
  "shared_child",
  "structopt",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "url 2.1.1",
  "ya-agreement-utils",
  "ya-client",
@@ -5171,12 +5194,12 @@ dependencies = [
  "chrono",
  "dotenv 0.15.0",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "humantime 2.0.0",
  "log 0.4.8",
  "serde_json",
  "structopt",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "url 2.1.1",
  "uuid 0.8.1",
  "ya-client",
@@ -5196,7 +5219,7 @@ dependencies = [
  "prost-build",
  "serial_test",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-util 0.2.0",
  "url 2.1.1",
  "ya-sb-util",
@@ -5210,12 +5233,12 @@ dependencies = [
  "bytes 0.4.12",
  "chrono",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "lazy_static",
  "log 0.4.8",
  "prost",
  "structopt",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-util 0.2.0",
  "url 2.1.1",
  "uuid 0.8.1",
@@ -5230,7 +5253,7 @@ version = "0.1.0"
 dependencies = [
  "bytes 0.4.12",
  "bytes 0.5.4",
- "futures 0.3.4",
+ "futures 0.3.5",
  "pin-project",
 ]
 
@@ -5252,7 +5275,7 @@ dependencies = [
 name = "ya-service-api-cache"
 version = "0.1.0"
 dependencies = [
- "futures 0.3.4",
+ "futures 0.3.5",
  "log 0.4.8",
 ]
 
@@ -5268,12 +5291,12 @@ dependencies = [
  "lazy_static",
  "log 0.4.8",
  "proc-macro-hack",
- "proc-macro2 1.0.12",
- "quote 1.0.4",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
  "structopt",
  "strum",
  "strum_macros",
- "syn 1.0.19",
+ "syn 1.0.30",
  "ya-service-api-interfaces",
 ]
 
@@ -5283,7 +5306,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "anyhow",
- "futures 0.3.4",
+ "futures 0.3.5",
 ]
 
 [[package]]
@@ -5297,7 +5320,7 @@ dependencies = [
  "anyhow",
  "awc",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "log 0.4.8",
  "serde",
  "structopt",
@@ -5322,7 +5345,7 @@ dependencies = [
  "actix-rt",
  "async-stream",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "lazy_static",
  "log 0.4.8",
  "rand 0.7.3",
@@ -5331,7 +5354,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-util 0.2.0",
  "url 2.1.1",
  "ya-sb-proto",
@@ -5349,18 +5372,18 @@ dependencies = [
  "awc",
  "bytes 0.5.4",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "gftp",
  "hex",
  "lazy_static",
  "log 0.4.8",
  "rand 0.7.3",
  "serde",
- "sha2 0.8.1",
+ "sha2 0.8.2",
  "sha3",
  "tempdir",
  "thiserror",
- "tokio 0.2.20",
+ "tokio 0.2.21",
  "tokio-util 0.2.0",
  "url 2.1.1",
  "ya-core-model",
@@ -5374,7 +5397,7 @@ version = "0.1.0"
 dependencies = [
  "actix",
  "anyhow",
- "futures 0.3.4",
+ "futures 0.3.5",
  "log 0.4.8",
 ]
 
@@ -5388,12 +5411,12 @@ version = "0.1.0"
 dependencies = [
  "actix",
  "anyhow",
- "derive_more 0.99.5",
- "futures 0.3.4",
+ "derive_more 0.99.7",
+ "futures 0.3.5",
  "futures-util",
  "libc",
  "shared_child",
- "tokio 0.2.20",
+ "tokio 0.2.21",
 ]
 
 [[package]]
@@ -5414,7 +5437,7 @@ dependencies = [
  "directories",
  "dotenv 0.15.0",
  "env_logger 0.7.1",
- "futures 0.3.4",
+ "futures 0.3.5",
  "lazy_static",
  "log 0.4.8",
  "openssl",
@@ -5438,9 +5461,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-rust"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65923dd1784f44da1d2c3dbbc5e822045628c590ba72123e1c73d3c230c4434d"
+checksum = "39f0c922f1a334134dc2f7a8b67dc5d25f0735263feec974345ff706bcf20b0d"
 dependencies = [
  "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,8 +120,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "493461d"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "493461d"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "9a34fbe"}
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "9a34fbe"}
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/exe-unit/examples/exe-unit2gsb.rs
+++ b/exe-unit/examples/exe-unit2gsb.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 use std::time::Duration;
 use structopt::StructOpt;
 use tokio::process::Command;
-use ya_client_model::activity::ExeScriptCommand;
-use ya_core_model::activity::{self, Exec, GetExecBatchResults};
+use ya_client_model::activity::{ExeScriptCommand, State};
+use ya_core_model::activity::{self, Exec, GetExecBatchResults, GetState};
 use ya_service_bus::actix_rpc;
 
 const ACTIVITY_BUS_ID: &str = "activity";
@@ -20,11 +20,14 @@ const BATCH_ID: &str = "fake_batch_id";
 /// It tests also Exec and GetExecBatchResults messages support by ExeUnit.
 /// Example ends when all ExeScript commands are executed or timeout occurs.
 ///
+///
 /// Before running this example you need to provide http server
 /// as specified in your `agreement.json` and `commands.json`
 /// For default files it is enough to invoke this:
 ///
 ///   cargo run -p ya-exe-unit --example http-get-put -- -r <path with two files: rust-wasi-tutorial.zip and LICENSE>
+///
+/// The timeout parameter can be set to 0 to test out immediate execution result responses.
 #[derive(StructOpt, Debug)]
 pub struct Cli {
     /// Supervisor binary
@@ -49,9 +52,12 @@ pub struct Cli {
     /// Other strategy is to wait once for the whole script to complete.
     #[structopt(long)]
     pub wait_once: bool,
-    /// timeout in seconds
+    /// Execute a scenario where the exe script is interrupted and replaced with another
     #[structopt(long)]
-    pub timeout: Option<f32>,
+    pub terminate: bool,
+    /// timeout in seconds
+    #[structopt(long, default_value = "20")]
+    pub timeout: f32,
 }
 
 mod mock_activity {
@@ -131,45 +137,82 @@ async fn main() -> anyhow::Result<()> {
 
 async fn exec_and_wait(args: &Cli) -> anyhow::Result<()> {
     let contents = std::fs::read_to_string(&args.script)?;
-    let exe_script: Vec<ExeScriptCommand> = serde_json::from_str(&contents)?;
-    let exe_len = exe_script.len();
-    log::warn!("executing script with {} command(s)", exe_len);
+    let mut exe_script: Vec<ExeScriptCommand> = serde_json::from_str(&contents)?;
+    log::warn!("executing script with {} command(s)", exe_script.len());
 
     let exe_unit_url = activity::exeunit::bus_id(ACTIVITY_ID);
     let exe_unit_service = actix_rpc::service(&exe_unit_url);
-    let _ = exe_unit_service
-        .send(Exec {
-            activity_id: ACTIVITY_ID.to_owned(),
-            batch_id: BATCH_ID.to_string(),
-            exe_script,
-            timeout: None,
-        })
-        .await?;
-
-    let mut msg = GetExecBatchResults {
+    let exec = Exec {
         activity_id: ACTIVITY_ID.to_owned(),
         batch_id: BATCH_ID.to_string(),
-        timeout: args.timeout,
+        exe_script: exe_script.clone(),
+        timeout: None,
+    };
+
+    let _ = exe_unit_service.send(exec.clone()).await?;
+
+    let mut msg = GetExecBatchResults {
+        activity_id: ACTIVITY_ID.to_string(),
+        batch_id: BATCH_ID.to_string(),
+        timeout: Some(args.timeout),
         command_index: None,
     };
 
     if args.wait_once {
-        match args.timeout {
-            Some(t) => log::warn!("waiting at most {:?}s for exe script to complete", t),
-            None => log::warn!("Immediately requesting full exe script result"),
-        };
+        if args.timeout == 0. {
+            log::warn!("Immediately requesting full exe script result")
+        } else {
+            log::warn!(
+                "waiting at most {:?}s for exe script to complete",
+                args.timeout
+            )
+        }
         let results = exe_unit_service.send(msg).await?;
         log::warn!("Exe script results: {:#?}", results);
         return Ok(());
     }
 
-    for i in 0..exe_len {
+    for i in 0..exe_script.len() {
         msg.command_index = Some(i);
         log::warn!("waiting at most {:?}s for {}. command", msg.timeout, i);
-
         let results = exe_unit_service.send(msg.clone()).await?;
-
         log::warn!("Command {} result: {:#?}", i, results);
+
+        if args.terminate {
+            let response = exe_unit_service
+                .send(GetState {
+                    activity_id: ACTIVITY_ID.to_string(),
+                    timeout: None,
+                })
+                .await??;
+            if response.state.0 == State::Ready {
+                break;
+            }
+        }
     }
+
+    if args.terminate {
+        log::warn!("Executing a script starting with TERMINATE");
+        let batch_id = "new_batch_id".to_string();
+
+        msg.batch_id = batch_id.clone();
+        exe_script.insert(0, ExeScriptCommand::Terminate {});
+
+        let exec = Exec {
+            activity_id: ACTIVITY_ID.to_owned(),
+            batch_id,
+            exe_script: exe_script.clone(),
+            timeout: None,
+        };
+
+        let _ = exe_unit_service.send(exec.clone()).await?;
+        for i in 0..exe_script.len() {
+            msg.command_index = Some(i);
+            log::warn!("waiting at most {:?}s for {}. command", msg.timeout, i);
+            let results = exe_unit_service.send(msg.clone()).await?;
+            log::warn!("Command {} result: {:#?}", i, results);
+        }
+    }
+
     Ok(())
 }

--- a/exe-unit/src/handlers/local.rs
+++ b/exe-unit/src/handlers/local.rs
@@ -5,6 +5,7 @@ use crate::service::ServiceAddr;
 use crate::state::State;
 use crate::{report, ExeUnit};
 use actix::prelude::*;
+use futures::FutureExt;
 use ya_client_model::activity::ActivityState;
 use ya_core_model::activity::local::SetState as SetActivityState;
 
@@ -75,6 +76,26 @@ where
     }
 }
 
+impl<R: Runtime> Handler<Stop> for ExeUnit<R> {
+    type Result = ActorResponse<Self, (), Error>;
+
+    fn handle(&mut self, msg: Stop, _: &mut Context<Self>) -> Self::Result {
+        self.state.batch_control.retain(|id, tx| {
+            if msg.exclude_batches.contains(id) {
+                return true;
+            }
+            if let Some(tx) = tx.take() {
+                let _ = tx.send(());
+            }
+            false
+        });
+
+        let fut = Self::stop_runtime(self.runtime.clone(), ShutdownReason::Interrupted(0))
+            .map(|_| Ok(()));
+        ActorResponse::r#async(fut.into_actor(self))
+    }
+}
+
 impl<R: Runtime> Handler<Shutdown> for ExeUnit<R> {
     type Result = ActorResponse<Self, (), Error>;
 
@@ -84,7 +105,6 @@ impl<R: Runtime> Handler<Shutdown> for ExeUnit<R> {
         }
 
         let address = ctx.address();
-        let runtime = self.runtime.clone();
         let services = std::mem::replace(&mut self.services, Vec::new());
         let state = self.state.inner.to_pending(State::Terminated);
         let reason = format!("{}: {}", msg.0, self.state.report());
@@ -92,15 +112,14 @@ impl<R: Runtime> Handler<Shutdown> for ExeUnit<R> {
         let fut = async move {
             log::info!("Shutting down ...");
             let _ = address.send(SetState::from(state)).await;
+            let _ = address.send(Stop::default()).await;
 
-            Self::stop_runtime(runtime, msg.0).await;
             for mut service in services.into_iter() {
                 service.stop().await;
             }
 
-            let _ = address
-                .send(SetState::default().state_reason(State::Terminated.into(), reason))
-                .await;
+            let set_state = SetState::default().state_reason(State::Terminated.into(), reason);
+            let _ = address.send(set_state).await;
 
             System::current().stop();
 

--- a/exe-unit/src/lib.rs
+++ b/exe-unit/src/lib.rs
@@ -1,4 +1,5 @@
 use actix::prelude::*;
+use futures::channel::oneshot;
 use futures::TryFutureExt;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -88,18 +89,6 @@ impl<R: Runtime> ExeUnit<R> {
             log::warn!("Unable to stop the runtime: {:?}", e);
         }
     }
-
-    async fn shutdown(addr: &Addr<Self>, reason: ShutdownReason) {
-        log::warn!("Initiating shutdown: {}", reason);
-
-        if let Err(error) = addr.send(Shutdown(reason)).await {
-            log::error!(
-                "Unable to perform a graceful shutdown: {:?}. Terminating",
-                error
-            );
-            System::current().stop();
-        }
-    }
 }
 
 #[derive(Clone, Debug)]
@@ -126,10 +115,12 @@ impl ExecCtx {
             (None, Some(stderr)) => Some(stderr),
             (Some(stdout), Some(stderr)) => Some(format!("{}\n{}", stdout, stderr)),
         };
+        let finished =
+            self.idx == self.batch_size - 1 || exec_result.result == CommandResult::Error;
         ExeScriptCommandResult {
             index: self.idx as u32,
             result: exec_result.result,
-            is_batch_finished: self.idx == self.batch_size - 1,
+            is_batch_finished: finished,
             message,
         }
     }
@@ -141,8 +132,16 @@ impl<R: Runtime> ExeUnit<R> {
         runtime: Addr<R>,
         transfers: Addr<TransferService>,
         exec: activity::Exec,
+        mut control: oneshot::Receiver<()>,
     ) {
         let batch_size = exec.exe_script.len();
+        let on_error = |batch_id, result| async {
+            let set_state = SetState::default().cmd(None).result(batch_id, result);
+            if let Err(error) = addr.send(set_state).await {
+                log::error!("Cannot update state during exec: {:?}", error);
+            }
+        };
+
         for (idx, cmd) in exec.exe_script.into_iter().enumerate() {
             let ctx = ExecCtx {
                 batch_id: exec.batch_id.clone(),
@@ -150,6 +149,12 @@ impl<R: Runtime> ExeUnit<R> {
                 idx,
                 cmd,
             };
+
+            if let Ok(Some(_)) = control.try_recv() {
+                let cmd_result = ctx.cmd_result(ExecCmdResult::error("interrupted"));
+                on_error(ctx.batch_id, cmd_result).await;
+                break;
+            }
 
             if let Err(error) = Self::exec_cmd(
                 addr.clone(),
@@ -159,22 +164,9 @@ impl<R: Runtime> ExeUnit<R> {
             )
             .await
             {
+                log::warn!("Command interrupted: {}", error.to_string());
                 let cmd_result = ctx.cmd_result(ExecCmdResult::error(&error));
-                let set_state = SetState::default()
-                    .cmd(None)
-                    .result(ctx.batch_id, cmd_result);
-
-                if let Err(error) = addr.send(set_state).await {
-                    log::error!(
-                        "Unable to update the state during exec failure: {:?}",
-                        error
-                    );
-                }
-
-                log::error!("Command interrupted: {}", error.to_string());
-
-                let message = format!("Command interrupted: {:?}", ctx.cmd);
-                Self::shutdown(&addr, ShutdownReason::Error(message)).await;
+                on_error(ctx.batch_id, cmd_result).await;
                 break;
             }
         }
@@ -186,8 +178,21 @@ impl<R: Runtime> ExeUnit<R> {
         transfer_service: Addr<TransferService>,
         ctx: ExecCtx,
     ) -> Result<()> {
+        if let ExeScriptCommand::Terminate {} = &ctx.cmd {
+            log::warn!("Terminating running ExeScripts");
+
+            let exclude_batches = vec![ctx.batch_id];
+            let set_state = SetState::default()
+                .state(StatePair(State::Initialized, None))
+                .cmd(None);
+
+            addr.send(Stop { exclude_batches }).await??;
+            addr.send(set_state).await?;
+            return Ok(());
+        }
+
         let state = addr.send(GetState {}).await?.0;
-        let exec_state = match (&state.0, &state.1) {
+        let state_pre = match (&state.0, &state.1) {
             (_, Some(_)) => {
                 return Err(StateError::Busy(state).into());
             }
@@ -208,7 +213,7 @@ impl<R: Runtime> ExeUnit<R> {
                 ExeScriptCommand::Deploy { .. } | ExeScriptCommand::Start { .. } => {
                     return Err(StateError::InvalidState(state).into());
                 }
-                _ => StatePair(s.clone(), Some(*s)),
+                _ => StatePair(*s, Some(*s)),
             },
         };
 
@@ -216,44 +221,11 @@ impl<R: Runtime> ExeUnit<R> {
 
         addr.send(
             SetState::default()
-                .state(exec_state.clone())
+                .state(state_pre.clone())
                 .cmd(Some(ctx.cmd.clone())),
         )
         .await?;
 
-        Self::pre_exec(transfer_service, runtime.clone(), ctx.clone()).await?;
-
-        let exec_result = runtime.send(ExecCmd(ctx.cmd.clone())).await??;
-        if let CommandResult::Error = exec_result.result {
-            return Err(Error::CommandError(exec_result));
-        }
-
-        let sanity_state = addr.send(GetState {}).await?.0;
-        if sanity_state != exec_state {
-            return Err(StateError::UnexpectedState {
-                current: sanity_state,
-                expected: exec_state,
-            }
-            .into());
-        }
-
-        let cmd_result = ctx.cmd_result(exec_result);
-        addr.send(
-            SetState::default()
-                .state(exec_state.1.unwrap().into())
-                .cmd(None)
-                .result(ctx.batch_id, cmd_result),
-        )
-        .await?;
-
-        Ok(())
-    }
-
-    async fn pre_exec(
-        transfer_service: Addr<TransferService>,
-        runtime: Addr<R>,
-        ctx: ExecCtx,
-    ) -> Result<()> {
         match &ctx.cmd {
             ExeScriptCommand::Transfer { from, to } => {
                 let msg = TransferResource {
@@ -269,6 +241,28 @@ impl<R: Runtime> ExeUnit<R> {
             }
             _ => (),
         }
+
+        let exec_result = runtime.send(ExecCmd(ctx.cmd.clone())).await??;
+        if let CommandResult::Error = exec_result.result {
+            return Err(Error::CommandError(exec_result));
+        }
+
+        let state_cur = addr.send(GetState {}).await?.0;
+        if state_cur != state_pre {
+            return Err(StateError::UnexpectedState {
+                current: state_cur,
+                expected: state_pre,
+            }
+            .into());
+        }
+
+        let cmd_result = ctx.cmd_result(exec_result);
+        let state_post = SetState::default()
+            .state(state_pre.1.unwrap().into())
+            .cmd(None)
+            .result(ctx.batch_id, cmd_result);
+        addr.send(state_post).await?;
+
         Ok(())
     }
 }

--- a/exe-unit/src/message.rs
+++ b/exe-unit/src/message.rs
@@ -8,10 +8,6 @@ use ya_client_model::activity::{
     CommandResult, ExeScriptCommand, ExeScriptCommandResult, ExeScriptCommandState,
 };
 
-#[derive(Debug, Message)]
-#[rtype("()")]
-pub struct SetTaskPackagePath(pub PathBuf);
-
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Message)]
 #[rtype(result = "Result<Vec<f64>>")]
 pub struct GetMetrics;
@@ -29,6 +25,10 @@ pub struct GetBatchResults(pub String);
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, MessageResponse)]
 pub struct GetBatchResultsResponse(pub Vec<ExeScriptCommandResult>);
+
+#[derive(Debug, Message)]
+#[rtype(result = "()")]
+pub struct SetTaskPackagePath(pub PathBuf);
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Message)]
 #[rtype(result = "()")]
@@ -125,6 +125,20 @@ impl ExecCmdResult {
 pub struct Register<Svc>(pub Addr<Svc>)
 where
     Svc: Actor<Context = Context<Svc>> + Handler<Shutdown>;
+
+#[derive(Clone, Debug, Message)]
+#[rtype(result = "Result<()>")]
+pub struct Stop {
+    pub exclude_batches: Vec<String>,
+}
+
+impl Default for Stop {
+    fn default() -> Self {
+        Stop {
+            exclude_batches: Vec::new(),
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Message)]
 #[rtype(result = "Result<()>")]

--- a/exe-unit/src/state.rs
+++ b/exe-unit/src/state.rs
@@ -1,4 +1,5 @@
 use crate::notify::Notify;
+use futures::channel::oneshot;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use thiserror::Error;
@@ -23,6 +24,7 @@ pub struct ExeUnitState {
     pub inner: StatePair,
     pub running_command: Option<ExeScriptCommandState>,
     pub batches: HashMap<String, Exec>,
+    pub batch_control: HashMap<String, Option<oneshot::Sender<()>>>,
     batch_results: HashMap<String, Vec<ExeScriptCommandResult>>,
     batch_notifiers: HashMap<String, Notify<usize>>,
 }
@@ -87,6 +89,7 @@ impl Default for ExeUnitState {
             inner: StatePair::default(),
             running_command: None,
             batches: HashMap::new(),
+            batch_control: HashMap::new(),
             batch_results: HashMap::new(),
             batch_notifiers: HashMap::new(),
         }


### PR DESCRIPTION
Termination scenario:

* a new ExeScript is received; the script starts with (or consists of) a TERMINATE command
* any other running ExeUnit::exec futures are interrupted via a oneshot channel (or fail due to Runtime shutdown)
* a Shutdown command is sent to the Runtime handler; the Runtime's state is expected to be reset
* pending commands are updated with an erroneous result (command interrupted)
* ExeUnit state is reverted to State::Initialized
* the remaining commands of the received script are executes as normally

Changes:

* new: handle the new TERMINATE command
* new: stop the currently executed script + runtime via the `Stop` message
* refactor: set ExeScriptCommandResult::is_batch_finished to true on command error
* refactor: do not terminate the Supervisor on command error
* refactor: disallow executing an ExeScript with an already known batchId
* refactor: move the body of ExeUnit::pre_exec to ExeUnit::exec
* refactor: example option to show a termination scenario flow

Part of #292