### PR TITLE
Provider agent: save preset coefficients as a map instead of a vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3889,10 +3889,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "530efb820d53b712f4e347916c5e7ed20deb76a4f0457943b3182fb889b06d2c"
 
 [[package]]
+name = "strum"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
+
+[[package]]
 name = "strum_macros"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6e163a520367c465f59e0a61a23cfae3b10b6546d78b6f672a382be79f7110"
+dependencies = [
+ "heck",
+ "proc-macro2 1.0.18",
+ "quote 1.0.6",
+ "syn 1.0.30",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck",
  "proc-macro2 1.0.18",
@@ -5282,6 +5300,8 @@ dependencies = [
  "serde_json",
  "shared_child",
  "structopt",
+ "strum 0.18.0",
+ "strum_macros 0.18.0",
  "sys-info",
  "thiserror",
  "tokio 0.2.21",
@@ -5406,8 +5426,8 @@ dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.6",
  "structopt",
- "strum",
- "strum_macros",
+ "strum 0.17.1",
+ "strum_macros 0.17.1",
  "syn 1.0.30",
  "ya-service-api-interfaces",
 ]

--- a/agent/provider/Cargo.toml
+++ b/agent/provider/Cargo.toml
@@ -38,6 +38,8 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0"
 shared_child = "0.3.4"
 structopt = "0.3.8"
+strum = "0.18.0"
+strum_macros = "0.18.0"
 sys-info = "0.7.0"
 thiserror = "1.0.14"
 tokio = { version = "0.2.10", features = ["process", "signal"] }


### PR DESCRIPTION
Presets now consist of a coefficient - value map instead of a value vector. This allows the preset to be valid in situations, where we choose a different subset / order of the coefficients.

Targets #348