### PR TITLE
Process utils: revert to setsid from tokio_process_ns::pre_exec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6029,7 +6029,6 @@ dependencies = [
  "nix 0.17.0",
  "shared_child",
  "tokio 0.2.22",
- "tokio-process-ns",
 ]
 
 [[package]]

--- a/utils/process/Cargo.toml
+++ b/utils/process/Cargo.toml
@@ -14,8 +14,5 @@ libc = "0.2"
 shared_child = "0.3.4"
 tokio = { version = "0.2.10", features = ["process", "signal"] }
 
-[target.'cfg(target_os = "linux")'.dependencies]
-tokio-process-ns = "0.1"
-
 [target.'cfg(target_family = "unix")'.dependencies]
 nix = "0.17.0"

--- a/utils/process/src/lib.rs
+++ b/utils/process/src/lib.rs
@@ -19,15 +19,10 @@ pub trait ProcessGroupExt<T> {
 }
 
 impl ProcessGroupExt<Command> for Command {
-    #[cfg(target_os = "linux")]
+    #[cfg(unix)]
     fn new_process_group(&mut self) -> &mut Command {
-        use tokio_process_ns::{NsCommand, NsOptions};
+        // FIXME: Linux: refactor and use the tokio-process-ns crate
 
-        self.new_ns(NsOptions::new().procfs().kill_child())
-    }
-
-    #[cfg(target_os = "macos")]
-    fn new_process_group(&mut self) -> &mut Command {
         use nix::Error;
         use std::io;
         use std::os::unix::process::CommandExt;
@@ -44,7 +39,7 @@ impl ProcessGroupExt<Command> for Command {
         self
     }
 
-    #[cfg(target_os = "windows")]
+    #[cfg(not(unix))]
     fn new_process_group(&mut self) -> &mut Command {
         self
     }


### PR DESCRIPTION
Reverts #542 due to:
- Exe unit not stopped, call to DestroyActivity failed: Timeout (Resolves #560)
- can't spawn ExeUnit: operation not permitted (Resolves #550)