### PR TITLE
Add GSB endpoint for receiving RuntimeEvent

### DIFF
--- a/core/activity/migrations/2020-07-15-084557_runtime_event/down.sql
+++ b/core/activity/migrations/2020-07-15-084557_runtime_event/down.sql
@@ -1,0 +1,3 @@
+DROP TABLE "runtime_event";
+
+DROP TABLE "runtime_event_type";

--- a/core/activity/migrations/2020-07-15-084557_runtime_event/up.sql
+++ b/core/activity/migrations/2020-07-15-084557_runtime_event/up.sql
@@ -1,0 +1,24 @@
+CREATE TABLE "runtime_event" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "activity_id" INTEGER NOT NULL,
+    "batch_id" VARCHAR(255) NOT NULL,
+    "index" INTEGER NOT NULL,
+    "timestamp" DATETIME NOT NULL,
+    "type_id" INTEGER NOT NULL,
+    "command" TEXT,
+    "return_code" INTEGER,
+    "message" TEXT,
+    FOREIGN KEY("activity_id") REFERENCES "activity" ("id"),
+    FOREIGN KEY("type_id") REFERENCES "runtime_event_type" ("id")
+);
+
+CREATE TABLE "runtime_event_type"(
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" VARCHAR(50) NOT NULL
+);
+
+INSERT INTO "runtime_event_type"("name") VALUES
+    ("Started"),
+    ("Finished"),
+    ("StdOut"),
+    ("StdErr");

--- a/core/activity/src/dao/mod.rs
+++ b/core/activity/src/dao/mod.rs
@@ -7,8 +7,8 @@ mod runtime_event;
 pub use activity::ActivityDao;
 pub use activity_state::ActivityStateDao;
 pub use activity_usage::ActivityUsageDao;
-pub use runtime_event::RuntimeEventDao;
 pub use event::{Event, EventDao};
+pub use runtime_event::RuntimeEventDao;
 use thiserror::Error;
 
 type Result<T> = std::result::Result<T, DaoError>;

--- a/core/activity/src/dao/mod.rs
+++ b/core/activity/src/dao/mod.rs
@@ -2,6 +2,7 @@ mod activity;
 mod activity_state;
 mod activity_usage;
 mod event;
+mod runtime_event;
 
 pub use activity::ActivityDao;
 pub use activity_state::ActivityStateDao;

--- a/core/activity/src/dao/mod.rs
+++ b/core/activity/src/dao/mod.rs
@@ -7,6 +7,7 @@ mod runtime_event;
 pub use activity::ActivityDao;
 pub use activity_state::ActivityStateDao;
 pub use activity_usage::ActivityUsageDao;
+pub use runtime_event::RuntimeEventDao;
 pub use event::{Event, EventDao};
 use thiserror::Error;
 

--- a/core/activity/src/dao/runtime_event.rs
+++ b/core/activity/src/dao/runtime_event.rs
@@ -1,10 +1,10 @@
 use diesel::prelude::*;
-use diesel::sql_types::{Integer, Text, Timestamp};
 
+use ya_core_model::activity::{RuntimeEvent as RpcRuntimeEvent, RuntimeEventKind};
 use ya_persistence::executor::{do_with_transaction, AsDao, PoolType};
 
 use crate::dao::Result;
-use crate::db::{models::RuntimeEvent, models::RuntimeEventType, schema};
+use crate::db::{models::RuntimeEventType, schema};
 
 pub struct RuntimeEventDao<'c> {
     pool: &'c PoolType,
@@ -20,9 +20,64 @@ impl<'c> RuntimeEventDao<'c> {
     pub async fn create(
         &self,
         activity_id: &str,
-        event_type: RuntimeEventType,
+        event: RpcRuntimeEvent,
     ) -> Result<i32> {
-        // TODO
-        Ok(42)
+
+        //use schema::activity::dsl;
+        use schema::runtime_event::dsl as dsl_event;
+
+        let activity_id = activity_id.to_owned();
+
+        do_with_transaction(self.pool, move |conn| {
+            diesel::insert_into(dsl_event::runtime_event)
+            .values((
+                dsl_event::activity_id.eq(0 // TODO
+                    /*dsl::activity
+                    .select((
+                        dsl::id,
+                    ))
+                    .filter(dsl::natural_id.eq(activity_id))
+                    .limit(1)
+                    .get_result(conn)?*/),
+                dsl_event::batch_id.eq(event.batch_id),
+                dsl_event::index.eq(event.index as i32),
+                dsl_event::timestamp.eq(event.timestamp),
+                dsl_event::type_id.eq(
+                    match event.kind {
+                        RuntimeEventKind::Started{ command: _ } => RuntimeEventType::Started,
+                        RuntimeEventKind::Finished{ return_code: _, message: _ } => RuntimeEventType::Finished,
+                        RuntimeEventKind::StdOut(_) => RuntimeEventType::StdOut,
+                        RuntimeEventKind::StdErr(_) => RuntimeEventType::StdErr,
+                    }
+                ),
+                dsl_event::command.eq(
+                    match event.kind {
+                        RuntimeEventKind::Started{ command } => Some(serde_json::to_string(&command)?),
+                        _ => None
+                    }
+                ),
+                dsl_event::return_code.eq(
+                    match event.kind {
+                        RuntimeEventKind::Finished{ return_code, message: _ } => Some(return_code),
+                        _ => None,
+                    },
+                ),
+                dsl_event::message.eq(
+                    match event.kind {
+                        RuntimeEventKind::Finished{ return_code: _, message } => message,
+                        RuntimeEventKind::StdOut(msg) => Some(msg),
+                        RuntimeEventKind::StdErr(msg) => Some(msg),
+                        _ => None,
+                    }
+                ),
+            ))
+            .execute(conn)?;
+
+            let event_id = diesel::select(super::last_insert_rowid).first(conn)?;
+            log::trace!("runtime event inserted: {}", event_id);
+
+            Ok(event_id)
+        })
+        .await
     }
 }

--- a/core/activity/src/dao/runtime_event.rs
+++ b/core/activity/src/dao/runtime_event.rs
@@ -1,10 +1,13 @@
 use diesel::prelude::*;
 
-use ya_core_model::activity::{RuntimeEvent as RpcRuntimeEvent, RuntimeEventKind};
+use ya_client_model::activity::{RuntimeEvent as RpcRuntimeEvent, RuntimeEventKind};
 use ya_persistence::executor::{do_with_transaction, AsDao, PoolType};
 
-use crate::dao::Result;
-use crate::db::{models::RuntimeEventType, schema};
+use crate::dao::{DaoError, Result};
+use crate::db::{
+    models::{Activity, RuntimeEventType},
+    schema,
+};
 
 pub struct RuntimeEventDao<'c> {
     pool: &'c PoolType,
@@ -17,61 +20,61 @@ impl<'a> AsDao<'a> for RuntimeEventDao<'a> {
 }
 
 impl<'c> RuntimeEventDao<'c> {
-    pub async fn create(
-        &self,
-        activity_id: &str,
-        event: RpcRuntimeEvent,
-    ) -> Result<i32> {
-
-        //use schema::activity::dsl;
+    pub async fn create(&self, activity_id: &str, event: RpcRuntimeEvent) -> Result<i32> {
+        use schema::activity::dsl;
         use schema::runtime_event::dsl as dsl_event;
 
         let activity_id = activity_id.to_owned();
 
         do_with_transaction(self.pool, move |conn| {
             diesel::insert_into(dsl_event::runtime_event)
-            .values((
-                dsl_event::activity_id.eq(0 // TODO
-                    /*dsl::activity
-                    .select((
-                        dsl::id,
-                    ))
-                    .filter(dsl::natural_id.eq(activity_id))
-                    .limit(1)
-                    .get_result(conn)?*/),
-                dsl_event::batch_id.eq(event.batch_id),
-                dsl_event::index.eq(event.index as i32),
-                dsl_event::timestamp.eq(event.timestamp),
-                dsl_event::type_id.eq(
-                    match event.kind {
-                        RuntimeEventKind::Started{ command: _ } => RuntimeEventType::Started,
-                        RuntimeEventKind::Finished{ return_code: _, message: _ } => RuntimeEventType::Finished,
+                .values((
+                    dsl_event::activity_id.eq(dsl::activity
+                        .filter(dsl::natural_id.eq(&activity_id))
+                        .first::<Activity>(conn)
+                        .map_err(|e| match e {
+                            diesel::NotFound => {
+                                DaoError::NotFound(format!("activity {}", &activity_id))
+                            }
+                            e => e.into(),
+                        })?
+                        .id),
+                    dsl_event::batch_id.eq(event.batch_id),
+                    dsl_event::index.eq(event.index as i32),
+                    dsl_event::timestamp.eq(event.timestamp),
+                    dsl_event::type_id.eq(match &event.kind {
+                        RuntimeEventKind::Started { command: _ } => RuntimeEventType::Started,
+                        RuntimeEventKind::Finished {
+                            return_code: _,
+                            message: _,
+                        } => RuntimeEventType::Finished,
                         RuntimeEventKind::StdOut(_) => RuntimeEventType::StdOut,
                         RuntimeEventKind::StdErr(_) => RuntimeEventType::StdErr,
-                    }
-                ),
-                dsl_event::command.eq(
-                    match event.kind {
-                        RuntimeEventKind::Started{ command } => Some(serde_json::to_string(&command)?),
-                        _ => None
-                    }
-                ),
-                dsl_event::return_code.eq(
-                    match event.kind {
-                        RuntimeEventKind::Finished{ return_code, message: _ } => Some(return_code),
+                    }),
+                    dsl_event::command.eq(match &event.kind {
+                        RuntimeEventKind::Started { command } => {
+                            Some(serde_json::to_string(&command)?)
+                        }
                         _ => None,
-                    },
-                ),
-                dsl_event::message.eq(
-                    match event.kind {
-                        RuntimeEventKind::Finished{ return_code: _, message } => message,
+                    }),
+                    dsl_event::return_code.eq(match &event.kind {
+                        RuntimeEventKind::Finished {
+                            return_code,
+                            message: _,
+                        } => Some(return_code),
+                        _ => None,
+                    }),
+                    dsl_event::message.eq(match &event.kind {
+                        RuntimeEventKind::Finished {
+                            return_code: _,
+                            message,
+                        } => message.as_ref(),
                         RuntimeEventKind::StdOut(msg) => Some(msg),
                         RuntimeEventKind::StdErr(msg) => Some(msg),
                         _ => None,
-                    }
-                ),
-            ))
-            .execute(conn)?;
+                    }),
+                ))
+                .execute(conn)?;
 
             let event_id = diesel::select(super::last_insert_rowid).first(conn)?;
             log::trace!("runtime event inserted: {}", event_id);

--- a/core/activity/src/dao/runtime_event.rs
+++ b/core/activity/src/dao/runtime_event.rs
@@ -1,0 +1,28 @@
+use diesel::prelude::*;
+use diesel::sql_types::{Integer, Text, Timestamp};
+
+use ya_persistence::executor::{do_with_transaction, AsDao, PoolType};
+
+use crate::dao::Result;
+use crate::db::{models::RuntimeEvent, models::RuntimeEventType, schema};
+
+pub struct RuntimeEventDao<'c> {
+    pool: &'c PoolType,
+}
+
+impl<'a> AsDao<'a> for RuntimeEventDao<'a> {
+    fn as_dao(pool: &'a PoolType) -> Self {
+        RuntimeEventDao { pool }
+    }
+}
+
+impl<'c> RuntimeEventDao<'c> {
+    pub async fn create(
+        &self,
+        activity_id: &str,
+        event_type: RuntimeEventType,
+    ) -> Result<i32> {
+        // TODO
+        Ok(42)
+    }
+}

--- a/core/activity/src/db/models.rs
+++ b/core/activity/src/db/models.rs
@@ -104,3 +104,51 @@ impl std::convert::TryFrom<ActivityUsage> for ya_client_model::activity::Activit
         })
     }
 }
+
+#[derive(Queryable, Debug, Identifiable)]
+#[table_name = "runtime_event"]
+pub struct RuntimeEvent {
+    pub id: i32,
+    pub activity_id: i32,
+    pub batch_id: String,
+    pub index: i32,
+    pub timestamp: NaiveDateTime,
+    pub type_id: RuntimeEventType,
+    pub command: Option<String>,
+    pub return_code: Option<i32>,
+    pub message: Option<String>,
+}
+
+#[derive(AsExpression, FromSqlRow, PartialEq, Debug, Clone, Copy)]
+#[sql_type = "Integer"]
+pub enum RuntimeEventType {
+    Started = 1,
+    Finished = 2,
+    StdOut = 3,
+    StdErr = 4,
+}
+
+impl<DB: Backend> ToSql<Integer, DB> for RuntimeEventType
+where
+    i32: ToSql<Integer, DB>,
+{
+    fn to_sql<W: std::io::Write>(&self, out: &mut Output<W, DB>) -> diesel::serialize::Result {
+        (*self as i32).to_sql(out)
+    }
+}
+
+impl<DB> FromSql<Integer, DB> for RuntimeEventType
+where
+    i32: FromSql<Integer, DB>,
+    DB: Backend,
+{
+    fn from_sql(bytes: Option<&DB::RawValue>) -> deserialize::Result<Self> {
+        Ok(match i32::from_sql(bytes)? {
+            1 => RuntimeEventType::Started,
+            2 => RuntimeEventType::Finished,
+            3 => RuntimeEventType::StdOut,
+            4 => RuntimeEventType::StdErr,
+            _ => return Err(anyhow::anyhow!("invalid value").into()),
+        })
+    }
+}

--- a/core/activity/src/db/schema.rs
+++ b/core/activity/src/db/schema.rs
@@ -43,10 +43,33 @@ table! {
     }
 }
 
+table! {
+    runtime_event (id) {
+        id -> Integer,
+        activity_id -> Integer,
+        batch_id -> Text,
+        index -> Integer,
+        timestamp -> Timestamp,
+        type_id -> Integer,
+        command -> Nullable<Text>,
+        return_code -> Nullable<Integer>,
+        message -> Nullable<Text>,
+    }
+}
+
+table! {
+    runtime_event_type (id) {
+        id -> Integer,
+        name -> Text,
+    }
+}
+
 joinable!(activity -> activity_state (state_id));
 joinable!(activity -> activity_usage (usage_id));
 joinable!(activity_event -> activity (activity_id));
 joinable!(activity_event -> activity_event_type (event_type_id));
+joinable!(runtime_event -> activity (activity_id));
+joinable!(runtime_event -> runtime_event_type (type_id));
 
 allow_tables_to_appear_in_same_query!(
     activity,
@@ -54,4 +77,6 @@ allow_tables_to_appear_in_same_query!(
     activity_event_type,
     activity_state,
     activity_usage,
+    runtime_event,
+    runtime_event_type,
 );

--- a/core/activity/src/requestor/mod.rs
+++ b/core/activity/src/requestor/mod.rs
@@ -1,3 +1,4 @@
 //! Provider side operations
 pub mod control;
+pub mod service;
 pub mod state;

--- a/core/activity/src/requestor/service.rs
+++ b/core/activity/src/requestor/service.rs
@@ -2,15 +2,12 @@ use ya_core_model::activity;
 use ya_persistence::executor::DbExecutor;
 use ya_service_bus::typed::ServiceBinder;
 
-use crate::common::{
-    authorize_activity_initiator, RpcMessageResult,
-};
+use crate::common::{authorize_activity_initiator, RpcMessageResult};
 use crate::dao::*;
 use crate::error::Error;
 
 pub fn bind_gsb(db: &DbExecutor) {
-    ServiceBinder::new(activity::BUS_ID, db, ())
-        .bind(receive_runtime_event_gsb);
+    ServiceBinder::new(activity::BUS_ID, db, ()).bind(receive_runtime_event_gsb);
 }
 
 async fn receive_runtime_event_gsb(

--- a/core/activity/src/requestor/service.rs
+++ b/core/activity/src/requestor/service.rs
@@ -1,0 +1,24 @@
+use ya_core_model::activity::{self, RuntimeEvent, RuntimeEventKind};
+use ya_persistence::executor::DbExecutor;
+use ya_service_bus::{timeout::*, typed::ServiceBinder};
+
+use crate::common::{
+    authorize_activity_initiator, RpcMessageResult,
+};
+use crate::db::models::RuntimeEventType;
+
+pub fn bind_gsb(db: &DbExecutor) {
+    ServiceBinder::new(activity::BUS_ID, db, ())
+        .bind(receive_runtime_event_gsb);
+}
+
+async fn receive_runtime_event_gsb(
+    db: DbExecutor,
+    caller: String,
+    msg: activity::ReceiveRuntimeEvent,
+) -> RpcMessageResult<activity::ReceiveRuntimeEvent> {
+    authorize_activity_initiator(&db, caller, &msg.activity_id).await?;
+
+    // TODO
+    Ok(())
+}

--- a/core/activity/src/service.rs
+++ b/core/activity/src/service.rs
@@ -1,7 +1,7 @@
 use ya_persistence::executor::DbExecutor;
 use ya_service_api_interfaces::{Provider, Service};
 
-use crate::{api, db::migrations, provider};
+use crate::{api, db::migrations, provider, requestor};
 
 pub struct Activity;
 
@@ -14,6 +14,7 @@ impl Activity {
         let db: DbExecutor = ctx.component();
         db.apply_migration(migrations::run_with_output)?;
         provider::service::bind_gsb(&db);
+        requestor::service::bind_gsb(&db);
         Ok(())
     }
 

--- a/core/model/src/activity.rs
+++ b/core/model/src/activity.rs
@@ -134,6 +134,41 @@ impl RpcMessage for GetRunningCommand {
     type Item = ExeScriptCommandState;
     type Error = RpcMessageError;
 }
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeEvent {
+    pub batch_id: String,
+    pub index: usize,
+    pub timestamp: u64,
+    pub kind: RuntimeEventKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum RuntimeEventKind {
+    Started {
+        command: ExeScriptCommand
+    },
+    Finished {
+        return_code: i32,
+        message: Option<String>,
+    },
+    StdOut(String),
+    StdErr(String),
+}
+
+/// Receive runtime event from Supervisor.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReceiveRuntimeEvent {
+    pub activity_id: String,
+    pub event: RuntimeEvent,
+    //pub command_index: Option<usize>,
+}
+
+impl RpcMessage for ReceiveRuntimeEvent {
+    const ID: &'static str = "ReceiveRuntimeEvent";
+    type Item = ();
+    type Error = RpcMessageError;
+}
 
 /// Local activity bus API (used by ExeUnit).
 ///

--- a/core/model/src/activity.rs
+++ b/core/model/src/activity.rs
@@ -3,10 +3,10 @@
 //! Top level objects constitutes public activity API.
 //! Local and Exeunit are in dedicated submodules.
 use serde::{Deserialize, Serialize};
-use chrono::NaiveDateTime;
 
 use ya_client_model::activity::{
     ActivityState, ActivityUsage, ExeScriptCommand, ExeScriptCommandResult, ExeScriptCommandState,
+    RuntimeEvent,
 };
 use ya_service_bus::RpcMessage;
 
@@ -135,27 +135,6 @@ impl RpcMessage for GetRunningCommand {
     type Item = ExeScriptCommandState;
     type Error = RpcMessageError;
 }
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct RuntimeEvent {
-    pub batch_id: String,
-    pub index: usize,
-    pub timestamp: NaiveDateTime,
-    pub kind: RuntimeEventKind,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum RuntimeEventKind {
-    Started {
-        command: ExeScriptCommand
-    },
-    Finished {
-        return_code: i32,
-        message: Option<String>,
-    },
-    StdOut(String),
-    StdErr(String),
-}
-
 /// Receive runtime event from Supervisor.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/core/model/src/activity.rs
+++ b/core/model/src/activity.rs
@@ -3,6 +3,7 @@
 //! Top level objects constitutes public activity API.
 //! Local and Exeunit are in dedicated submodules.
 use serde::{Deserialize, Serialize};
+use chrono::NaiveDateTime;
 
 use ya_client_model::activity::{
     ActivityState, ActivityUsage, ExeScriptCommand, ExeScriptCommandResult, ExeScriptCommandState,
@@ -138,7 +139,7 @@ impl RpcMessage for GetRunningCommand {
 pub struct RuntimeEvent {
     pub batch_id: String,
     pub index: usize,
-    pub timestamp: u64,
+    pub timestamp: NaiveDateTime,
     pub kind: RuntimeEventKind,
 }
 


### PR DESCRIPTION
This endpoint stores received `RuntimeEvent`s in the db for persistence and later retrieval.

Requires https://github.com/golemfactory/ya-client/pull/32
Required for #409 (ExeUnit: streaming command output)

Closes #414 