### PR TITLE
Minor fix to ya-requestor-sdk

### DIFF
--- a/agent/requestor-sdk/src/requestor.rs
+++ b/agent/requestor-sdk/src/requestor.rs
@@ -278,13 +278,13 @@ impl Requestor {
         let (digest, url) = self.task_package.publish().await?;
         let url_with_hash = format!("hash:sha3:{}:{}", digest, url);
 
-        log::debug!("srv.comp.wasm.task_package: {}", url_with_hash);
+        log::debug!("srv.comp.task_package: {}", url_with_hash);
 
         let demand = Demand::new(
             serde_json::json!({
                 "golem": {
                     "node.id.name": self.name,
-                    "srv.comp.wasm.task_package": url_with_hash,
+                    "srv.comp.task_package": url_with_hash,
                     "srv.comp.expiration":
                         (chrono::Utc::now() + chrono::Duration::minutes(10)).timestamp_millis(), // TODO
                 },

--- a/core/market/decentralized/src/testing/mock_offer.rs
+++ b/core/market/decentralized/src/testing/mock_offer.rs
@@ -78,7 +78,7 @@ pub mod client {
                     "node.id.name": "its-test-requestor",
                     "node.debug.subnet": "blaa",
                     "srv.comp.expiration": 3,
-                    "srv.comp.wasm.task_package": "test-package",
+                    "srv.comp.task_package": "test-package",
                 },
             }),
             constraints![

--- a/core/market/resolver/tests/expression_resolve.rs
+++ b/core/market/resolver/tests/expression_resolve.rs
@@ -560,15 +560,15 @@ fn resolve_pseudo_function_array_sample_undefined() {
 #[test]
 fn resolve_wildcard_prop_sample_undefined() {
     // this syntax should work, and should return "undefined" for property declared with wildcards.
-    let f = r#"(golem.srv.comp.wasm.task_package=hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip)"#;
+    let f = r#"(golem.srv.comp.task_package=hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip)"#;
 
     // test positive
 
     run_resolve_test(f, &vec![
-                                r#"golem.srv.comp.wasm.task_package"#
+                                r#"golem.srv.comp.task_package"#
                             ], ResolveResult::Undefined(
-                                vec![&PropertyRef::Value(String::from("golem.srv.comp.wasm.task_package"), PropertyRefType::Any)],
-                                Expression::Equals(PropertyRef::Value(String::from("golem.srv.comp.wasm.task_package"), PropertyRefType::Any), 
+                                vec![&PropertyRef::Value(String::from("golem.srv.comp.task_package"), PropertyRefType::Any)],
+                                Expression::Equals(PropertyRef::Value(String::from("golem.srv.comp.task_package"), PropertyRefType::Any),
                                                    String::from("hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip"))
                             ));
 }

--- a/core/market/resolver/tests/sample/mod.rs
+++ b/core/market/resolver/tests/sample/mod.rs
@@ -92,7 +92,7 @@ pub static POC_DEMAND_PROPERTIES_JSON: &str = r#"
   "golem.node.debug.subnet": "piotr",
   "golem.node.id.name": "test1",
   "golem.srv.comp.expiration": 1590765503361,
-  "golem.srv.comp.wasm.task_package": "hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
+  "golem.srv.comp.task_package": "hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
 }"#;
 
 pub static POC_DEMAND_PROPERTIES_JSON_DEEP: &str = r#"
@@ -104,7 +104,7 @@ pub static POC_DEMAND_PROPERTIES_JSON_DEEP: &str = r#"
     },
     "srv.comp": {
       "expiration": 1590765503361,
-      "wasm.task_package": "hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
+      "task_package": "hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip"
     }
   }
 }"#;
@@ -113,7 +113,7 @@ pub static POC_DEMAND_PROPERTIES_FLAT: &'static [&'static str] = &[
     "golem.node.debug.subnet=\"piotr\"",
     "golem.node.id.name=\"test1\"",
     "golem.srv.comp.expiration=1590765503361",
-    "golem.srv.comp.wasm.task_package=\"hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip\""
+    "golem.srv.comp.task_package=\"hash://sha3:D5E31B2EED628572A5898BF8C34447644BFC4B5130CFC1E4F10AEAA1:http://34.244.4.185:8000/rust-wasi-tutorial.zip\""
 ];
 
 pub static POC_DEMAND_CONSTRAINTS: &'static str = r#"


### PR DESCRIPTION
Fixes incorrect syntax from `srv.comp.wasm.task_package` to
`srv.comp.task_package`.