### PR TITLE
Payment: initialize accounts from file

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -35,6 +35,9 @@ ETH_FAUCET_ADDRESS=http://faucet.testnet.golem.network:4000/donate
 #GNT2_FAUCET_CONTRACT_ADDRESS=0x59259943616265A03d775145a2eC371732E2B06C
 #REQUIRED_CONFIRMATIONS=5
 
+## Payment accounts
+#ACCOUNT_LIST=accounts.json
+
 ## Activity Service
 
 # Threshold of inactivity period in seconds.

--- a/accounts-example.json
+++ b/accounts-example.json
@@ -1,0 +1,13 @@
+[
+    {
+        "driver": "gnt",
+        "address": "0xdde2ccd1566294aa77db314501385ea50f1059c3",
+        "send": true,
+        "receive": false
+    }, {
+        "driver": "gnt",
+        "address": "0x96af8f53f7f135824273105f94716f36970cfe75",
+        "send": false,
+        "receive": true
+    }
+]

--- a/core/model/src/payment.rs
+++ b/core/model/src/payment.rs
@@ -224,6 +224,24 @@ pub mod local {
             iter.fold(Default::default(), |acc, item| acc + item)
         }
     }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct GetAccounts {}
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct Account {
+        pub platform: String,
+        pub address: String,
+        pub driver: String,
+        pub send: bool,
+        pub receive: bool,
+    }
+
+    impl RpcMessage for GetAccounts {
+        const ID: &'static str = "GetAccounts";
+        type Item = Vec<Account>;
+        type Error = GenericError;
+    }
 }
 
 pub mod public {

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -48,7 +48,7 @@ r2d2 = "0.8"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 thiserror = "1.0"
-tokio = "0.2"
+tokio = { version = "0.2", features = ["fs"] }
 uint = "0.7"
 uuid = { version = "0.8", features = ["v4"] }
 structopt = "0.3"

--- a/core/payment/src/accounts.rs
+++ b/core/payment/src/accounts.rs
@@ -1,0 +1,80 @@
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::path::Path;
+use tokio::fs;
+use ya_core_model::driver::{driver_bus_id, AccountMode, Init};
+use ya_core_model::identity;
+use ya_service_bus::typed as bus;
+
+pub const DEFAULT_PAYMENT_DRIVER: &str = "gnt";
+
+lazy_static! {
+    pub static ref ACCOUNT_LIST_PATH: String =
+        env::var("ACCOUNT_LIST").unwrap_or("accounts.json".to_string());
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct Account {
+    pub driver: String,
+    pub address: String,
+    pub send: bool,
+    pub receive: bool,
+}
+
+pub(crate) async fn init_account(account: Account) -> anyhow::Result<()> {
+    log::debug!("Initializing payment account {:?}...", account);
+    let mut mode = AccountMode::NONE;
+    mode.set(AccountMode::SEND, account.send);
+    mode.set(AccountMode::RECV, account.receive);
+    bus::service(driver_bus_id(account.driver))
+        .call(Init::new(account.address, mode))
+        .await??;
+    log::debug!("Account initialized.");
+    Ok(())
+}
+
+/// Read payment accounts information from `ACCOUNT_LIST` file and initialize them.
+pub async fn init_accounts() -> anyhow::Result<()> {
+    log::debug!(
+        "Initializing payment accounts from file {} ...",
+        &*ACCOUNT_LIST_PATH
+    );
+    let text = fs::read(&*ACCOUNT_LIST_PATH).await?;
+    let accounts: Vec<Account> = serde_json::from_slice(&text)?;
+
+    for account in accounts {
+        init_account(account).await?;
+    }
+    log::debug!("Payment accounts initialized.");
+    Ok(())
+}
+
+/// Get default node ID from identity service and save it in `ACCOUNT_LIST` file as default payment account.
+/// If `ACCOUNT_LIST` file already exists, do nothing.
+pub async fn save_default_account() -> anyhow::Result<()> {
+    if Path::new(&*ACCOUNT_LIST_PATH).exists() {
+        log::debug!("Accounts file {} already exists.", &*ACCOUNT_LIST_PATH);
+        return Ok(());
+    }
+
+    log::debug!(
+        "Saving default payment account to file {} ...",
+        &*ACCOUNT_LIST_PATH
+    );
+    let default_node_id = bus::service(identity::BUS_ID)
+        .call(identity::Get::ByDefault)
+        .await??
+        .ok_or(anyhow::anyhow!("Default identity not found"))?
+        .node_id;
+    let default_account = vec![Account {
+        driver: DEFAULT_PAYMENT_DRIVER.to_string(),
+        address: default_node_id.to_string(),
+        send: false,
+        receive: true,
+    }];
+    let text = serde_json::to_string(&default_account)?;
+    fs::write(&*ACCOUNT_LIST_PATH, text).await?;
+    log::debug!("Default payment account saved successfully.");
+    Ok(())
+}

--- a/core/payment/src/lib.rs
+++ b/core/payment/src/lib.rs
@@ -7,6 +7,7 @@ use ya_service_api_interfaces::*;
 #[macro_use]
 extern crate diesel;
 
+pub mod accounts;
 pub mod api;
 mod cli;
 pub mod dao;

--- a/core/payment/src/service.rs
+++ b/core/payment/src/service.rs
@@ -25,7 +25,8 @@ mod local {
             .bind_with_processor(register_account)
             .bind_with_processor(unregister_account)
             .bind_with_processor(notify_payment)
-            .bind_with_processor(get_status);
+            .bind_with_processor(get_status)
+            .bind_with_processor(get_accounts);
         log::debug!("Successfully bound payment private service to service bus");
     }
 
@@ -55,6 +56,15 @@ mod local {
         msg: UnregisterAccount,
     ) -> Result<(), UnregisterAccountError> {
         processor.unregister_account(msg).await
+    }
+
+    async fn get_accounts(
+        db: DbExecutor,
+        processor: PaymentProcessor,
+        sender: String,
+        msg: GetAccounts,
+    ) -> Result<Vec<Account>, GenericError> {
+        Ok(processor.get_accounts().await)
     }
 
     async fn notify_payment(

--- a/core/serv/src/main.rs
+++ b/core/serv/src/main.rs
@@ -23,7 +23,7 @@ compile_error!("Either feature \"market-forwarding\" or \"market-decentralized\"
 use ya_activity::service::Activity as ActivityService;
 use ya_identity::service::Identity as IdentityService;
 use ya_net::Net as NetService;
-use ya_payment::PaymentService;
+use ya_payment::{accounts as payment_accounts, PaymentService};
 
 #[cfg(feature = "dummy-driver")]
 use ya_dummy_driver::PaymentDriverService;
@@ -238,6 +238,15 @@ impl ServiceCommand {
 
                 let context = ServiceContext::from_data_dir(&ctx.data_dir, name)?;
                 Services::gsb(&context).await?;
+
+                payment_accounts::save_default_account()
+                    .await
+                    .unwrap_or_else(|e| {
+                        log::error!("Saving default payment account failed: {}", e)
+                    });
+                payment_accounts::init_accounts()
+                    .await
+                    .unwrap_or_else(|e| log::error!("Initializing payment accounts failed: {}", e));
 
                 let api_host_port = rest_api_host_port(api_url.clone());
                 HttpServer::new(move || {


### PR DESCRIPTION
### Description

On startup Yagna daemon will automatically initialize all payment accounts listed in `accounts.json` file (path to this file can be
changed using `ACCOUNT_LIST` variable). If the file does not exist, it will be automatically created with the default identity listed as receive-only GNT account. Format of the file is specified by an example `accounts-example.json`.

A new command was added to the CLI in order to verify if the initialization is working correctly: `yagna payment accounts`. This
command lists all initialized payment accounts with information about platform, driver, and mode.

----

### Testing instrucitons

1. Start yagna daemon with a clean database.
```shell
$ yagna service run
```
2. Verify if the default payment account is initialized (address should be the same as default identity).
```shell
$ yagna payment accounts
┌────────────┬──────────────────────────────────────────────┬──────────┬────────┬────────┐
│  platform  │  address                                     │  driver  │  send  │  recv  │
├────────────┼──────────────────────────────────────────────┼──────────┼────────┼────────┤
│  GNT       │  0xdde2ccd1566294aa77db314501385ea50f1059c3  │  gnt     │        │  X     │
└────────────┴──────────────────────────────────────────────┴──────────┴────────┴────────┘
```
3. Verify if the `accounts.json` file has been created.
```shell
$ cat accounts.json
[{"driver":"gnt","address":"0xdde2ccd1566294aa77db314501385ea50f1059c3","send":false,"receive":true}]
```
4. Stop the daemon.
5. Edit `accounts.json` and set the default account into send mode.
```shell
$ cat accounts.json
[{"driver":"gnt","address":"0xdde2ccd1566294aa77db314501385ea50f1059c3","send":true,"receive":false}]
```
6. Start the daemon again (could take some time this time because it will be requesting money from faucet).
```shell
$ yagna service run
```
7. Verify if the account is initialized in send mode.
```shell
$ yagna payment accounts
┌────────────┬──────────────────────────────────────────────┬──────────┬────────┬────────┐
│  platform  │  address                                     │  driver  │  send  │  recv  │
├────────────┼──────────────────────────────────────────────┼──────────┼────────┼────────┤
│  GNT       │  0xdde2ccd1566294aa77db314501385ea50f1059c3  │  gnt     │  X     │        │
└────────────┴──────────────────────────────────────────────┴──────────┴────────┴────────┘
```
8. Verify if the funds have been obtained from faucet.
```shell
$ yagna payment status -p gnt 0xdde2ccd1566294aa77db314501385ea50f1059c3
---
amount: "1000"
incoming:
  accepted: "0"
  confirmed: "0"
  requested: "0"
outgoing:
  accepted: "0"
  confirmed: "0"
  requested: "0"
reserved: "0"
```