### PR TITLE
[ya-provider] Spawn ExeUnit in its own process group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5932,6 +5932,7 @@ dependencies = [
  "futures 0.3.5",
  "futures-util",
  "libc",
+ "nix 0.17.0",
  "shared_child",
  "tokio 0.2.21",
 ]

--- a/agent/provider/src/execution/exeunit_instance.rs
+++ b/agent/provider/src/execution/exeunit_instance.rs
@@ -34,6 +34,13 @@ impl ExeUnitInstance {
         let mut command = Command::new(&binary_path);
         command.args(args).current_dir(working_dir);
 
+        #[cfg(unix)]
+        {
+            // executes the command in its own process group
+            use ya_utils_process::CommandSetSid;
+            command.setsid();
+        }
+
         let child = ProcessHandle::new(&mut command).map_err(|error| {
             anyhow!(
                 "Can't spawn ExeUnit [{}] from binary [{}] in working directory [{}]. Error: {}",

--- a/agent/provider/src/execution/exeunit_instance.rs
+++ b/agent/provider/src/execution/exeunit_instance.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
-use ya_utils_process::ProcessHandle;
+use ya_utils_process::{ProcessGroupExt, ProcessHandle};
 
 /// Working ExeUnit instance representation.
 #[derive(Display)]
@@ -32,14 +32,11 @@ impl ExeUnitInstance {
             .with_context(|| format!("Failed to spawn [{}].", binary_path.display()))?;
 
         let mut command = Command::new(&binary_path);
-        command.args(args).current_dir(working_dir);
-
-        #[cfg(unix)]
-        {
-            // executes the command in its own process group
-            use ya_utils_process::CommandSetSid;
-            command.setsid();
-        }
+        // new_process_group is a no-op on non-Unix systems
+        command
+            .args(args)
+            .current_dir(working_dir)
+            .new_process_group();
 
         let child = ProcessHandle::new(&mut command).map_err(|error| {
             anyhow!(

--- a/utils/process/Cargo.toml
+++ b/utils/process/Cargo.toml
@@ -13,3 +13,6 @@ futures = "0.3"
 futures-util = "0.3.4"
 shared_child = "0.3.4"
 tokio = { version = "0.2.10", features = ["process", "signal"] }
+
+[target.'cfg(target_family = "unix")'.dependencies]
+nix = "0.17.0"

--- a/utils/process/src/lib.rs
+++ b/utils/process/src/lib.rs
@@ -14,6 +14,25 @@ use {
     shared_child::unix::SharedChildExt,
 };
 
+#[cfg(unix)]
+pub trait CommandSetSid<T> {
+    fn setsid(&mut self) -> &mut T;
+}
+
+#[cfg(unix)]
+impl CommandSetSid<Command> for Command {
+    fn setsid(&mut self) -> &mut Command {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            self.pre_exec(|| {
+                libc::setsid();
+                Ok(())
+            });
+        }
+        self
+    }
+}
+
 #[derive(Display)]
 pub enum ExeUnitExitStatus {
     #[display(fmt = "Aborted - {}", _0)]


### PR DESCRIPTION
Introduces separation of process groups as a countermeasure for any potential issues with ExeUnit's process tree scanning