### PR TITLE
Add CLI config option for negotiator strategy

### DIFF
--- a/agent/provider/src/provider_agent.rs
+++ b/agent/provider/src/provider_agent.rs
@@ -37,7 +37,7 @@ impl ProviderAgent {
         let mut hardware = hardware::Manager::try_new(&config)?;
         hardware.spawn_monitor(&config.hardware_file)?;
 
-        let market = ProviderMarket::new(api.market, "LimitAgreements").start();
+        let market = ProviderMarket::new(api.market, &config.negotiator_strategy).start();
         let payments = Payments::new(api.activity.clone(), api.payment).start();
         let runner = TaskRunner::new(api.activity, args.runner_config, registry, data_dir)?.start();
         let task_manager = TaskManager::new(market.clone(), runner.clone(), payments)?.start();

--- a/agent/provider/src/startup_config.rs
+++ b/agent/provider/src/startup_config.rs
@@ -60,6 +60,11 @@ pub struct ProviderConfig {
         env = "YA_RT_STORAGE")
     ]
     pub rt_storage: Option<f64>,
+
+    /// Negotiator strategy used by this provider.
+    /// Can be one of: LimitAgreements, AcceptAll.
+    #[structopt(long, default_value = "LimitAgreements")]
+    pub negotiator_strategy: String,
 }
 
 impl ProviderConfig {


### PR DESCRIPTION
This seemed to have been missing in the provider CLI and overriding
the default behaviour of accepting only one agreement to accepting
all agreements is really useful for local testing.