### PR TITLE
restore `gftp` binary to be build by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6051,6 +6051,7 @@ dependencies = [
  "dotenv",
  "env_logger 0.7.1",
  "futures 0.3.5",
+ "gftp",
  "lazy_static",
  "log 0.4.11",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "GPL-3.0"
 edition = "2018"
 
 [features]
-default = ['market-forwarding', 'gnt-driver']
+default = ['market-forwarding', 'gnt-driver', "gftp/bin"]
 static-openssl = ["openssl/vendored"]
 market-forwarding = ['ya-market-forwarding']
 market-decentralized = ['ya-market-decentralized']
@@ -22,6 +22,7 @@ name = "yagna"
 path = "core/serv/src/main.rs"
 
 [dependencies]
+gftp="0.1" # just to enable gftp build for cargo-deb
 ya-activity = "0.2"
 ya-compile-time-utils = "0.1"
 ya-dummy-driver = { version = "0.1", optional = true }


### PR DESCRIPTION
I'm making gftp binary to be built by default bc it is included in deb build.

Other parts moved to separate PRs #563 #564 