### PR TITLE
ExeUnit Supervisor: manage Runtime process groups

### DIFF
--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -26,7 +26,7 @@ procfs = "0.7.8"
 libproc = "0.7.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = { version = "0.3.8", features = ["jobapi2"] }
+winapi = { version = "0.3.8", features = ["jobapi2", "processthreadsapi"] }
 
 [dependencies]
 ya-core-model = { version = "0.1", features = ["activity", "appkey"] }

--- a/exe-unit/examples/commands.json
+++ b/exe-unit/examples/commands.json
@@ -9,7 +9,7 @@
   }},
   {
     "transfer": {
-      "from": "http://34.244.4.185:8000/LICENSE",
+      "from": "http://127.0.0.1:8000/LICENSE",
       "to": "container:/input/file_in"
     }
   },
@@ -20,7 +20,7 @@
   {
     "transfer": {
       "from": "container:/output/file_cp",
-      "to": "http://34.244.4.185:8000/upload/file_up"
+      "to": "http://127.0.0.1:8000/upload/file_up"
     }
   }
 ]

--- a/exe-unit/src/lib.rs
+++ b/exe-unit/src/lib.rs
@@ -28,6 +28,7 @@ mod handlers;
 pub mod message;
 pub mod metrics;
 mod notify;
+pub mod process;
 pub mod runtime;
 pub mod service;
 pub mod state;

--- a/exe-unit/src/metrics/error.rs
+++ b/exe-unit/src/metrics/error.rs
@@ -1,4 +1,4 @@
-use crate::metrics::os::SystemError;
+use crate::process::SystemError;
 use std::time::SystemTimeError;
 use thiserror::Error;
 

--- a/exe-unit/src/metrics/os/unix.rs
+++ b/exe-unit/src/metrics/os/unix.rs
@@ -1,41 +1,22 @@
 use crate::metrics::{error::MetricError, Result};
-use nix::libc;
-use std::collections::{HashMap, HashSet};
-use std::mem;
+use crate::process::*;
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use thiserror::Error;
 
 lazy_static::lazy_static! {
     static ref METRICS: Arc<RwLock<Metrics>> = Arc::new(RwLock::new(Metrics::default()));
-    static ref PID: i32 = unsafe { libc::getpid() };
-    static ref GID: i32 = unsafe { libc::getpgrp() };
 }
 
 const MAX_UPDATE_RESOLUTION_MS: i64 = 100;
 
-#[derive(Clone, Debug, Error)]
-pub enum SystemError {
-    #[error("{0}")]
-    NixError(#[from] nix::Error),
-    #[error("unable to retrieve lock: {0}")]
-    LockError(String),
-    #[error("{0}")]
-    Error(String),
-}
-
-impl<T> From<std::sync::PoisonError<T>> for SystemError {
-    fn from(e: std::sync::PoisonError<T>) -> Self {
-        SystemError::LockError(e.to_string())
-    }
-}
-
 pub fn cpu_time() -> Result<Duration> {
     let mut metrics = (&(*METRICS)).write().map_err(SystemError::from)?;
     metrics.sample()?;
-    Ok(metrics.cpu())
+    Ok(metrics.cpu_total)
 }
 
+#[inline(always)]
 pub fn mem_rss() -> Result<f64> {
     Err(MetricError::Unsupported("mem".to_owned()))
 }
@@ -43,10 +24,11 @@ pub fn mem_rss() -> Result<f64> {
 pub fn mem_peak_rss() -> Result<f64> {
     let mut metrics = (&(*METRICS)).write().map_err(SystemError::from)?;
     metrics.sample()?;
-    Ok(metrics.mem())
+    Ok(metrics.mem_total)
 }
 
 struct Metrics {
+    process_tree: ProcessTree,
     cpu: HashMap<i32, Duration>,
     mem: HashMap<i32, f64>,
     cpu_total: Duration,
@@ -56,31 +38,35 @@ struct Metrics {
 
 impl Default for Metrics {
     fn default() -> Self {
+        let pid = unsafe { nix::libc::getpid() } as u32;
+        let process_tree = ProcessTree::try_new(pid).unwrap();
+
         Metrics {
             cpu: HashMap::new(),
             mem: HashMap::new(),
             cpu_total: Duration::default(),
             mem_total: 0f64,
             updated: 0i64,
+            process_tree,
         }
     }
 }
 
 impl Metrics {
     fn sample(&mut self) -> Result<()> {
-        // Grace period
+        // grace period
         let now = chrono::Local::now().timestamp_millis();
         if now < self.updated + MAX_UPDATE_RESOLUTION_MS {
             return Ok(());
         }
         self.updated = now;
 
-        // Read and store process tree usage
-        self.extend(process_tree_info(*PID, *GID)?.into_iter());
+        // read and store process tree usage
+        self.extend(self.process_tree.list().into_iter());
         self.cpu_total = self.cpu.values().sum();
         self.mem_total = self.mem.values().sum();
 
-        // Apply corrections in case there was a process we missed
+        // apply corrections in case we skipped a process
         let usage = getrusage(0)? + getrusage(-1)?;
 
         if usage.cpu_sec > self.cpu_total {
@@ -88,7 +74,6 @@ impl Metrics {
             *self.cpu.entry(-1).or_insert_with(|| Duration::default()) += dv;
             self.cpu_total += dv;
         }
-
         if usage.rss_gib > self.mem_total {
             let dv = usage.rss_gib - self.mem_total;
             *self.mem.entry(-1).or_insert(0f64) += dv;
@@ -96,16 +81,6 @@ impl Metrics {
         }
 
         Ok(())
-    }
-
-    #[inline]
-    fn cpu(&self) -> Duration {
-        self.cpu_total
-    }
-
-    #[inline]
-    fn mem(&self) -> f64 {
-        self.mem_total
     }
 
     fn extend<I: Iterator<Item = Process>>(&mut self, iter: I) {
@@ -124,166 +99,5 @@ impl Metrics {
                     *mem_entry = usage.rss_gib;
                 }
             })
-    }
-}
-
-struct Process {
-    pid: i32,
-    ppid: i32,
-    pgid: i32,
-    start_ts: u64,
-}
-
-#[cfg(target_os = "linux")]
-impl Process {
-    fn all() -> impl Iterator<Item = Process> {
-        use std::str::FromStr;
-
-        std::fs::read_dir("/proc/")
-            .expect("no /proc mountpoint")
-            .into_iter()
-            .filter_map(|res| res.ok())
-            .filter_map(|entry| i32::from_str(&entry.file_name().to_string_lossy()).ok())
-            .filter_map(|pid| Process::info(pid).ok())
-    }
-
-    fn info(pid: i32) -> Result<Process> {
-        let proc = Self::stat(pid)?;
-
-        Ok(Process {
-            pid: proc.pid,
-            ppid: proc.stat.ppid,
-            pgid: proc.stat.pgrp,
-            start_ts: proc.stat.starttime,
-        })
-    }
-
-    fn usage(pid: i32) -> Result<Usage> {
-        let proc = Self::stat(pid)?;
-
-        let tps = procfs::ticks_per_second().map_err(|e| SystemError::Error(e.to_string()))?;
-        let cpu_sec = Duration::from_secs((proc.stat.stime + proc.stat.utime) / tps as u64);
-        let rss_gib = proc.stat.rss as f64 / (1024. * 1024.);
-
-        Ok(Usage { cpu_sec, rss_gib })
-    }
-
-    #[inline]
-    fn stat(pid: i32) -> Result<procfs::process::Process> {
-        procfs::process::Process::new(pid).map_err(|e| SystemError::Error(e.to_string()).into())
-    }
-}
-
-#[cfg(target_os = "macos")]
-impl Process {
-    fn all() -> impl Iterator<Item = Process> {
-        use libproc::libproc::proc_pid::{listpids, ProcType};
-
-        listpids(ProcType::ProcAllPIDS)
-            .unwrap_or(Vec::new())
-            .into_iter()
-            .filter_map(|p| Process::info(p as i32).ok())
-    }
-
-    fn info(pid: i32) -> Result<Process> {
-        use libproc::libproc::bsd_info::BSDInfo;
-        use libproc::libproc::proc_pid::pidinfo;
-
-        let info = pidinfo::<BSDInfo>(pid, 0).map_err(SystemError::Error)?;
-        let start_ts = (info.pbi_start_tvsec + info.pbi_start_tvusec / 1_000_000_000) as u64;
-
-        Ok(Process {
-            pid: info.pbi_pid as i32,
-            ppid: info.pbi_ppid as i32,
-            pgid: info.pbi_pgid as i32,
-            start_ts,
-        })
-    }
-
-    fn usage(pid: i32) -> Result<Usage> {
-        use libproc::libproc::pid_rusage::{pidrusage, RUsageInfoV2};
-
-        let usage = pidrusage::<RUsageInfoV2>(pid).map_err(SystemError::Error)?;
-        let cpu_sec = Duration::from_secs_f64(
-            (usage.ri_system_time as f64 + usage.ri_user_time as f64) / 1_000_000_000.,
-        );
-        let rss_gib = usage.ri_resident_size as f64 / (1024. * 1024. * 1024.);
-
-        Ok(Usage { cpu_sec, rss_gib })
-    }
-}
-
-struct Usage {
-    cpu_sec: Duration,
-    rss_gib: f64,
-}
-
-impl std::ops::Add for Usage {
-    type Output = Usage;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Usage {
-            cpu_sec: self.cpu_sec + rhs.cpu_sec,
-            rss_gib: self.rss_gib + rhs.rss_gib,
-        }
-    }
-}
-
-impl From<libc::rusage> for Usage {
-    fn from(usage: libc::rusage) -> Self {
-        let cpu_sec = Duration::from_secs((usage.ru_utime.tv_sec + usage.ru_stime.tv_sec) as u64)
-            + Duration::from_micros((usage.ru_utime.tv_usec + usage.ru_stime.tv_usec) as u64);
-        let rss_gib = (usage.ru_maxrss + usage.ru_ixrss + usage.ru_idrss + usage.ru_isrss) as f64
-            / (1024. * 1024. * 1024.);
-
-        Usage { cpu_sec, rss_gib }
-    }
-}
-
-fn process_tree_info(pid: i32, gid: i32) -> Result<Vec<Process>> {
-    let now = chrono::Local::now().timestamp() as u64;
-
-    let candidates = Process::all()
-        .filter(|i| (i.pgid == gid) && (i.start_ts <= now))
-        .collect::<Vec<_>>();
-
-    let procs = vec![Process::info(pid)?];
-    let mut parents = HashSet::new();
-    parents.insert(pid);
-
-    process_info(candidates, parents, procs)
-}
-
-fn process_info(
-    candidates: Vec<Process>,
-    parents: HashSet<i32>,
-    mut procs: Vec<Process>,
-) -> Result<Vec<Process>> {
-    let mut children = HashSet::new();
-
-    let (pids, candidates): (Vec<_>, Vec<_>) = candidates
-        .into_iter()
-        .partition(|proc| parents.contains(&(proc.ppid)));
-
-    pids.into_iter().for_each(|proc| {
-        if !children.contains(&proc.pid) {
-            children.insert(proc.pid);
-            procs.push(proc);
-        }
-    });
-
-    if children.is_empty() {
-        Ok(procs)
-    } else {
-        process_info(candidates, children, procs)
-    }
-}
-
-fn getrusage(resource: i32) -> Result<Usage> {
-    let mut usage = mem::MaybeUninit::<libc::rusage>::uninit();
-    let ret = unsafe { libc::getrusage(resource as i32, usage.as_mut_ptr()) };
-    match ret {
-        0 => Ok(Usage::from(unsafe { usage.assume_init() })),
-        _ => Err(SystemError::from(nix::Error::last()).into()),
     }
 }

--- a/exe-unit/src/metrics/os/win.rs
+++ b/exe-unit/src/metrics/os/win.rs
@@ -1,145 +1,34 @@
 use crate::metrics::error::MetricError;
 use crate::metrics::Result;
-use std::mem;
-use std::ptr;
-use std::sync::{Arc, Mutex, PoisonError};
+use crate::process::*;
 use std::time::Duration;
-use thiserror::Error;
-use winapi::shared::minwindef::{DWORD, LPDWORD, LPVOID};
-use winapi::shared::ntdef::{HANDLE, NULL};
 use winapi::um;
 
-lazy_static::lazy_static! {
-    static ref JOB_OBJECT: Arc<Mutex<JobObject>> = Arc::new(Mutex::new(JobObject::new()));
-}
-
-#[derive(Clone, Debug, Error)]
-pub enum SystemError {
-    #[error("Null pointer: {0}")]
-    NullPointer(String),
-    #[error("Mutex poison error")]
-    PoisonError,
-    #[error("API error: {0}")]
-    ApiError(u32),
-}
-
-impl<T> From<PoisonError<T>> for SystemError {
-    fn from(_: PoisonError<T>) -> Self {
-        SystemError::PoisonError
-    }
-}
-
-impl SystemError {
-    pub fn last() -> Self {
-        let code = unsafe { um::errhandlingapi::GetLastError() };
-        SystemError::ApiError(code)
-    }
-}
-
 pub fn cpu_time() -> Result<Duration> {
-    let info = JOB_OBJECT.lock().map_err(SystemError::from)?.accounting()?;
+    let info = ProcessTree::job()
+        .lock()
+        .map_err(SystemError::from)?
+        .accounting()?;
     let user_time = to_duration(unsafe { info.TotalUserTime.u() });
     let kernel_time = to_duration(unsafe { info.TotalKernelTime.u() });
 
     Ok(user_time + kernel_time)
 }
 
+#[inline(always)]
 pub fn mem_rss() -> Result<f64> {
     Err(MetricError::Unsupported("mem".to_owned()))
 }
 
 pub fn mem_peak_rss() -> Result<f64> {
-    let info = JOB_OBJECT.lock().map_err(SystemError::from)?.limits()?;
+    let info = ProcessTree::job()
+        .lock()
+        .map_err(SystemError::from)?
+        .limits()?;
     Ok((info.PeakJobMemoryUsed as f64) / (1024_f64 * 1024_f64)) // kiB to giB
 }
 
-struct JobObject {
-    handle: HANDLE,
-}
-
-unsafe impl Send for JobObject {}
-
-impl JobObject {
-    pub fn new() -> Self {
-        let job_object = JobObject {
-            handle: Self::create_job().unwrap(),
-        };
-
-        let mut info: um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { mem::zeroed() };
-        info.BasicLimitInformation.LimitFlags = um::winnt::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-        job_object.set_limits(info).unwrap();
-
-        job_object
-    }
-
-    fn accounting(&self) -> Result<um::winnt::JOBOBJECT_BASIC_ACCOUNTING_INFORMATION> {
-        let mut info: um::winnt::JOBOBJECT_BASIC_ACCOUNTING_INFORMATION = unsafe { mem::zeroed() };
-
-        if unsafe {
-            um::jobapi2::QueryInformationJobObject(
-                self.handle,
-                um::winnt::JobObjectBasicAccountingInformation,
-                &mut info as *mut _ as LPVOID,
-                mem::size_of::<um::winnt::JOBOBJECT_BASIC_ACCOUNTING_INFORMATION>() as DWORD,
-                NULL as *mut _ as LPDWORD,
-            )
-        } == 0
-        {
-            return Err(SystemError::last().into());
-        }
-
-        Ok(info)
-    }
-
-    fn limits(&self) -> Result<um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION> {
-        let mut info: um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { mem::zeroed() };
-
-        if unsafe {
-            um::jobapi2::QueryInformationJobObject(
-                self.handle,
-                um::winnt::JobObjectExtendedLimitInformation,
-                &mut info as *mut _ as LPVOID,
-                mem::size_of::<um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as DWORD,
-                NULL as *mut _ as LPDWORD,
-            )
-        } == 0
-        {
-            return Err(SystemError::last().into());
-        }
-
-        Ok(info)
-    }
-
-    fn set_limits(&self, mut info: um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION) -> Result<()> {
-        if unsafe {
-            um::jobapi2::SetInformationJobObject(
-                self.handle,
-                um::winnt::JobObjectExtendedLimitInformation,
-                &mut info as *mut _ as LPVOID,
-                mem::size_of::<um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as DWORD,
-            )
-        } == 0
-        {
-            return Err(SystemError::last().into());
-        }
-        Ok(())
-    }
-
-    fn create_job() -> Result<HANDLE> {
-        let handle = unsafe { um::jobapi2::CreateJobObjectW(ptr::null_mut(), ptr::null()) };
-        if handle.is_null() {
-            return Err(SystemError::NullPointer(format!("handle to JobObject")).into());
-        }
-
-        let proc = unsafe { um::processthreadsapi::GetCurrentProcess() };
-        if unsafe { um::jobapi2::AssignProcessToJobObject(handle, proc) } == 0 {
-            return Err(SystemError::last().into());
-        }
-
-        Ok(handle)
-    }
-}
-
+#[inline(always)]
 fn to_duration(large_int: &um::winnt::LARGE_INTEGER_u) -> Duration {
     Duration::from_nanos(((large_int.HighPart as u64) << 32) + large_int.LowPart as u64)
 }

--- a/exe-unit/src/process/mod.rs
+++ b/exe-unit/src/process/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod win;
+
+#[cfg(unix)]
+pub use self::unix::*;
+#[cfg(windows)]
+pub use self::win::*;

--- a/exe-unit/src/process/unix.rs
+++ b/exe-unit/src/process/unix.rs
@@ -1,0 +1,244 @@
+use nix::libc;
+use nix::sys::signal;
+use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
+use nix::unistd::Pid;
+use std::hash::Hash;
+use std::mem;
+use std::time::{Duration, Instant};
+use thiserror::Error;
+
+#[cfg(target_os = "macos")]
+use libproc::libproc::bsd_info::BSDInfo;
+#[cfg(target_os = "macos")]
+use libproc::libproc::proc_pid::{listpids, pidinfo, ProcType};
+use std::collections::HashSet;
+
+#[derive(Clone, Debug, Error)]
+pub enum SystemError {
+    #[error("{0}")]
+    NixError(#[from] nix::Error),
+    #[error("unable to retrieve lock: {0}")]
+    LockError(String),
+    #[error("{0}")]
+    Error(String),
+}
+
+impl<T> From<std::sync::PoisonError<T>> for SystemError {
+    fn from(e: std::sync::PoisonError<T>) -> Self {
+        SystemError::LockError(e.to_string())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Process {
+    pub pid: i32,
+    pub ppid: i32,
+    pub pgid: i32,
+    pub start_ts: u64,
+}
+
+#[cfg(target_os = "linux")]
+impl Process {
+    pub fn group(group: i32) -> impl Iterator<Item = Process> {
+        use std::str::FromStr;
+
+        std::fs::read_dir("/proc/")
+            .expect("no /proc mountpoint")
+            .into_iter()
+            .filter_map(|res| res.ok())
+            .filter_map(|entry| i32::from_str(&entry.file_name().to_string_lossy()).ok())
+            .filter_map(|pid| Process::info(pid).ok())
+            .filter(move |proc| proc.pgid == group)
+    }
+
+    pub fn info(pid: i32) -> Result<Process, SystemError> {
+        let proc = Self::stat(pid)?;
+
+        Ok(Process {
+            pid: proc.pid,
+            ppid: proc.stat.ppid,
+            pgid: proc.stat.pgrp,
+            start_ts: proc.stat.starttime,
+        })
+    }
+
+    pub fn usage(pid: i32) -> Result<Usage, SystemError> {
+        let proc = Self::stat(pid)?;
+
+        let tps = procfs::ticks_per_second().map_err(|e| SystemError::Error(e.to_string()))?;
+        let cpu_sec = Duration::from_secs((proc.stat.stime + proc.stat.utime) / tps as u64);
+        let rss_gib = proc.stat.rss as f64 / (1024. * 1024.);
+
+        Ok(Usage { cpu_sec, rss_gib })
+    }
+
+    #[inline]
+    fn stat(pid: i32) -> Result<procfs::process::Process, SystemError> {
+        procfs::process::Process::new(pid).map_err(|e| SystemError::Error(e.to_string()).into())
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl Process {
+    pub fn group(pgid: i32) -> impl Iterator<Item = Process> {
+        listpids(ProcType::ProcAllPIDS)
+            .unwrap_or_else(|_| Vec::new())
+            .into_iter()
+            .filter_map(|p| Process::info(p as i32).ok())
+            .filter(move |p| p.pgid == pgid)
+    }
+
+    pub fn info(pid: i32) -> Result<Process, SystemError> {
+        let info = pidinfo::<BSDInfo>(pid, 0).map_err(SystemError::Error)?;
+        let start_ts = (info.pbi_start_tvsec + info.pbi_start_tvusec / 1_000_000_000) as u64;
+
+        Ok(Process {
+            pid: info.pbi_pid as i32,
+            ppid: info.pbi_ppid as i32,
+            pgid: info.pbi_pgid as i32,
+            start_ts,
+        })
+    }
+
+    pub fn usage(pid: i32) -> Result<Usage, SystemError> {
+        use libproc::libproc::pid_rusage::{pidrusage, RUsageInfoV2};
+
+        let usage = pidrusage::<RUsageInfoV2>(pid).map_err(SystemError::Error)?;
+        let cpu_sec = Duration::from_secs_f64(
+            (usage.ri_system_time as f64 + usage.ri_user_time as f64) / 1_000_000_000.,
+        );
+        let rss_gib = usage.ri_resident_size as f64 / (1024. * 1024. * 1024.);
+
+        Ok(Usage { cpu_sec, rss_gib })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ProcessTree {
+    pub pid: i32,
+    proc: Process,
+}
+
+impl PartialEq for ProcessTree {
+    fn eq(&self, other: &Self) -> bool {
+        self.pid == other.pid
+    }
+}
+
+impl Eq for ProcessTree {}
+
+impl Hash for ProcessTree {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.pid.to_be_bytes())
+    }
+}
+
+impl ProcessTree {
+    pub fn try_new(pid: u32) -> Result<Self, SystemError> {
+        let pid = pid as i32;
+        let proc = Process::info(pid)?;
+        Ok(ProcessTree { pid, proc })
+    }
+
+    #[inline]
+    pub fn list(&self) -> Vec<Process> {
+        let parents = parents(self.proc.pid);
+        Process::group(self.proc.pgid)
+            .filter(move |p| !parents.contains(&p.pid))
+            .collect()
+    }
+
+    pub async fn kill(self, timeout: i64) -> Result<(), SystemError> {
+        futures::future::join_all(self.list().into_iter().map(|p| kill(p.pid, timeout))).await;
+        Ok(())
+    }
+}
+
+pub struct Usage {
+    pub cpu_sec: Duration,
+    pub rss_gib: f64,
+}
+
+impl std::ops::Add for Usage {
+    type Output = Usage;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Usage {
+            cpu_sec: self.cpu_sec + rhs.cpu_sec,
+            rss_gib: self.rss_gib + rhs.rss_gib,
+        }
+    }
+}
+
+impl From<libc::rusage> for Usage {
+    fn from(usage: libc::rusage) -> Self {
+        let cpu_sec = Duration::from_secs((usage.ru_utime.tv_sec + usage.ru_stime.tv_sec) as u64)
+            + Duration::from_micros((usage.ru_utime.tv_usec + usage.ru_stime.tv_usec) as u64);
+        let rss_gib = (usage.ru_maxrss + usage.ru_ixrss + usage.ru_idrss + usage.ru_isrss) as f64
+            / (1024. * 1024. * 1024.);
+
+        Usage { cpu_sec, rss_gib }
+    }
+}
+
+pub fn getrusage(resource: i32) -> Result<Usage, SystemError> {
+    let mut usage = mem::MaybeUninit::<libc::rusage>::uninit();
+    let ret = unsafe { libc::getrusage(resource as i32, usage.as_mut_ptr()) };
+    match ret {
+        0 => Ok(Usage::from(unsafe { usage.assume_init() })),
+        _ => Err(SystemError::from(nix::Error::last()).into()),
+    }
+}
+
+async fn kill(pid: i32, timeout: i64) {
+    fn alive(pid: Pid) -> bool {
+        match waitpid(pid, Some(WaitPidFlag::WNOHANG)) {
+            Ok(status) => match status {
+                WaitStatus::Exited(_, _) | WaitStatus::Signaled(_, _, _) => false,
+                _ => true,
+            },
+            _ => false,
+        }
+    }
+
+    let pid = Pid::from_raw(pid);
+    let delay = Duration::from_secs_f32(timeout as f32 / 5.);
+    let started = Instant::now();
+
+    if let Ok(_) = signal::kill(pid, signal::Signal::SIGTERM) {
+        log::info!("Sent SIGTERM to {:?}", pid);
+        loop {
+            if !alive(pid) {
+                break;
+            }
+            if Instant::now() >= started + delay {
+                log::info!("Sending SIGKILL to {:?}", pid);
+                if let Ok(_) = signal::kill(pid, signal::Signal::SIGKILL) {
+                    let _ = waitpid(pid, None);
+                }
+                break;
+            }
+            tokio::time::delay_for(delay).await;
+        }
+    }
+}
+
+fn parents(pid: i32) -> HashSet<i32> {
+    let mut parents = HashSet::new();
+    let mut proc = match Process::info(pid) {
+        Ok(proc) => proc,
+        _ => return parents,
+    };
+
+    while proc.ppid != 0 {
+        parents.insert(proc.ppid);
+        proc = match Process::info(proc.ppid) {
+            Ok(p) => p,
+            _ => break,
+        };
+        if proc.ppid == proc.pgid {
+            break;
+        }
+    }
+    parents
+}

--- a/exe-unit/src/process/win.rs
+++ b/exe-unit/src/process/win.rs
@@ -1,0 +1,210 @@
+use std::hash::Hash;
+use std::mem;
+use std::ptr;
+use std::sync::{Arc, Mutex};
+use thiserror::Error;
+use winapi::shared::minwindef::{DWORD, LPDWORD, LPVOID};
+use winapi::shared::ntdef::{HANDLE, NULL};
+use winapi::um;
+
+lazy_static::lazy_static! {
+    static ref JOB_OBJECT: Arc<Mutex<JobObject>> = {
+        let job = JobObject::try_new(None).unwrap();
+        Arc::new(Mutex::new(job))
+    };
+}
+
+#[derive(Clone, Debug, Error)]
+pub enum SystemError {
+    #[error("Null pointer: {0}")]
+    NullPointer(String),
+    #[error("Mutex poison error")]
+    PoisonError,
+    #[error("API error: {0}")]
+    ApiError(u32),
+}
+
+impl<T> From<std::sync::PoisonError<T>> for SystemError {
+    fn from(_: std::sync::PoisonError<T>) -> Self {
+        SystemError::PoisonError
+    }
+}
+
+impl SystemError {
+    pub fn last() -> Self {
+        let code = unsafe { um::errhandlingapi::GetLastError() };
+        SystemError::ApiError(code)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ProcessTree {
+    pub pid: u32,
+    job: JobObject,
+}
+
+unsafe impl Send for ProcessTree {}
+
+impl PartialEq for ProcessTree {
+    fn eq(&self, other: &Self) -> bool {
+        self.pid == other.pid
+    }
+}
+
+impl Eq for ProcessTree {}
+
+impl Hash for ProcessTree {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        state.write(&self.pid.to_be_bytes())
+    }
+}
+
+impl ProcessTree {
+    #[inline]
+    pub fn job() -> Arc<Mutex<JobObject>> {
+        (*JOB_OBJECT).clone()
+    }
+
+    pub fn try_new(pid: u32) -> Result<Self, SystemError> {
+        let job = JobObject::try_new(Some(pid))?;
+        Ok(ProcessTree { pid, job })
+    }
+
+    pub async fn kill(self, _timeout: i64) -> Result<(), SystemError> {
+        self.job.terminate()?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct JobObject {
+    handle: HANDLE,
+}
+
+unsafe impl Send for JobObject {}
+
+impl JobObject {
+    pub fn try_new(pid: Option<u32>) -> Result<Self, SystemError> {
+        let job_object = JobObject {
+            handle: Self::create_job(process_handle(pid)?)?,
+        };
+
+        let mut info: um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { mem::zeroed() };
+        info.BasicLimitInformation.LimitFlags = um::winnt::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        job_object.set_limits(info).unwrap();
+
+        Ok(job_object)
+    }
+
+    pub fn accounting(
+        &self,
+    ) -> Result<um::winnt::JOBOBJECT_BASIC_ACCOUNTING_INFORMATION, SystemError> {
+        let mut info: um::winnt::JOBOBJECT_BASIC_ACCOUNTING_INFORMATION = unsafe { mem::zeroed() };
+
+        if unsafe {
+            um::jobapi2::QueryInformationJobObject(
+                self.handle,
+                um::winnt::JobObjectBasicAccountingInformation,
+                &mut info as *mut _ as LPVOID,
+                mem::size_of::<um::winnt::JOBOBJECT_BASIC_ACCOUNTING_INFORMATION>() as DWORD,
+                NULL as *mut _ as LPDWORD,
+            )
+        } == 0
+        {
+            return Err(SystemError::last().into());
+        }
+
+        Ok(info)
+    }
+
+    pub fn limits(&self) -> Result<um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION, SystemError> {
+        let mut info: um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { mem::zeroed() };
+
+        if unsafe {
+            um::jobapi2::QueryInformationJobObject(
+                self.handle,
+                um::winnt::JobObjectExtendedLimitInformation,
+                &mut info as *mut _ as LPVOID,
+                mem::size_of::<um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as DWORD,
+                NULL as *mut _ as LPDWORD,
+            )
+        } == 0
+        {
+            return Err(SystemError::last().into());
+        }
+
+        Ok(info)
+    }
+
+    pub fn terminate(&self) -> Result<(), SystemError> {
+        if unsafe { um::jobapi2::TerminateJobObject(self.handle, 0) } == 0 {
+            return Err(SystemError::last().into());
+        }
+        Ok(())
+    }
+
+    fn set_limits(
+        &self,
+        mut info: um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    ) -> Result<(), SystemError> {
+        if unsafe {
+            um::jobapi2::SetInformationJobObject(
+                self.handle,
+                um::winnt::JobObjectExtendedLimitInformation,
+                &mut info as *mut _ as LPVOID,
+                mem::size_of::<um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as DWORD,
+            )
+        } == 0
+        {
+            return Err(SystemError::last().into());
+        }
+        Ok(())
+    }
+
+    fn create_job(proc: HANDLE) -> Result<HANDLE, SystemError> {
+        let handle = unsafe { um::jobapi2::CreateJobObjectW(ptr::null_mut(), ptr::null()) };
+        if handle.is_null() {
+            return Err(SystemError::NullPointer(format!("JobObject handle")).into());
+        }
+        if unsafe { um::jobapi2::AssignProcessToJobObject(handle, proc) } == 0 {
+            return Err(SystemError::last().into());
+        }
+
+        Ok(handle)
+    }
+}
+
+impl Drop for JobObject {
+    fn drop(&mut self) {
+        if unsafe { um::handleapi::CloseHandle(self.handle) } == 0 {
+            log::error!("{:?}", SystemError::last());
+        }
+    }
+}
+
+fn process_handle(pid: Option<u32>) -> Result<HANDLE, SystemError> {
+    match pid {
+        Some(pid) => {
+            let handle = unsafe {
+                um::processthreadsapi::OpenProcess(
+                    um::winnt::PROCESS_TERMINATE
+                        | um::winnt::PROCESS_QUERY_INFORMATION
+                        | um::winnt::PROCESS_QUERY_LIMITED_INFORMATION
+                        | um::winnt::PROCESS_SET_INFORMATION
+                        | um::winnt::PROCESS_SET_LIMITED_INFORMATION
+                        | um::winnt::PROCESS_SET_QUOTA,
+                    0,
+                    pid,
+                )
+            };
+            if handle.is_null() {
+                return Err(SystemError::NullPointer(format!("process {} handle", pid)).into());
+            }
+            Ok(handle)
+        }
+        _ => {
+            let handle = unsafe { um::processthreadsapi::GetCurrentProcess() };
+            Ok(handle)
+        }
+    }
+}

--- a/exe-unit/src/runtime.rs
+++ b/exe-unit/src/runtime.rs
@@ -7,12 +7,7 @@ use std::path::PathBuf;
 pub mod process;
 
 pub trait Runtime:
-    Actor<Context = Context<Self>>
-    + Handler<Shutdown>
-    + Handler<ExecCmd>
-    + Handler<SetTaskPackagePath>
-    + Send
-    + Sync
+    Actor<Context = Context<Self>> + Handler<Shutdown> + Handler<ExecCmd> + Handler<SetTaskPackagePath>
 {
 }
 

--- a/exe-unit/src/runtime/process.rs
+++ b/exe-unit/src/runtime/process.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use crate::message::{ExecCmd, ExecCmdResult, SetTaskPackagePath, Shutdown};
+use crate::process::ProcessTree;
 use crate::runtime::{Runtime, RuntimeArgs};
 use crate::ExeUnitContext;
 use actix::prelude::*;
@@ -7,7 +8,7 @@ use futures::prelude::*;
 use std::collections::HashSet;
 use std::ffi::OsString;
 use std::path::PathBuf;
-use std::process::{Output, Stdio};
+use std::process::Stdio;
 use tokio::process::Command;
 use ya_client_model::activity::{CommandResult, ExeScriptCommand};
 
@@ -26,7 +27,7 @@ pub struct RuntimeProcess {
     binary: PathBuf,
     runtime_args: RuntimeArgs,
     task_package_path: Option<PathBuf>,
-    children: HashSet<u32>,
+    children: HashSet<ProcessTree>,
 }
 
 impl RuntimeProcess {
@@ -67,22 +68,25 @@ impl Actor for RuntimeProcess {
 
 #[derive(Debug, Message)]
 #[rtype("()")]
-struct AddChild(u32);
+struct AddProcessTree(ProcessTree);
 
 #[derive(Debug, Message)]
 #[rtype("()")]
-struct RemoveChild(u32);
+struct RemoveProcessTree(ProcessTree);
 
 impl Handler<ExecCmd> for RuntimeProcess {
     type Result = ActorResponse<Self, ExecCmdResult, Error>;
 
     fn handle(&mut self, msg: ExecCmd, ctx: &mut Self::Context) -> Self::Result {
         let cmd_args = match msg.0.clone() {
-            ExeScriptCommand::Deploy {} => Some(vec![OsString::from("deploy")]),
+            ExeScriptCommand::Deploy {} => {
+                let result = vec![OsString::from("deploy")];
+                result
+            }
             ExeScriptCommand::Start { args } => {
                 let mut result = vec![OsString::from("start")];
                 result.extend(args.into_iter().map(OsString::from));
-                Some(result)
+                result
             }
             ExeScriptCommand::Run { entry_point, args } => {
                 let mut result = vec![
@@ -91,57 +95,55 @@ impl Handler<ExecCmd> for RuntimeProcess {
                     OsString::from(entry_point),
                 ];
                 result.extend(args.into_iter().map(OsString::from));
-                Some(result)
+                result
             }
-            _ => None,
+            _ => {
+                let fut = futures::future::ok(ExecCmdResult {
+                    result: CommandResult::Ok,
+                    stdout: None,
+                    stderr: None,
+                });
+                return ActorResponse::r#async(fut.into_actor(self));
+            }
         };
 
         let address = ctx.address();
-        match cmd_args {
-            Some(cmd_args) => {
-                let binary = self.binary.clone();
-                let args = self.args(cmd_args);
-                let current_path = std::env::current_dir();
-                log::info!(
-                    "Executing {:?} with {:?} from path {:?}",
-                    binary,
-                    args,
-                    current_path
-                );
+        let binary = self.binary.clone();
+        let args = self.args(cmd_args);
+        let current_path = std::env::current_dir();
+        log::info!(
+            "Executing {:?} with {:?} from path {:?}",
+            binary,
+            args,
+            current_path
+        );
 
-                let fut = async move {
-                    let child = Command::new(binary)
-                        .kill_on_drop(true)
-                        .args(args?)
-                        .stdout(Stdio::piped())
-                        .stderr(Stdio::piped())
-                        .spawn()?;
-                    let pid = child.id();
+        let fut = async move {
+            let child = Command::new(binary)
+                .kill_on_drop(true)
+                .args(args?)
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()?;
 
-                    address.do_send(AddChild(pid));
-                    let result = child.wait_with_output().await;
-                    address.do_send(RemoveChild(pid));
-                    let output = result?;
+            let tree =
+                ProcessTree::try_new(child.id()).map_err(|e| Error::RuntimeError(e.to_string()))?;
 
-                    Ok(ExecCmdResult {
-                        result: output_to_result(&output),
-                        stdout: Some(vec_to_string(output.stdout)),
-                        stderr: Some(vec_to_string(output.stderr)),
-                    })
-                };
-                ActorResponse::r#async(fut.into_actor(self))
-            }
-            None => {
-                let fut = async {
-                    Ok(ExecCmdResult {
-                        result: CommandResult::Ok,
-                        stdout: None,
-                        stderr: None,
-                    })
-                };
-                ActorResponse::r#async(fut.into_actor(self))
-            }
-        }
+            address.do_send(AddProcessTree(tree.clone()));
+            let result = child.wait_with_output().await;
+            address.do_send(RemoveProcessTree(tree));
+            let output = result?;
+
+            Ok(ExecCmdResult {
+                result: match output.status.success() {
+                    true => CommandResult::Ok,
+                    _ => CommandResult::Error,
+                },
+                stdout: Some(vec_to_string(output.stdout)),
+                stderr: Some(vec_to_string(output.stderr)),
+            })
+        };
+        ActorResponse::r#async(fut.into_actor(self))
     }
 }
 
@@ -153,18 +155,18 @@ impl Handler<SetTaskPackagePath> for RuntimeProcess {
     }
 }
 
-impl Handler<AddChild> for RuntimeProcess {
-    type Result = <AddChild as Message>::Result;
+impl Handler<AddProcessTree> for RuntimeProcess {
+    type Result = <AddProcessTree as Message>::Result;
 
-    fn handle(&mut self, msg: AddChild, _: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: AddProcessTree, _: &mut Self::Context) -> Self::Result {
         self.children.insert(msg.0);
     }
 }
 
-impl Handler<RemoveChild> for RuntimeProcess {
-    type Result = <RemoveChild as Message>::Result;
+impl Handler<RemoveProcessTree> for RuntimeProcess {
+    type Result = <RemoveProcessTree as Message>::Result;
 
-    fn handle(&mut self, msg: RemoveChild, _: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: RemoveProcessTree, _: &mut Self::Context) -> Self::Result {
         self.children.remove(&msg.0);
     }
 }
@@ -174,18 +176,10 @@ impl Handler<Shutdown> for RuntimeProcess {
 
     fn handle(&mut self, _: Shutdown, _: &mut Self::Context) -> Self::Result {
         let timeout = process_kill_timeout_seconds();
-        future::join_all(self.children.drain().map(|p| kill_pid(p, timeout)))
+        let futs = self.children.drain().map(move |t| t.kill(timeout));
+        futures::future::join_all(futs)
             .map(|_| Ok(()))
             .boxed_local()
-    }
-}
-
-#[inline]
-fn output_to_result(output: &Output) -> CommandResult {
-    if output.status.success() {
-        CommandResult::Ok
-    } else {
-        CommandResult::Error
     }
 }
 
@@ -197,57 +191,5 @@ fn vec_to_string(vec: Vec<u8>) -> String {
             .into_iter()
             .map(|&c| c as char)
             .collect::<String>(),
-    }
-}
-
-#[cfg(windows)]
-async fn kill_pid(_: u32, _: i64) {
-    // FIXME: implement for win32
-    unimplemented!()
-}
-
-#[cfg(not(windows))]
-async fn kill_pid(pid: u32, timeout: i64) {
-    use chrono::Local;
-    use nix::sys::signal;
-    use nix::sys::wait::{waitpid, WaitPidFlag, WaitStatus};
-    use nix::unistd::Pid;
-    use std::time::Duration;
-
-    fn alive(pid: Pid) -> bool {
-        match waitpid(pid, Some(WaitPidFlag::WNOHANG)) {
-            Ok(status) => match status {
-                WaitStatus::Exited(_, _) | WaitStatus::Signaled(_, _, _) => false,
-                _ => true,
-            },
-            _ => false,
-        }
-    }
-
-    let pid = Pid::from_raw(pid as i32);
-    let delay = Duration::from_secs_f32(timeout as f32 / 10.);
-    let started = Local::now().timestamp();
-
-    if let Ok(_) = signal::kill(pid, signal::Signal::SIGTERM) {
-        log::info!("Sent SIGTERM to process {:?}", pid);
-
-        loop {
-            let elapsed = Local::now().timestamp() >= started + timeout as i64;
-            match alive(pid) {
-                true => {
-                    if elapsed {
-                        log::info!("Sending SIGKILL to process {:?}", pid);
-                        if let Ok(_) = signal::kill(pid, signal::Signal::SIGKILL) {
-                            let _ = waitpid(pid, None);
-                        }
-                    }
-                }
-                _ => break,
-            }
-            match elapsed {
-                true => break,
-                _ => tokio::time::delay_for(delay).await,
-            }
-        }
     }
 }


### PR DESCRIPTION
- move out `Process` and `JobObject` out of `crate::metrics`
- terminate _child_ processes belonging to a process group id on macOS and linux
- terminate `JobObject`s (process groups) on Windows