### PR TITLE
SGX support: credentials flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5464,6 +5464,7 @@ dependencies = [
  "diesel_migrations",
  "env_logger 0.7.1",
  "futures 0.3.5",
+ "hex",
  "lazy_static",
  "libsqlite3-sys",
  "log 0.4.8",
@@ -5502,7 +5503,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=f4d12744a4197518c97576e85c96fde78dc0e98c#f4d12744a4197518c97576e85c96fde78dc0e98c"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=f97d129c4e17fcbd60110667ee244159f6a2f823#f97d129c4e17fcbd60110667ee244159f6a2f823"
 dependencies = [
  "awc",
  "backtrace",
@@ -5524,12 +5525,12 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=f4d12744a4197518c97576e85c96fde78dc0e98c#f4d12744a4197518c97576e85c96fde78dc0e98c"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=f97d129c4e17fcbd60110667ee244159f6a2f823#f97d129c4e17fcbd60110667ee244159f6a2f823"
 dependencies = [
- "base64 0.12.3",
  "bigdecimal",
  "chrono",
  "diesel",
+ "hex",
  "openssl",
  "rand 0.7.3",
  "secp256k1 0.17.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,7 +5503,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=f97d129c4e17fcbd60110667ee244159f6a2f823#f97d129c4e17fcbd60110667ee244159f6a2f823"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=dae8febbe71bcdc65ae4dedbe2d4371e79ccd589#dae8febbe71bcdc65ae4dedbe2d4371e79ccd589"
 dependencies = [
  "awc",
  "backtrace",
@@ -5525,7 +5525,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=f97d129c4e17fcbd60110667ee244159f6a2f823#f97d129c4e17fcbd60110667ee244159f6a2f823"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=dae8febbe71bcdc65ae4dedbe2d4371e79ccd589#dae8febbe71bcdc65ae4dedbe2d4371e79ccd589"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,8 +135,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "f97d129c4e17fcbd60110667ee244159f6a2f823"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "f97d129c4e17fcbd60110667ee244159f6a2f823"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "dae8febbe71bcdc65ae4dedbe2d4371e79ccd589"}
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "dae8febbe71bcdc65ae4dedbe2d4371e79ccd589"}
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,8 +135,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "f4d12744a4197518c97576e85c96fde78dc0e98c"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "f4d12744a4197518c97576e85c96fde78dc0e98c"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "f97d129c4e17fcbd60110667ee244159f6a2f823"}
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "f97d129c4e17fcbd60110667ee244159f6a2f823"}
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/agent/provider/src/execution/task_runner.rs
+++ b/agent/provider/src/execution/task_runner.rs
@@ -79,6 +79,7 @@ pub struct ActivityDestroyed {
 struct CreateActivity {
     pub activity_id: String,
     pub agreement_id: String,
+    pub requestor_pub_key: Option<String>,
 }
 
 /// Called when we got destroyActivity event.
@@ -228,9 +229,14 @@ impl TaskRunner {
                     ProviderEvent::CreateActivity {
                         activity_id,
                         agreement_id,
+                        requestor_pub_key,
                     } => {
                         myself
-                            .send(CreateActivity::new(activity_id, agreement_id))
+                            .send(CreateActivity::new(
+                                activity_id,
+                                agreement_id,
+                                requestor_pub_key.as_ref(),
+                            ))
                             .await?
                     }
                     ProviderEvent::DestroyActivity {
@@ -268,7 +274,12 @@ impl TaskRunner {
 
         let exeunit_name = exe_unit_name_from(&agreement)?;
 
-        let task = match self.create_task(&exeunit_name, &msg.activity_id, &msg.agreement_id) {
+        let task = match self.create_task(
+            &exeunit_name,
+            &msg.activity_id,
+            &msg.agreement_id,
+            msg.requestor_pub_key.as_ref().map(|s| s.as_str()),
+        ) {
             Ok(task) => task,
             Err(error) => bail!("Error creating activity: {:?}: {}", msg, error),
         };
@@ -352,6 +363,7 @@ impl TaskRunner {
         exeunit_name: &str,
         activity_id: &str,
         agreement_id: &str,
+        requestor_pub_key: Option<&str>,
     ) -> Result<Task> {
         let working_dir = self
             .tasks_dir
@@ -378,6 +390,10 @@ impl TaskRunner {
         args.extend(["-c", self.cache_dir.to_str().ok_or(anyhow!("None"))?].iter());
         args.extend(["-w", working_dir.to_str().ok_or(anyhow!("None"))?].iter());
         args.extend(["-a", agreement_path.to_str().ok_or(anyhow!("None"))?].iter());
+
+        if let Some(req_pub_key) = requestor_pub_key {
+            args.extend(["--requestor-pub-key", req_pub_key.as_ref()].iter());
+        }
 
         args.push("service-bus");
         args.push(activity_id);
@@ -647,10 +663,15 @@ impl Handler<AgreementBroken> for TaskRunner {
 // =========================================== //
 
 impl CreateActivity {
-    pub fn new(activity_id: &str, agreement_id: &str) -> CreateActivity {
+    pub fn new<S: AsRef<str>>(
+        activity_id: S,
+        agreement_id: S,
+        requestor_pub_key: Option<S>,
+    ) -> CreateActivity {
         CreateActivity {
-            activity_id: activity_id.to_string(),
-            agreement_id: agreement_id.to_string(),
+            activity_id: activity_id.as_ref().to_string(),
+            agreement_id: agreement_id.as_ref().to_string(),
+            requestor_pub_key: requestor_pub_key.map(|s| s.as_ref().to_string()),
         }
     }
 }

--- a/core/activity/Cargo.toml
+++ b/core/activity/Cargo.toml
@@ -22,6 +22,7 @@ diesel = { version = "1.4", features = ["chrono", "sqlite", "r2d2"] }
 diesel_migrations = "1.4"
 env_logger = "0.7"
 futures = "0.3"
+hex = "0.4"
 lazy_static = "1.4"
 libsqlite3-sys = { version = "0.9.1", features = ["bundled"] }
 log = "0.4"

--- a/core/activity/Cargo.toml
+++ b/core/activity/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 ya-core-model = { version = "0.1", features = ["activity", "market"] }
-ya-client-model = "0.1"
+ya-client-model = { version = "0.1", features = ["sgx"] }
 ya-net = "0.1"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"

--- a/core/activity/migrations/2020-08-21-121851_credentials/down.sql
+++ b/core/activity/migrations/2020-08-21-121851_credentials/down.sql
@@ -1,0 +1,18 @@
+CREATE TABLE activity_event_migrate (
+	id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+	activity_id INTEGER NOT NULL,
+	identity_id VARCHAR(50) NOT NULL,
+	event_date DATETIME NOT NULL,
+	event_type_id INTEGER NOT NULL,
+    FOREIGN KEY(activity_id) REFERENCES activity (id),
+    FOREIGN KEY(event_type_id) REFERENCES activity_event_type (id)
+);
+
+INSERT INTO activity_event_migrate(activity_id, identity_id, event_date, event_type_id)
+SELECT activity_id, identity_id, event_date, event_type_id
+FROM activity_event;
+
+DROP TABLE activity_event;
+ALTER TABLE activity_event_migrate RENAME TO activity_event;
+
+DROP TABLE activity_credentials;

--- a/core/activity/migrations/2020-08-21-121851_credentials/up.sql
+++ b/core/activity/migrations/2020-08-21-121851_credentials/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE activity_event ADD COLUMN requestor_pub_key BLOB;
+
+CREATE TABLE activity_credentials (
+	activity_id TEXT NOT NULL PRIMARY KEY,
+	credentials TEXT NOT NULL,
+    UNIQUE(activity_id)
+);

--- a/core/activity/src/dao/activity_credentials.rs
+++ b/core/activity/src/dao/activity_credentials.rs
@@ -1,0 +1,60 @@
+use ya_core_model::activity::local::Credentials;
+use ya_persistence::executor::{do_with_transaction, readonly_transaction, AsDao, PoolType};
+
+use crate::dao::Result;
+use crate::db::{models::ActivityCredentials, schema};
+use diesel::{OptionalExtension, QueryDsl, RunQueryDsl};
+
+pub struct ActivityCredentialsDao<'c> {
+    pool: &'c PoolType,
+}
+
+impl<'a> AsDao<'a> for ActivityCredentialsDao<'a> {
+    fn as_dao(pool: &'a PoolType) -> Self {
+        ActivityCredentialsDao { pool }
+    }
+}
+
+impl<'c> ActivityCredentialsDao<'c> {
+    pub async fn get(&self, activity_id: &str) -> Result<Option<ActivityCredentials>> {
+        use schema::activity_credentials::dsl as dsl_cred;
+        let activity_id = activity_id.to_owned();
+
+        readonly_transaction(self.pool, move |conn| {
+            Ok(dsl_cred::activity_credentials
+                .find(&activity_id)
+                .first::<ActivityCredentials>(conn)
+                .optional()?)
+        })
+        .await
+    }
+
+    pub async fn set(&self, activity_id: &str, credentials: Credentials) -> Result<()> {
+        use schema::activity_credentials::dsl as dsl_cred;
+
+        let activity_id = activity_id.to_owned();
+        let cred = ActivityCredentials {
+            activity_id: activity_id.clone(),
+            credentials: serde_json::to_string(&credentials)?,
+        };
+
+        do_with_transaction(self.pool, move |conn| {
+            if let Err(e) = diesel::insert_into(dsl_cred::activity_credentials)
+                .values(&cred)
+                .execute(conn)
+            {
+                use diesel::result::{DatabaseErrorKind, Error};
+                match e {
+                    Error::DatabaseError(DatabaseErrorKind::UniqueViolation, _) => {
+                        diesel::update(dsl_cred::activity_credentials.find(&activity_id))
+                            .set(&cred)
+                            .execute(conn)?;
+                    }
+                    _ => return Err(e.into()),
+                }
+            }
+            Ok(())
+        })
+        .await
+    }
+}

--- a/core/activity/src/dao/event.rs
+++ b/core/activity/src/dao/event.rs
@@ -19,6 +19,7 @@ pub struct Event {
     pub event_type: ActivityEventType,
     pub activity_natural_id: String,
     pub agreement_natural_id: String,
+    pub requestor_pub_key: Option<Vec<u8>>,
 }
 
 impl From<Event> for ProviderEvent {
@@ -27,6 +28,7 @@ impl From<Event> for ProviderEvent {
             ActivityEventType::CreateActivity => ProviderEvent::CreateActivity {
                 activity_id: value.activity_natural_id,
                 agreement_id: value.agreement_natural_id,
+                requestor_pub_key: value.requestor_pub_key.map(hex::encode),
             },
             ActivityEventType::DestroyActivity => ProviderEvent::DestroyActivity {
                 activity_id: value.activity_natural_id,
@@ -52,6 +54,7 @@ impl<'c> EventDao<'c> {
         activity_id: &str,
         identity_id: &str,
         event_type: ActivityEventType,
+        requestor_pub_key: Option<Vec<u8>>,
     ) -> Result<i32> {
         use schema::activity::dsl;
         use schema::activity_event::dsl as dsl_event;
@@ -71,6 +74,7 @@ impl<'c> EventDao<'c> {
                             identity_id.clone().into_sql::<Text>(),
                             now.into_sql::<Timestamp>(),
                             event_type.into_sql::<Integer>(),
+                            requestor_pub_key.into_sql(),
                         ))
                         .filter(dsl::natural_id.eq(activity_id))
                         .limit(1),
@@ -80,6 +84,7 @@ impl<'c> EventDao<'c> {
                     dsl_event::identity_id,
                     dsl_event::event_date,
                     dsl_event::event_type_id,
+                    dsl_event::requestor_pub_key,
                 ))
                 .execute(conn)?;
 
@@ -116,6 +121,7 @@ impl<'c> EventDao<'c> {
                     dsl_event::event_type_id,
                     dsl::natural_id,
                     dsl::agreement_id,
+                    dsl_event::requestor_pub_key,
                 ))
                 .order(dsl_event::event_date.asc())
                 .limit(limit as i64)

--- a/core/activity/src/dao/mod.rs
+++ b/core/activity/src/dao/mod.rs
@@ -1,9 +1,11 @@
 mod activity;
+mod activity_credentials;
 mod activity_state;
 mod activity_usage;
 mod event;
 
 pub use activity::ActivityDao;
+pub use activity_credentials::ActivityCredentialsDao;
 pub use activity_state::ActivityStateDao;
 pub use activity_usage::ActivityUsageDao;
 pub use event::{Event, EventDao};

--- a/core/activity/src/db/models.rs
+++ b/core/activity/src/db/models.rs
@@ -1,4 +1,3 @@
-#![allow(unused)]
 #![allow(clippy::all)]
 
 use super::schema::*;
@@ -9,7 +8,6 @@ use diesel::serialize::Output;
 use diesel::sql_types::Integer;
 use diesel::types::{FromSql, ToSql};
 use std::convert::TryFrom;
-use std::error::Error;
 
 #[derive(Queryable, Debug, Identifiable)]
 #[table_name = "activity"]
@@ -71,7 +69,7 @@ pub struct ActivityState {
     pub updated_date: NaiveDateTime,
 }
 
-impl std::convert::TryFrom<ActivityState> for ya_client_model::activity::ActivityState {
+impl TryFrom<ActivityState> for ya_client_model::activity::ActivityState {
     type Error = ya_persistence::Error;
 
     fn try_from(value: ActivityState) -> Result<Self, Self::Error> {
@@ -91,7 +89,7 @@ pub struct ActivityUsage {
     pub updated_date: NaiveDateTime,
 }
 
-impl std::convert::TryFrom<ActivityUsage> for ya_client_model::activity::ActivityUsage {
+impl TryFrom<ActivityUsage> for ya_client_model::activity::ActivityUsage {
     type Error = ya_persistence::Error;
 
     fn try_from(value: ActivityUsage) -> Result<Self, Self::Error> {
@@ -102,5 +100,21 @@ impl std::convert::TryFrom<ActivityUsage> for ya_client_model::activity::Activit
                 .transpose()?,
             timestamp: value.updated_date.timestamp(),
         })
+    }
+}
+
+#[derive(Queryable, Debug, Clone, Identifiable, Insertable, AsChangeset)]
+#[table_name = "activity_credentials"]
+#[primary_key(activity_id)]
+pub struct ActivityCredentials {
+    pub activity_id: String,
+    pub credentials: String,
+}
+
+impl TryFrom<ActivityCredentials> for Option<ya_client_model::activity::Credentials> {
+    type Error = ya_persistence::Error;
+
+    fn try_from(value: ActivityCredentials) -> Result<Self, Self::Error> {
+        Ok(serde_json::from_str(&value.credentials)?)
     }
 }

--- a/core/activity/src/db/schema.rs
+++ b/core/activity/src/db/schema.rs
@@ -9,12 +9,20 @@ table! {
 }
 
 table! {
+    activity_credentials (activity_id) {
+        activity_id -> Text,
+        credentials -> Text,
+    }
+}
+
+table! {
     activity_event (id) {
         id -> Integer,
         activity_id -> Integer,
         identity_id -> Text,
         event_date -> Timestamp,
         event_type_id -> Integer,
+        requestor_pub_key -> Nullable<Binary>,
     }
 }
 
@@ -50,6 +58,7 @@ joinable!(activity_event -> activity_event_type (event_type_id));
 
 allow_tables_to_appear_in_same_query!(
     activity,
+    activity_credentials,
     activity_event,
     activity_event_type,
     activity_state,

--- a/core/activity/src/requestor/control.rs
+++ b/core/activity/src/requestor/control.rs
@@ -46,19 +46,19 @@ async fn create_activity(
         requestor_pub_key: None,
     };
 
-    let activity_id = net::from(id.identity)
+    let create_resp = net::from(id.identity)
         .to(provider_id)
         .service(activity::BUS_ID)
         .send(msg)
         .timeout(query.timeout)
         .await???;
 
-    log::debug!("activity created: {}, inserting", activity_id);
+    log::debug!("activity created: {}, inserting", create_resp.activity_id);
     db.as_dao::<ActivityDao>()
-        .create_if_not_exists(&activity_id, &agreement_id)
+        .create_if_not_exists(&create_resp.activity_id, &agreement_id)
         .await?;
 
-    Ok::<_, Error>(web::Json(activity_id))
+    Ok::<_, Error>(web::Json(create_resp))
 }
 
 /// Destroys given Activity.

--- a/core/model/src/activity.rs
+++ b/core/model/src/activity.rs
@@ -110,23 +110,6 @@ pub mod sgx {
         type Item = Vec<u8>;
         type Error = RpcMessageError;
     }
-
-    #[derive(Clone, Serialize, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    pub enum Request {
-        Exec(super::Exec),
-        GetExecBatchResults(super::GetExecBatchResults),
-        GetRunningCommand(super::GetRunningCommand),
-    }
-
-    #[derive(Clone, Serialize, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    pub enum Response {
-        Exec(Result<String, RpcMessageError>),
-        GetExecBatchResults(Result<Vec<super::ExeScriptCommandResult>, RpcMessageError>),
-        GetRunningCommand(Result<super::ExeScriptCommandState, RpcMessageError>),
-        Error(RpcMessageError),
-    }
 }
 
 /// Execute a script within the activity. Returns `batch_id`.

--- a/core/model/src/activity.rs
+++ b/core/model/src/activity.rs
@@ -228,6 +228,7 @@ pub mod local {
             requestor: Vec<u8>,
             enclave: Vec<u8>,
             // sha3-256
+            payload_sha3: [u8; 32],
             enclave_hash: [u8; 32],
             ias_report: String,
             ias_sig: Vec<u8>,

--- a/core/model/src/activity.rs
+++ b/core/model/src/activity.rs
@@ -40,8 +40,15 @@ pub struct Create {
 
 impl RpcMessage for Create {
     const ID: &'static str = "CreateActivity";
-    type Item = String;
+    type Item = CreateResponse;
     type Error = RpcMessageError;
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateResponse {
+    pub activity_id: String,
+    pub credentials: Option<local::Credentials>,
 }
 
 /// Destroy activity.
@@ -109,6 +116,7 @@ pub mod sgx {
     pub enum Request {
         Exec(super::Exec),
         GetExecBatchResults(super::GetExecBatchResults),
+        GetRunningCommand(super::GetRunningCommand),
     }
 
     #[derive(Clone, Serialize, Deserialize)]
@@ -116,6 +124,7 @@ pub mod sgx {
     pub enum Response {
         Exec(Result<String, RpcMessageError>),
         GetExecBatchResults(Result<Vec<super::ExeScriptCommandResult>, RpcMessageError>),
+        GetRunningCommand(Result<super::ExeScriptCommandState, RpcMessageError>),
         Error(RpcMessageError),
     }
 }
@@ -188,16 +197,20 @@ pub mod local {
         pub state: ActivityState,
         pub timeout: Option<f32>,
         #[serde(default)]
-        pub credentials: Option<Box<Credentials>>,
+        pub credentials: Option<Credentials>,
     }
 
     impl SetState {
-        pub fn new(activity_id: String, state: ActivityState) -> Self {
+        pub fn new(
+            activity_id: String,
+            state: ActivityState,
+            credentials: Option<Credentials>,
+        ) -> Self {
             SetState {
                 activity_id,
                 state,
                 timeout: Default::default(),
-                credentials: Default::default(),
+                credentials,
             }
         }
     }
@@ -215,7 +228,6 @@ pub mod local {
             requestor: Vec<u8>,
             enclave: Vec<u8>,
             // sha3-256
-            payload_sha3: [u8; 32],
             enclave_hash: [u8; 32],
             ias_report: String,
             ias_sig: Vec<u8>,

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -34,11 +34,10 @@ ya-agreement-utils = "0.1"
 ya-client-model = "0.1"
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.1", features = ["activity", "appkey"] }
-ya-runtime-api= { version = "0.1", path ="runtime-api", features=["server"] }
+ya-runtime-api = { version = "0.1", path = "runtime-api", features = ["server"] }
 ya-service-bus = "0.2"
 ya-transfer = "0.1"
 
-reqwest = { version = "0.10.7", optional = true }
 actix = "0.9"
 anyhow = "1.0.19"
 async-trait = "0.1.24"
@@ -52,7 +51,8 @@ lazy_static = "1.4.0"
 log = "0.4.8"
 rand = "0.6"
 regex = "1.3.4"
-secp256k1={ version = "0.17.2", optional=true }
+reqwest = { version = "0.10.7", optional = true }
+secp256k1 = { version = "0.17.2", optional = true }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8.11"
@@ -65,7 +65,7 @@ url = "2.1.1"
 
 [dev-dependencies]
 ya-sb-router = "0.1"
-ya-runtime-api= { version = "0.1", path ="runtime-api", features=["codec", "server"] }
+ya-runtime-api = { version = "0.1", path = "runtime-api", features = ["codec", "server"] }
 
 actix-files = "0.2.1"
 actix-rt = "1.0.0"

--- a/exe-unit/examples/transfer.rs
+++ b/exe-unit/examples/transfer.rs
@@ -183,6 +183,7 @@ async fn main() -> anyhow::Result<()> {
     let exe_ctx = ExeUnitContext {
         activity_id: None,
         report_url: None,
+        credentials: None,
         agreement,
         work_dir: work_dir.clone(),
         cache_dir,

--- a/exe-unit/examples/transfer_abort.rs
+++ b/exe-unit/examples/transfer_abort.rs
@@ -166,6 +166,7 @@ async fn main() -> anyhow::Result<()> {
     let exe_ctx = ExeUnitContext {
         activity_id: None,
         report_url: None,
+        credentials: None,
         agreement,
         work_dir,
         cache_dir,

--- a/exe-unit/src/bin.rs
+++ b/exe-unit/src/bin.rs
@@ -107,6 +107,7 @@ fn init_crypto(
 
 fn run() -> anyhow::Result<()> {
     dotenv::dotenv().ok();
+    #[allow(unused_mut)]
     let mut cli: Cli = Cli::from_args();
 
     if !cli.agreement.exists() {
@@ -143,15 +144,16 @@ fn run() -> anyhow::Result<()> {
     let mut ctx = ExeUnitContext {
         activity_id: None,
         report_url: None,
+        credentials: None,
         agreement,
         work_dir,
         cache_dir,
         runtime_args,
         #[cfg(feature = "sgx")]
-        crypto: {
-            let sec_key = cli.sec_key.replace("<hidden>".into());
-            init_crypto(sec_key, cli.requestor_pub_key.clone())?
-        },
+        crypto: init_crypto(
+            cli.sec_key.replace("<hidden>".into()),
+            cli.requestor_pub_key.clone(),
+        )?,
     };
 
     log::debug!("CLI args: {:?}", cli);

--- a/exe-unit/src/crypto.rs
+++ b/exe-unit/src/crypto.rs
@@ -5,8 +5,8 @@ use ya_client_model::activity::encrypted::EncryptionCtx;
 #[derive(Clone)]
 pub struct Crypto {
     sec_key: SecretKey,
-    pub_key: PublicKey,
-    requestor_pub_key: PublicKey,
+    pub pub_key: PublicKey,
+    pub requestor_pub_key: PublicKey,
 }
 
 impl Crypto {
@@ -56,10 +56,5 @@ impl Crypto {
 
     pub fn ctx(&mut self) -> EncryptionCtx {
         EncryptionCtx::new(&self.requestor_pub_key, &self.sec_key)
-    }
-
-    pub fn public_key(&self) -> String {
-        let key = self.pub_key.serialize().to_vec();
-        hex::encode(&key)
     }
 }

--- a/exe-unit/src/handlers/local.rs
+++ b/exe-unit/src/handlers/local.rs
@@ -75,6 +75,7 @@ impl<R: Runtime> Handler<Initialize> for ExeUnit<R> {
                     Some(Credentials::Sgx {
                         requestor: Vec::new(),
                         enclave: Vec::new(),
+                        payload_sha3: [0u8; 32],
                         enclave_hash: [0u8; 32],
                         ias_report: String::new(),
                         ias_sig: Vec::new(),

--- a/exe-unit/src/handlers/local.rs
+++ b/exe-unit/src/handlers/local.rs
@@ -6,7 +6,7 @@ use crate::state::State;
 use crate::{report, ExeUnit};
 use actix::prelude::*;
 use futures::FutureExt;
-use ya_client_model::activity::ActivityState;
+use ya_client_model::activity;
 use ya_core_model::activity::local::SetState as SetActivityState;
 
 impl<R: Runtime> Handler<GetState> for ExeUnit<R> {
@@ -37,21 +37,61 @@ impl<R: Runtime> Handler<SetState> for ExeUnit<R> {
                 self.state.inner = update.state.clone();
 
                 if let Some(id) = &self.ctx.activity_id {
+                    let credentials = match &update.state {
+                        activity::StatePair(activity::State::Initialized, None) => {
+                            self.ctx.credentials.clone()
+                        }
+                        _ => None,
+                    };
                     let fut = report(
                         self.ctx.report_url.clone().unwrap(),
                         SetActivityState::new(
                             id.clone(),
-                            ActivityState {
+                            activity::ActivityState {
                                 state: update.state,
                                 reason: update.reason,
                                 error_message: None,
                             },
+                            credentials,
                         ),
                     );
                     ctx.spawn(fut.into_actor(self));
                 }
             }
         }
+    }
+}
+
+impl<R: Runtime> Handler<Initialize> for ExeUnit<R> {
+    type Result = ResponseActFuture<Self, <Initialize as Message>::Result>;
+
+    fn handle(&mut self, _: Initialize, _: &mut Context<Self>) -> Self::Result {
+        let fut = async move {
+            Ok::<_, Error>({
+                #[cfg(feature = "sgx")]
+                {
+                    use ya_core_model::activity::local::Credentials;
+                    // TODO: attestation
+                    Some(Credentials::Sgx {
+                        requestor: Vec::new(),
+                        enclave: Vec::new(),
+                        enclave_hash: [0u8; 32],
+                        ias_report: String::new(),
+                        ias_sig: Vec::new(),
+                        session_key: Vec::new(),
+                    })
+                }
+                #[cfg(not(feature = "sgx"))]
+                None
+            })
+        }
+        .into_actor(self)
+        .map(move |result, actor, _| {
+            actor.ctx.credentials = result?;
+            Ok(())
+        });
+
+        Box::new(fut)
     }
 }
 

--- a/exe-unit/src/handlers/local.rs
+++ b/exe-unit/src/handlers/local.rs
@@ -66,6 +66,8 @@ impl<R: Runtime> Handler<Initialize> for ExeUnit<R> {
     type Result = ResponseActFuture<Self, <Initialize as Message>::Result>;
 
     fn handle(&mut self, _: Initialize, _: &mut Context<Self>) -> Self::Result {
+        #[cfg(feature = "sgx")]
+        let crypto = self.ctx.crypto.clone();
         let fut = async move {
             Ok::<_, Error>({
                 #[cfg(feature = "sgx")]
@@ -73,8 +75,8 @@ impl<R: Runtime> Handler<Initialize> for ExeUnit<R> {
                     use ya_core_model::activity::local::Credentials;
                     // TODO: attestation
                     Some(Credentials::Sgx {
-                        requestor: Vec::new(),
-                        enclave: Vec::new(),
+                        requestor: crypto.requestor_pub_key.serialize().to_vec(),
+                        enclave: crypto.pub_key.serialize().to_vec(),
                         payload_sha3: [0u8; 32],
                         enclave_hash: [0u8; 32],
                         ias_report: String::new(),

--- a/exe-unit/src/handlers/rpc.rs
+++ b/exe-unit/src/handlers/rpc.rs
@@ -186,6 +186,15 @@ impl<R: Runtime> Handler<RpcEnvelope<sgx::CallEncryptedService>> for ExeUnit<R> 
                             })?,
                     )
                 }
+                sgx::Request::GetRunningCommand(get_running_command) => {
+                    sgx::Response::GetRunningCommand(
+                        me.send(RpcEnvelope::local(get_running_command))
+                            .await
+                            .map_err(|_e| {
+                                RpcMessageError::Service("fatal: exe-unit disconnected".to_string())
+                            })?,
+                    )
+                }
             })
         }
         .then(move |v| {

--- a/exe-unit/src/message.rs
+++ b/exe-unit/src/message.rs
@@ -153,6 +153,10 @@ impl From<proto::response::Error> for RuntimeCommandResult {
     }
 }
 
+#[derive(Clone, Debug, Message)]
+#[rtype(result = "Result<()>")]
+pub struct Initialize;
+
 #[derive(Clone, Debug, PartialEq, Message)]
 #[rtype(result = "()")]
 pub struct Register<Svc>(pub Addr<Svc>)


### PR DESCRIPTION
requires https://github.com/golemfactory/ya-client/pull/40

`ya-core-model`:
* [activity] respond to `Create` with `CreateResponse` (instead of `activity_id: String`)
* [activity::sgx] add `Request::GetRunningCommand` and `Response::GetRunningCommand` variants

`ya-exe-unit`:
* [sgx] include `Credentials` in `SetState`
* [sgx] handle `sgx::Request::GetRunningCommand`
* attestation placeholder

`ya-provider`:
* add `--requestor-pub-key` argument to ExeUnit command line

`ya-activity`:
* new: `ActivityCredentialsDao`
* [gsb] activity creation: respond to `CreateRequest` with `CreateResponse` (w/ credentials)
* [api] activity creation: use `CreateActivityRequest` and `CreateActivityResult`
* store `Credentials` sent in `SetState`
* include requestor_pub_key in `CreateActivity` event


**Further changes:**

`ya-core-model`:
* [sgx] remove `Request` and `Response` models

`ya-exe-unit`:
* [sgx] use `Request` and `Response` models from `ya_client_model`
* [sgx] add requestor and enclave public keys to `Credentials` placeholder

`ya-activity`:
* [api] requestor control: POST `/activity/{activity_id}/encrypted` endpoint