### PR TITLE
Release/provider not wait for invoice

### DIFF
--- a/agent/provider/src/payments/payments.rs
+++ b/agent/provider/src/payments/payments.rs
@@ -491,8 +491,11 @@ impl Handler<AgreementClosed> for Payments {
 
                 let costs_summary = myself.send(GetAgreementSummary { agreement_id }).await??;
                 let invoice = myself.send(IssueInvoice { costs_summary }).await??;
+                // We do not want to wait for sending Invoice, as we are eager to start new
+                // negotiations. Waiting for invoice to be sent to Requestor could result in
+                // hanging Provider waiting for Requestor to appear in the net and receive the Invoice
                 let invoice_id = invoice.invoice_id;
-                myself.send(SendInvoice { invoice_id }).await??;
+                myself.do_send(SendInvoice { invoice_id });
 
                 Ok(())
             }

--- a/agent/provider/src/task_manager.rs
+++ b/agent/provider/src/task_manager.rs
@@ -423,7 +423,6 @@ impl Handler<CloseAgreement> for TaskManager {
             start_transition(&myself, &msg.agreement_id, AgreementState::Closed).await?;
 
             runner.do_send(AgreementClosed::new(&msg.agreement_id));
-            //.await??;
             payments
                 .send(AgreementClosed::new(&msg.agreement_id))
                 .await??;

--- a/agent/provider/src/task_manager.rs
+++ b/agent/provider/src/task_manager.rs
@@ -385,20 +385,20 @@ impl Handler<BreakAgreement> for TaskManager {
                 msg.reason
             );
 
-            let msg1 = msg.clone();
             let result = async move {
-                runner.send(AgreementBroken::from(msg1.clone())).await??;
-                payments.send(AgreementBroken::from(msg1.clone())).await??;
+                let msg = AgreementBroken::from(msg.clone());
+                runner.send(msg.clone()).await??;
+                // Notify market, but we don't care about result.
+                // TODO: Breaking agreement shouldn't fail at anytime. But in current code we can
+                //       return early, before we notify market.
+                market.do_send(msg.clone());
 
-                finish_transition(&myself, &msg1.agreement_id, new_state).await?;
+                payments.send(msg.clone()).await??;
+
+                finish_transition(&myself, &msg.agreement_id, new_state).await?;
                 Ok(())
             }
             .await;
-
-            // Notify market, but we don't care about result.
-            // TODO: Breaking agreement shouldn't fail at anytime. But in current code we can
-            //       return early, before we notify market.
-            market.do_send(AgreementBroken::from(msg.clone()));
 
             result
         }
@@ -422,15 +422,13 @@ impl Handler<CloseAgreement> for TaskManager {
         let future = async move {
             start_transition(&myself, &msg.agreement_id, AgreementState::Closed).await?;
 
-            runner.do_send(AgreementClosed::new(&msg.agreement_id));
-            payments
-                .send(AgreementClosed::new(&msg.agreement_id))
-                .await??;
+            let msg = AgreementClosed::new(&msg.agreement_id);
+            runner.do_send(msg.clone());
+            market.do_send(msg.clone());
+            payments.send(msg.clone()).await??;
 
             finish_transition(&myself, &msg.agreement_id, AgreementState::Closed).await?;
 
-            // Notify market, but we don't care about result.
-            market.do_send(AgreementClosed::new(&msg.agreement_id));
             Ok(())
         }
         .map_err(move |error: Error| log::error!("Can't close agreement. Error: {}", error));


### PR DESCRIPTION
ya-provider will not wait for sending Invoice, as we are eager to start new negotiations.

Waiting for invoice to be sent to Requestor could result in hanging Provider waiting for Requestor to appear in the net and receive the Invoice.