### PR TITLE
[alpha] Windows 10 compatibility fixes 

### DIFF
--- a/core/payment-driver/Cargo.toml
+++ b/core/payment-driver/Cargo.toml
@@ -24,6 +24,7 @@ ethereum-tx-sign = { git = "https://github.com/bidzyyys/ethereum-tx-sign" }
 ethereum-types = "0.6.0"
 futures3 = { version = "0.3", features = ["compat"], package = "futures" }
 hex = "0.4"
+hyper = "0.13"
 lazy_static = "1.4.0"
 log = "0.4.8"
 num-bigint = "0.2"

--- a/core/payment-driver/Cargo.toml
+++ b/core/payment-driver/Cargo.toml
@@ -14,7 +14,6 @@ integration-tests = []
 actix = "0.9"
 actix-rt = "1.0"
 anyhow = "1.0"
-awc = "1.0.1"
 bigdecimal = "0.1.0"
 bitflags = "1.2"
 chrono = { version = "0.4", features = ["serde"] }

--- a/core/payment-driver/src/gnt/faucet.rs
+++ b/core/payment-driver/src/gnt/faucet.rs
@@ -1,6 +1,10 @@
 use crate::utils;
 use crate::{PaymentDriverError, PaymentDriverResult};
 use ethereum_types::Address;
+use hyper::body::HttpBody as _;
+use hyper::client::HttpConnector;
+use hyper::http::uri::InvalidUri;
+use hyper::{Body, Uri};
 use std::{env, time};
 
 const MAX_ETH_FAUCET_REQUESTS: u32 = 6;
@@ -26,18 +30,37 @@ impl EthFaucetConfig {
 
     pub async fn request_eth(&self, address: Address) -> PaymentDriverResult<()> {
         log::debug!("request eth");
-        let client = awc::Client::new();
+        let client = hyper::Client::new();
         let request_url = format!("{}/{}", &self.faucet_address, utils::addr_to_str(address));
 
-        async fn try_request_eth(client: &awc::Client, url: &str) -> PaymentDriverResult<()> {
+        async fn try_request_eth(
+            client: &hyper::Client<HttpConnector, Body>,
+            url: &str,
+        ) -> PaymentDriverResult<()> {
+            let uri: Uri = url.parse().map_err(|e: InvalidUri| {
+                PaymentDriverError::LibraryError(format!("URL parse() error: {}", e.to_string()))
+            })?;
             let body = client
-                .get(url)
-                .send()
+                .get(uri)
                 .await
-                .map_err(|e| PaymentDriverError::LibraryError(e.to_string()))?
-                .body()
+                .map_err(|e| {
+                    PaymentDriverError::LibraryError(format!(
+                        "Faucet request - Send() error: {}",
+                        e.to_string()
+                    ))
+                })?
+                .body_mut()
+                .data()
                 .await
-                .map_err(|e| PaymentDriverError::LibraryError(e.to_string()))?;
+                .ok_or(PaymentDriverError::LibraryError(String::from(
+                    "Faucet request returned empty response...",
+                )))?
+                .map_err(|e| {
+                    PaymentDriverError::LibraryError(format!(
+                        "Faucet request - Body() error: {}",
+                        e.to_string()
+                    ))
+                })?;
             let resp = std::string::String::from_utf8_lossy(body.as_ref());
             if resp.contains("sufficient funds") || resp.contains("txhash") {
                 log::debug!("resp: {}", resp);

--- a/core/payment-driver/src/gnt/faucet.rs
+++ b/core/payment-driver/src/gnt/faucet.rs
@@ -14,7 +14,7 @@ const ETH_FAUCET_ADDRESS_ENV_VAR: &str = "ETH_FAUCET_ADDRESS";
 const DEFAULT_ETH_FAUCET_ADDRESS: &str = "http://faucet.testnet.golem.network:4000/donate";
 
 pub struct EthFaucetConfig {
-    faucet_address: awc::http::Uri,
+    faucet_address: hyper::Uri,
 }
 
 impl EthFaucetConfig {

--- a/core/payment/src/processor.rs
+++ b/core/payment/src/processor.rs
@@ -94,7 +94,7 @@ impl PaymentProcessor {
 
             Ok(())
         }
-            .await;
+        .await;
 
         if let Err(e) = result {
             log::error!("Payment failed: {}", e);

--- a/core/payment/src/processor.rs
+++ b/core/payment/src/processor.rs
@@ -28,8 +28,13 @@ impl PaymentProcessor {
             let payment_status: PaymentStatus = bus::service(driver::BUS_ID)
                 .send(driver::GetPaymentStatus::from(invoice_id.to_string()))
                 .await
-                .unwrap()
-                .unwrap();
+                .map_err(|e| PaymentError::DriverService(e))?
+                .map_err(|e| {
+                    PaymentError::Driver(format!(
+                        "Payment GetPaymentStatus driver error: {}",
+                        e.to_string()
+                    ))
+                })?;
             match payment_status {
                 PaymentStatus::Ok(confirmation) => return Ok(confirmation),
                 PaymentStatus::NotYet => tokio::time::delay_for(Duration::from_secs(5)).await,
@@ -89,7 +94,7 @@ impl PaymentProcessor {
 
             Ok(())
         }
-        .await;
+            .await;
 
         if let Err(e) = result {
             log::error!("Payment failed: {}", e);
@@ -111,8 +116,13 @@ impl PaymentProcessor {
                 msg.due_date.clone(),
             ))
             .await
-            .unwrap()
-            .unwrap();
+            .map_err(|e| PaymentError::DriverService(e))?
+            .map_err(|e| {
+                PaymentError::Driver(format!(
+                    "Payment SchedulePayment driver error: {}",
+                    e.to_string()
+                ))
+            })?;
 
         let processor = self.clone();
         tokio::task::spawn_local(async move {
@@ -133,8 +143,13 @@ impl PaymentProcessor {
         let details: PaymentDetails = bus::service(driver::BUS_ID)
             .send(driver::VerifyPayment::from(confirmation))
             .await
-            .unwrap()
-            .unwrap();
+            .map_err(|e| PaymentError::DriverService(e))?
+            .map_err(|e| {
+                PaymentError::Driver(format!(
+                    "Payment VerifyPayment driver error: {}",
+                    e.to_string()
+                ))
+            })?;
 
         // Verify if amount declared in message matches actual amount transferred on blockchain
         let actual_amount = details.amount;
@@ -242,8 +257,13 @@ impl PaymentProcessor {
                 details.recipient.clone(),
             ))
             .await
-            .unwrap()
-            .unwrap();
+            .map_err(|e| PaymentError::DriverService(e))?
+            .map_err(|e| {
+                PaymentError::Driver(format!(
+                    "Payment GetTransactionBalance driver error: {}",
+                    e.to_string()
+                ))
+            })?;
 
         let bc_balance = bc_balance.amount;
         if bc_balance < db_balance + actual_amount {
@@ -269,8 +289,10 @@ impl PaymentProcessor {
         bus::service(driver::BUS_ID)
             .send(driver::Init::new(addr, mode))
             .await
-            .unwrap()
-            .unwrap();
+            .map_err(|e| PaymentError::DriverService(e))?
+            .map_err(|e| {
+                PaymentError::Driver(format!("Payment Init driver error: {}", e.to_string()))
+            })?;
         Ok(())
     }
 
@@ -279,8 +301,13 @@ impl PaymentProcessor {
         let account_balance: AccountBalance = bus::service(driver::BUS_ID)
             .send(driver::GetAccountBalance::from(address))
             .await
-            .unwrap()
-            .unwrap();
+            .map_err(|e| PaymentError::DriverService(e))?
+            .map_err(|e| {
+                PaymentError::Driver(format!(
+                    "Payment GetAccountBalance driver error: {}",
+                    e.to_string()
+                ))
+            })?;
         Ok(account_balance.base_currency.amount)
     }
 }


### PR DESCRIPTION
Pull request to aggregate the Windows 10 compatibility changes, introduces as a result of 'Alpha testing' round of yagna.

The testnet faucet request was failing on Win 10 machines. It appears the Actix Web Client is useless when trying to call a URL including a DNS name, which requires DNS resolution, on Windows machine with VM virtual switches configured. It is a known issue, which noone seems to be addressing (https://github.com/actix/actix-web/issues/858) - AWC uses non-default configuration of trust-dns-resolver package, and it seems impossible to easily override it.
Therefore AWC client has been replaced with a 'hyper' HTTP client.