### PR TITLE
added tokio-process-ns example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ members = [
     "core/serv-api/web",
     "exe-unit",
     "exe-unit/runtime-api",
+    "exe-unit/tokio-process-ns",
     "service-bus/bus",
     "service-bus/derive",
     "service-bus/proto",

--- a/exe-unit/tokio-process-ns/Cargo.toml
+++ b/exe-unit/tokio-process-ns/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tokio-process-ns"
+version = "0.1.0"
+authors = ["Golem Factory <contact@golem.network>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+libc= "0.2"
+nix="0.11.0"
+tokio= { version = "0.2", features=["process"] }
+
+[dev-dependencies]
+tokio= { version = "0.2", features=["process", "rt-threaded", "macros"] }

--- a/exe-unit/tokio-process-ns/examples/ns-shell.rs
+++ b/exe-unit/tokio-process-ns/examples/ns-shell.rs
@@ -1,0 +1,13 @@
+use std::error::Error;
+use tokio::process::Command;
+use tokio_process_ns::*;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let status = Command::new("/bin/bash")
+        .new_ns(NsOptions::new().procfs().kill_child())
+        .status()
+        .await?;
+    eprintln!("done: {}", status);
+    Ok(())
+}

--- a/exe-unit/tokio-process-ns/src/lib.rs
+++ b/exe-unit/tokio-process-ns/src/lib.rs
@@ -1,0 +1,35 @@
+mod pre_exec;
+
+#[derive(Default, Clone, Copy)]
+pub struct NsOptions {
+    fork: bool,
+    kill_child: bool,
+    procfs: bool,
+}
+
+impl NsOptions {
+    pub fn new() -> Self {
+        NsOptions::default()
+    }
+
+    pub fn kill_child(mut self) -> Self {
+        self.fork = true;
+        self.kill_child = true;
+        self
+    }
+
+    pub fn procfs(mut self) -> Self {
+        self.procfs = true;
+        self
+    }
+}
+
+pub trait NsCommand {
+    fn new_ns(&mut self, options: NsOptions) -> &mut Self;
+}
+
+impl NsCommand for tokio::process::Command {
+    fn new_ns(&mut self, options: NsOptions) -> &mut Self {
+        unsafe { self.pre_exec(move || pre_exec::pre_exec(options)) }
+    }
+}

--- a/exe-unit/tokio-process-ns/src/pre_exec.rs
+++ b/exe-unit/tokio-process-ns/src/pre_exec.rs
@@ -1,0 +1,70 @@
+use super::NsOptions;
+use libc::{prctl, PR_SET_PDEATHSIG};
+use nix::sched::{unshare, CloneFlags};
+use nix::sys::signal::Signal::{SIGKILL, SIGTERM};
+use nix::sys::wait::waitpid;
+use nix::unistd::{fork, ForkResult, Gid, Uid};
+use std::{fs, io};
+
+fn nix_to_io(e: nix::Error) -> io::Error {
+    match e {
+        nix::Error::Sys(errno) => errno.into(),
+        nix::Error::InvalidPath => io::Error::new(io::ErrorKind::NotFound, nix::Error::InvalidPath),
+        nix::Error::InvalidUtf8 => {
+            io::Error::new(io::ErrorKind::InvalidInput, nix::Error::InvalidUtf8)
+        }
+        nix::Error::UnsupportedOperation => {
+            io::Error::new(io::ErrorKind::Other, nix::Error::UnsupportedOperation)
+        }
+    }
+}
+
+pub fn pre_exec(options: NsOptions) -> io::Result<()> {
+    let uid = Uid::current();
+    let gid = Gid::current();
+    let mut flags = CloneFlags::CLONE_NEWUSER | CloneFlags::CLONE_NEWPID;
+    if options.procfs {
+        flags |= CloneFlags::CLONE_NEWNS;
+    }
+    unshare(flags).map_err(nix_to_io)?;
+    fs::write("/proc/self/setgroups", "deny")?;
+    fs::write("/proc/self/uid_map", format!("{} {} 1", uid, uid))?;
+    fs::write("/proc/self/gid_map", format!("{} {} 1", gid, gid))?;
+    if options.fork {
+        match fork().map_err(nix_to_io)? {
+            ForkResult::Parent { child, .. } => {
+                unsafe {
+                    prctl(PR_SET_PDEATHSIG, SIGTERM);
+                }
+                let _ = waitpid(child, None).map_err(nix_to_io)?;
+                std::process::exit(0);
+            }
+            _ => {
+                unsafe {
+                    prctl(PR_SET_PDEATHSIG, SIGKILL);
+                }
+                if options.procfs {
+                    nix::mount::mount::<str, _, str, str>(
+                        None,
+                        "/proc",
+                        None,
+                        nix::mount::MsFlags::MS_PRIVATE | nix::mount::MsFlags::MS_REC,
+                        None,
+                    )
+                    .unwrap();
+                    nix::mount::mount::<str, _, str, str>(
+                        Some("proc"),
+                        "/proc",
+                        Some("proc"),
+                        nix::mount::MsFlags::MS_NOSUID
+                            | nix::mount::MsFlags::MS_NOEXEC
+                            | nix::mount::MsFlags::MS_NODEV,
+                        None,
+                    )
+                    .unwrap();
+                }
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION

```
reqc@dell-s1:~/workspace/ya/yagna$ cargo run --example ns-shell -p tokio-process-ns
   Compiling tokio-process-ns v0.1.0 (/home/reqc/workspace/ya/yagna/exe-unit/tokio-process-ns)
    Finished dev [unoptimized + debuginfo] target(s) in 1.12s
     Running `target/debug/examples/ns-shell`
reqc@dell-s1:~/workspace/ya/yagna$ echo $$
1
reqc@dell-s1:~/workspace/ya/yagna$ ls /proc
1          dma          keys         mtrr          sys
289        driver       key-users    net           sysrq-trigger
acpi       execdomains  kmsg         pagetypeinfo  sysvipc
asound     fb           kpagecgroup  partitions    thread-self
buddyinfo  filesystems  kpagecount   pressure      timer_list
bus        fs           kpageflags   sched_debug   tty
cgroups    i8k          loadavg      schedstat     uptime
cmdline    interrupts   locks        scsi          version
consoles   iomem        mdstat       self          version_signature
cpuinfo    ioports      meminfo      slabinfo      vmallocinfo
crypto     irq          misc         softirqs      vmstat
devices    kallsyms     modules      stat          zoneinfo
diskstats  kcore        mounts       swaps
reqc@dell-s1:~/workspace/ya/yagna$ 
```
