### PR TITLE
Various path-related fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5753,6 +5753,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "log 0.4.8",
+ "percent-encoding 2.1.0",
  "rand 0.7.3",
  "serde",
  "sha2 0.8.2",

--- a/agent/provider/src/execution/task_runner.rs
+++ b/agent/provider/src/execution/task_runner.rs
@@ -138,14 +138,15 @@ pub struct TaskRunner {
 }
 
 impl TaskRunner {
-    pub fn new(
+    pub fn new<P: AsRef<Path>>(
         client: ActivityProviderApi,
         config: TaskRunnerConfig,
         registry: ExeUnitsRegistry,
+        data_dir: P,
     ) -> Result<TaskRunner> {
-        let current_dir = std::env::current_dir()?;
-        let tasks_dir = current_dir.join("exe-unit").join("work");
-        let cache_dir = current_dir.join("exe-unit").join("cache");
+        let data_dir = data_dir.as_ref().to_path_buf();
+        let tasks_dir = data_dir.join("exe-unit").join("work");
+        let cache_dir = data_dir.join("exe-unit").join("cache");
 
         log::debug!("TaskRunner config: {:?}", config);
 
@@ -167,9 +168,9 @@ impl TaskRunner {
 
         // Try convert to str to check if won't fail. If not we can than
         // unwrap() all paths that we created relative to current_dir.
-        current_dir.to_str().ok_or(anyhow!(
+        data_dir.to_str().ok_or(anyhow!(
             "Current dir [{}] contains invalid characters.",
-            current_dir.display()
+            data_dir.display()
         ))?;
 
         Ok(TaskRunner {

--- a/agent/provider/src/hardware.rs
+++ b/agent/provider/src/hardware.rs
@@ -73,11 +73,11 @@ impl Resources {
         }
     }
 
-    pub fn try_new(work_dir: &Path) -> Result<Self, Error> {
+    pub fn try_new(path: &Path) -> Result<Self, Error> {
         Ok(Resources {
             cpu_threads: num_cpus::get() as i32,
             mem_gib: 1000. * sys_info::mem_info()?.total as f64 / (1024. * 1024. * 1024.),
-            storage_gib: partition_space(work_dir)? as f64 / (1024. * 1024. * 1024.),
+            storage_gib: partition_space(path)? as f64 / (1024. * 1024. * 1024.),
         })
     }
 
@@ -182,8 +182,13 @@ impl Profiles {
         match path.exists() {
             true => Self::load(path),
             false => {
-                let current_dir = std::env::current_dir()?;
-                let profiles = Self::try_default(&current_dir)?;
+                if let Some(p) = path.parent() {
+                    std::fs::create_dir_all(p)?;
+                }
+                if !path.exists() {
+                    std::fs::File::create(&path)?;
+                }
+                let profiles = Self::try_default(&path)?;
                 profiles.save(path)?;
                 Ok(profiles)
             }
@@ -205,8 +210,8 @@ impl Profiles {
         Ok(path.swap_save(serde_json::to_string_pretty(self)?)?)
     }
 
-    fn try_default<P: AsRef<Path>>(work_dir: P) -> Result<Self, Error> {
-        let resources = Resources::try_default(work_dir.as_ref())?;
+    fn try_default<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let resources = Resources::try_default(path.as_ref())?;
         let active = DEFAULT_PROFILE_NAME.to_string();
         let profiles = vec![(active.clone(), resources)].into_iter().collect();
         Ok(Profiles { active, profiles })
@@ -315,11 +320,10 @@ impl ManagerState {
 
 impl Manager {
     pub fn try_new<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
-        let current_dir = std::env::current_dir()?;
         let profiles = Profiles::load_or_create(&path)?;
         let mut state = ManagerState {
             profiles,
-            res_available: Resources::try_new(&current_dir)?,
+            res_available: Resources::try_new(path.as_ref())?,
             res_cap: Resources::new_empty(),
             res_remaining: Resources::new_empty(),
             res_alloc: HashMap::new(),

--- a/agent/provider/src/provider_agent.rs
+++ b/agent/provider/src/provider_agent.rs
@@ -27,6 +27,7 @@ pub struct ProviderAgent {
 
 impl ProviderAgent {
     pub async fn new(args: RunConfig, config: ProviderConfig) -> anyhow::Result<ProviderAgent> {
+        let data_dir = config.data_dir.get_or_create()?.as_path().to_path_buf();
         let api = ProviderApi::try_from(&args.api)?;
         let registry = config.registry()?;
         registry.validate()?;
@@ -38,7 +39,7 @@ impl ProviderAgent {
 
         let market = ProviderMarket::new(api.market, "LimitAgreements").start();
         let payments = Payments::new(api.activity.clone(), api.payment).start();
-        let runner = TaskRunner::new(api.activity, args.runner_config.clone(), registry)?.start();
+        let runner = TaskRunner::new(api.activity, args.runner_config, registry, data_dir)?.start();
         let task_manager = TaskManager::new(market.clone(), runner.clone(), payments)?.start();
         let node_info = ProviderAgent::create_node_info(&args.node).await;
 

--- a/agent/requestor/src/main.rs
+++ b/agent/requestor/src/main.rs
@@ -15,7 +15,7 @@ mod market;
 mod payment;
 
 const DEFAULT_NODE_NAME: &str = "test1";
-const DEFAULT_TASK_PACKAGE: &str = "hash://sha3:38D951E2BD2408D95D8D5E5068A69C60C8238FA45DB8BC841DC0BD50:http://34.244.4.185:8000/rust-wasi-tutorial.zip";
+const DEFAULT_TASK_PACKAGE: &str = "hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip";
 
 #[derive(StructOpt)]
 #[structopt(rename_all = "kebab-case")]

--- a/core/market/resolver/tests/expression_resolve.rs
+++ b/core/market/resolver/tests/expression_resolve.rs
@@ -560,7 +560,7 @@ fn resolve_pseudo_function_array_sample_undefined() {
 #[test]
 fn resolve_wildcard_prop_sample_undefined() {
     // this syntax should work, and should return "undefined" for property declared with wildcards.
-    let f = r#"(golem.srv.comp.wasm.task_package=hash://sha3:38D951E2BD2408D95D8D5E5068A69C60C8238FA45DB8BC841DC0BD50:http://34.244.4.185:8000/rust-wasi-tutorial.zip)"#;
+    let f = r#"(golem.srv.comp.wasm.task_package=hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip)"#;
 
     // test positive
 
@@ -569,7 +569,7 @@ fn resolve_wildcard_prop_sample_undefined() {
                             ], ResolveResult::Undefined(
                                 vec![&PropertyRef::Value(String::from("golem.srv.comp.wasm.task_package"), PropertyRefType::Any)],
                                 Expression::Equals(PropertyRef::Value(String::from("golem.srv.comp.wasm.task_package"), PropertyRefType::Any), 
-                                                   String::from("hash://sha3:38D951E2BD2408D95D8D5E5068A69C60C8238FA45DB8BC841DC0BD50:http://34.244.4.185:8000/rust-wasi-tutorial.zip"))
+                                                   String::from("hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip"))
                             ));
 }
 

--- a/core/market/resolver/tests/sample/mod.rs
+++ b/core/market/resolver/tests/sample/mod.rs
@@ -92,7 +92,7 @@ pub static POC_DEMAND_PROPERTIES_JSON: &str = r#"
   "golem.node.debug.subnet": "piotr",
   "golem.node.id.name": "test1",
   "golem.srv.comp.expiration": 1590765503361,
-  "golem.srv.comp.wasm.task_package": "hash://sha3:38D951E2BD2408D95D8D5E5068A69C60C8238FA45DB8BC841DC0BD50:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
+  "golem.srv.comp.wasm.task_package": "hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
 }"#;
 
 pub static POC_DEMAND_PROPERTIES_JSON_DEEP: &str = r#"
@@ -104,7 +104,7 @@ pub static POC_DEMAND_PROPERTIES_JSON_DEEP: &str = r#"
     },
     "srv.comp": {
       "expiration": 1590765503361,
-      "wasm.task_package": "hash://sha3:38D951E2BD2408D95D8D5E5068A69C60C8238FA45DB8BC841DC0BD50:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
+      "wasm.task_package": "hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
     }
   }
 }"#;
@@ -113,7 +113,7 @@ pub static POC_DEMAND_PROPERTIES_FLAT: &'static [&'static str] = &[
     "golem.node.debug.subnet=\"piotr\"",
     "golem.node.id.name=\"test1\"",
     "golem.srv.comp.expiration=1590765503361",
-    "golem.srv.comp.wasm.task_package=\"hash://sha3:38D951E2BD2408D95D8D5E5068A69C60C8238FA45DB8BC841DC0BD50:http://34.244.4.185:8000/rust-wasi-tutorial.zip\""
+    "golem.srv.comp.wasm.task_package=\"hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip\""
 ];
 
 pub static POC_DEMAND_CONSTRAINTS: &'static str = r#"

--- a/exe-unit/examples/agreement.json
+++ b/exe-unit/examples/agreement.json
@@ -4,7 +4,7 @@
     "properties": {
       "golem": {
         "srv.comp": {
-          "task_package": "hash://sha3:38D951E2BD2408D95D8D5E5068A69C60C8238FA45DB8BC841DC0BD50:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
+          "task_package": "hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
         }
       }
     }

--- a/exe-unit/src/service/transfer.rs
+++ b/exe-unit/src/service/transfer.rs
@@ -17,7 +17,7 @@ use url::Url;
 use ya_transfer::error::Error as TransferError;
 use ya_transfer::{
     transfer, FileTransferProvider, GftpTransferProvider, HashStream, HttpTransferProvider,
-    TransferData, TransferProvider, TransferSink, TransferStream,
+    TransferData, TransferProvider, TransferSink, TransferStream, UrlExt,
 };
 
 #[derive(Clone, Debug, Message)]
@@ -119,7 +119,7 @@ impl TransferProvider<TransferData, TransferError> for ContainerTransferProvider
     }
 
     fn source(&self, url: &Url) -> TransferStream<TransferData, TransferError> {
-        let file_url = match self.resolve_url(url.path()) {
+        let file_url = match self.resolve_url(url.path_decoded().as_str()) {
             Ok(v) => v,
             Err(e) => return TransferStream::err(e),
         };
@@ -127,7 +127,7 @@ impl TransferProvider<TransferData, TransferError> for ContainerTransferProvider
     }
 
     fn destination(&self, url: &Url) -> TransferSink<TransferData, TransferError> {
-        let file_url = match self.resolve_url(url.path()) {
+        let file_url = match self.resolve_url(url.path_decoded().as_str()) {
             Ok(v) => v,
             Err(e) => return TransferSink::err(e),
         };
@@ -369,7 +369,7 @@ impl Cache {
             None => return Err(TransferError::InvalidUrlError("hash required".to_owned()).into()),
         };
 
-        let name = transfer_url.file_name();
+        let name = transfer_url.file_name()?;
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()

--- a/test-utils/linux-test-scripts/test1/agreement.json
+++ b/test-utils/linux-test-scripts/test1/agreement.json
@@ -4,7 +4,7 @@
     "properties": {
       "golem": {
         "srv.comp.wasm": {
-          "task_package": "hash://sha3:38D951E2BD2408D95D8D5E5068A69C60C8238FA45DB8BC841DC0BD50:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
+          "task_package": "hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
         },
         "com.usage.vector": [
           "golem.usage.duration_sec",

--- a/test-utils/win-test-scripts/test1/agreement.json
+++ b/test-utils/win-test-scripts/test1/agreement.json
@@ -4,7 +4,7 @@
     "properties": {
       "golem": {
         "srv.comp.wasm": {
-          "task_package": "hash://sha3:38D951E2BD2408D95D8D5E5068A69C60C8238FA45DB8BC841DC0BD50:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
+          "task_package": "hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
         }
       }
     }

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -19,6 +19,7 @@ futures = { version = "0.3.4" }
 hex = "0.4.2"
 lazy_static = "1.4.0"
 log = "0.4.8"
+percent-encoding = "2.1"
 serde = "1.0.104"
 sha3 = "0.8.2"
 thiserror = "1.0.11"

--- a/utils/transfer/src/file.rs
+++ b/utils/transfer/src/file.rs
@@ -1,6 +1,7 @@
 use crate::error::Error;
 use crate::{
     abortable_sink, abortable_stream, TransferData, TransferProvider, TransferSink, TransferStream,
+    UrlExt,
 };
 use bytes::BytesMut;
 use futures::future::ready;
@@ -18,33 +19,20 @@ impl Default for FileTransferProvider {
     }
 }
 
-#[cfg(windows)]
-fn extract_file_url(url: &Url) -> String {
-    // On Windows, Rust implementation of Url::parse() adds a third '/' after the 'file://' indicator,
-    // thus making .path() method unusable for the purposes of file creation (because File::create() will not accept that),
-    // and therefore - Url hardly usable for carrying absolute file paths...
-    url.as_str().to_owned().replace("file:///", "")
-}
-
-#[cfg(not(windows))]
-fn extract_file_url(url: &Url) -> String {
-    url.path().to_owned()
-}
-
 impl TransferProvider<TransferData, Error> for FileTransferProvider {
     fn schemes(&self) -> Vec<&'static str> {
         vec!["file"]
     }
 
     fn source(&self, url: &Url) -> TransferStream<TransferData, Error> {
-        let url = extract_file_url(url);
-
         let (stream, tx, abort_reg) = TransferStream::<TransferData, Error>::create(1);
         let txc = tx.clone();
+        let url = url.clone();
 
         tokio::task::spawn_local(async move {
             let fut = async move {
-                let file = File::open(url).await?;
+                let path = url.path_decoded();
+                let file = File::open(&path).await?;
                 FramedRead::new(file, BytesCodec::new())
                     .map_ok(BytesMut::freeze)
                     .map_err(Error::from)
@@ -64,17 +52,15 @@ impl TransferProvider<TransferData, Error> for FileTransferProvider {
     }
 
     fn destination(&self, url: &Url) -> TransferSink<TransferData, Error> {
-        let url = extract_file_url(url);
-
-        log::info!("destination url: {}", url);
-
         let (sink, mut rx, res_tx) = TransferSink::<TransferData, Error>::create(1);
+        let url = url.clone();
+        let url_f = url.clone();
 
         //TODO: Return Result from function if file creation fails.
         tokio::task::spawn_local(async move {
-            let local_url = url.clone();
+            let path = url_f.path_decoded();
             let fut = async move {
-                let mut file = File::create(url.clone()).await?;
+                let mut file = File::create(&path).await?;
                 while let Some(result) = rx.next().await {
                     file.write_all(&result?.into_bytes()).await?;
                 }
@@ -83,7 +69,7 @@ impl TransferProvider<TransferData, Error> for FileTransferProvider {
                 Result::<(), Error>::Ok(())
             }
             .map_err(|error| {
-                log::error!("Error opening destination file [{}]: {}", local_url, error);
+                log::error!("Error opening destination file [{}]: {}", url, error);
                 Error::from(error)
             });
 

--- a/utils/transfer/src/lib.rs
+++ b/utils/transfer/src/lib.rs
@@ -2,8 +2,10 @@ pub mod error;
 mod file;
 mod gftp;
 mod http;
+mod util;
 
 use crate::error::{ChannelError, Error};
+use actix_rt::Arbiter;
 use bytes::Bytes;
 use futures::channel::mpsc::{channel, Receiver, Sender};
 use futures::channel::oneshot;
@@ -18,7 +20,7 @@ use url::Url;
 pub use crate::file::FileTransferProvider;
 pub use crate::gftp::GftpTransferProvider;
 pub use crate::http::HttpTransferProvider;
-use actix_rt::Arbiter;
+pub use crate::util::UrlExt;
 
 pub async fn transfer<S, T>(stream: S, mut sink: TransferSink<T, Error>) -> Result<(), Error>
 where

--- a/utils/transfer/src/util.rs
+++ b/utils/transfer/src/util.rs
@@ -1,0 +1,13 @@
+use percent_encoding::percent_decode;
+
+pub trait UrlExt {
+    fn path_decoded(&self) -> String;
+}
+
+impl UrlExt for url::Url {
+    fn path_decoded(&self) -> String {
+        percent_decode(self.path().as_bytes())
+            .decode_utf8_lossy()
+            .to_string()
+    }
+}


### PR DESCRIPTION
Provider:
- create `work` and `cache` sub-directories in a working directory
- use any existing path for hw configuration (free partition space)

Transfer:
- use url-decoded Url::path()

Deploy package path:
- fix deploy image's SHA-3 sum