### PR TITLE
Include last commit's SHA in .deb package version

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -16,14 +16,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Compute deb package version
+        ids: vars
+        run: |
+          VERSION="$(cargo pkgid | cut -d'#' -f2)"
+          ROUTER_VERSION=$(cargo pkgid --manifest-path service-bus/router/Cargo.toml | cut -d'#' -f2)"
+          SHA="$(echo ${{ github.sha }} | cut -c1-8)"
+          echo "::set-output name=deb_version::$VERSION-$SHA"
+          echo "::set-output name=router_deb_version::$ROUTER_VERSION-$SHA"
+
       - name: Build the Docker image
-        run: docker build . -f build-deb.Dockerfile -t build-deb
+        run: docker build . -f build-deb.Dockerfile -t build-deb --build-arg DEB_VERSION=${{ vars.outputs.deb_version }}
 
       - name: Copy yagna.deb file
         run: docker run build-deb bash -c "cat /src/target/debian/yagna*.deb" > yagna.deb
 
       - name: Build the router
-        run: docker build . -f build-deb-router.Dockerfile -t build-deb-router
+        run: docker build . -f build-deb-router.Dockerfile -t build-deb-router --build-arg DEB_VERSION=${{ vars.outputs.router_deb_version }}
 
       - name: Copy ya-sb-router.deb file
         run: docker run build-deb-router bash -c "cat /src/target/debian/ya-sb-router*.deb" > ya-sb-router.deb

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - az/commit-sha-in-deb-version
       # - <your-branch>    # put your branch name here to test it @ GH Actions
 
 jobs:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - az/commit-sha-in-deb-version
       # - <your-branch>    # put your branch name here to test it @ GH Actions
 
 jobs:
@@ -18,15 +19,16 @@ jobs:
 
       - name: Compute deb package version
         id: vars
+        env:
+          YAGNA_VERSION: $(cargo pkgid yagna | cut -d'#' -f2)
+          ROUTER_VERSION: $(cargo pkgid ya-sb-router | cut -d':' -f3)
+          COMMIT_SHA: $(echo ${{ github.sha }} | cut -c1-8)
         run: |
-          VERSION=$(cargo pkgid yagna | cut -d'#' -f2)
-          ROUTER_VERSION=$(cargo pkgid ya-sb-router | cut -d':' -f3)
-          SHA=$(echo ${{ github.sha }} | cut -c1-8)
-          echo "::set-output name=deb_version::$VERSION-$SHA"
-          echo "::set-output name=router_deb_version::$ROUTER_VERSION-$SHA"
+          echo "::set-output name=yagna_deb_version::$YAGNA_VERSION-$COMMIT_SHA"
+          echo "::set-output name=router_deb_version::$ROUTER_VERSION-$COMMIT_SHA"
 
       - name: Build the Docker image
-        run: docker build . -f build-deb.Dockerfile -t build-deb --build-arg DEB_VERSION=${{ steps.vars.outputs.deb_version }}
+        run: docker build . -f build-deb.Dockerfile -t build-deb --build-arg DEB_VERSION=${{ steps.vars.outputs.yagna_deb_version }}
 
       - name: Copy yagna.deb file
         run: docker run build-deb bash -c "cat /src/target/debian/yagna*.deb" > yagna.deb

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Compute deb package version
         id: vars
         run: |
-          VERSION=$(cargo pkgid | cut -d'#' -f2)
-          ROUTER_VERSION=$(cargo pkgid --manifest-path service-bus/router/Cargo.toml | cut -d'#' -f2)
+          VERSION=$(cargo pkgid yagna | cut -d'#' -f2)
+          ROUTER_VERSION=$(cargo pkgid ya-sb-router | cut -d':' -f3)
           SHA=$(echo ${{ github.sha }} | cut -c1-8)
           echo "::set-output name=deb_version::$VERSION-$SHA"
           echo "::set-output name=router_deb_version::$ROUTER_VERSION-$SHA"

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - az/commit-sha-in-deb-version
       # - <your-branch>    # put your branch name here to test it @ GH Actions
 
 jobs:

--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -18,22 +18,22 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Compute deb package version
-        ids: vars
+        id: vars
         run: |
-          VERSION="$(cargo pkgid | cut -d'#' -f2)"
-          ROUTER_VERSION=$(cargo pkgid --manifest-path service-bus/router/Cargo.toml | cut -d'#' -f2)"
-          SHA="$(echo ${{ github.sha }} | cut -c1-8)"
+          VERSION=$(cargo pkgid | cut -d'#' -f2)
+          ROUTER_VERSION=$(cargo pkgid --manifest-path service-bus/router/Cargo.toml | cut -d'#' -f2)
+          SHA=$(echo ${{ github.sha }} | cut -c1-8)
           echo "::set-output name=deb_version::$VERSION-$SHA"
           echo "::set-output name=router_deb_version::$ROUTER_VERSION-$SHA"
 
       - name: Build the Docker image
-        run: docker build . -f build-deb.Dockerfile -t build-deb --build-arg DEB_VERSION=${{ vars.outputs.deb_version }}
+        run: docker build . -f build-deb.Dockerfile -t build-deb --build-arg DEB_VERSION=${{ steps.vars.outputs.deb_version }}
 
       - name: Copy yagna.deb file
         run: docker run build-deb bash -c "cat /src/target/debian/yagna*.deb" > yagna.deb
 
       - name: Build the router
-        run: docker build . -f build-deb-router.Dockerfile -t build-deb-router --build-arg DEB_VERSION=${{ vars.outputs.router_deb_version }}
+        run: docker build . -f build-deb-router.Dockerfile -t build-deb-router --build-arg DEB_VERSION=${{ steps.vars.outputs.router_deb_version }}
 
       - name: Copy ya-sb-router.deb file
         run: docker run build-deb-router bash -c "cat /src/target/debian/ya-sb-router*.deb" > ya-sb-router.deb

--- a/build-deb-router.Dockerfile
+++ b/build-deb-router.Dockerfile
@@ -1,3 +1,4 @@
 FROM build-deb
+ARG DEB_VERSION=unknown
 
-RUN cargo deb -p ya-sb-router -- --example ya_sb_router
+RUN cargo deb -p ya-sb-router --deb-version $DEB_VERSION -- --example ya_sb_router

--- a/build-deb.Dockerfile
+++ b/build-deb.Dockerfile
@@ -1,8 +1,9 @@
 FROM ubuntu:16.04
+ARG DEB_VERSION=unknown
 WORKDIR /src/
 RUN apt-get update && apt-get install -y curl gcc pkg-config libssl-dev
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 RUN cargo install cargo-deb
 COPY . .
-RUN cargo deb -p yagna
+RUN cargo deb -p yagna --deb-version $DEB_VERSION


### PR DESCRIPTION
This PR modifies the workflow file for the `Build .deb` action and the dockerfiles that are used to build .deb packages, in order to include the SHA of the current commit in the `Version` property of the .deb packages. After this change, the version property of `yagna.deb` will be something like `0.3.0-8832501e` instead of just `0.3.0`.

This will allow us to identify which version of `yagna` code is actually being tested in integration tests. 