### PR TITLE
Payment API: endpoints for listing accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5312,7 +5312,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=1bfbcfa25694c1638b81f86774137b4bdf3abb37#1bfbcfa25694c1638b81f86774137b4bdf3abb37"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=2c1776c268dd95f55b6064017834069062945b76#2c1776c268dd95f55b6064017834069062945b76"
 dependencies = [
  "awc",
  "backtrace",
@@ -5333,7 +5333,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=1bfbcfa25694c1638b81f86774137b4bdf3abb37#1bfbcfa25694c1638b81f86774137b4bdf3abb37"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=2c1776c268dd95f55b6064017834069062945b76#2c1776c268dd95f55b6064017834069062945b76"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,8 +137,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "2c1776c268dd95f55b6064017834069062945b76" }
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "2c1776c268dd95f55b6064017834069062945b76" }
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "099944b74c2743457feb825ccc4b8b3d83f587c4" }
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "099944b74c2743457feb825ccc4b8b3d83f587c4" }
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,8 +136,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "1bfbcfa25694c1638b81f86774137b4bdf3abb37" }
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "1bfbcfa25694c1638b81f86774137b4bdf3abb37" }
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "2c1776c268dd95f55b6064017834069062945b76" }
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "2c1776c268dd95f55b6064017834069062945b76" }
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/core/payment/examples/get_accounts.rs
+++ b/core/payment/examples/get_accounts.rs
@@ -1,0 +1,51 @@
+use structopt::StructOpt;
+use ya_client::payment::{PaymentProviderApi, PaymentRequestorApi};
+use ya_client::web::WebClient;
+use ya_client_model::payment::Account;
+
+#[derive(Clone, Debug, StructOpt)]
+struct Args {
+    #[structopt(short, long, default_value = "NGNT")]
+    platform: String,
+    #[structopt()]
+    provider_addr: String,
+    #[structopt()]
+    requestor_addr: String,
+}
+
+#[actix_rt::main]
+async fn main() -> anyhow::Result<()> {
+    let log_level = std::env::var("RUST_LOG").unwrap_or("info".to_owned());
+    std::env::set_var("RUST_LOG", log_level);
+    env_logger::init();
+
+    let args: Args = Args::from_args();
+
+    let client = WebClient::builder().build();
+    let provider: PaymentProviderApi = client.interface()?;
+    let requestor: PaymentRequestorApi = client.interface()?;
+
+    log::info!("Checking provider account...");
+    let provider_account = Account {
+        platform: args.platform.clone(),
+        address: args.provider_addr,
+    };
+    let provider_accounts = provider.get_accounts().await?;
+    assert!(provider_accounts
+        .iter()
+        .any(|account| account == &provider_account));
+    log::info!("OK.");
+
+    log::info!("Checking requestor account...");
+    let requestor_account = Account {
+        platform: args.platform.clone(),
+        address: args.requestor_addr,
+    };
+    let requestor_accounts = requestor.get_accounts().await?;
+    assert!(requestor_accounts
+        .iter()
+        .any(|account| account == &requestor_account));
+    log::info!("OK.");
+
+    Ok(())
+}

--- a/core/payment/src/api/requestor.rs
+++ b/core/payment/src/api/requestor.rs
@@ -6,7 +6,7 @@ use actix_web::web::{delete, get, post, put, Data, Json, Path, Query};
 use actix_web::{HttpResponse, Scope};
 use serde_json::value::Value::Null;
 use ya_client_model::payment::*;
-use ya_core_model::payment::local::{SchedulePayment, BUS_ID as LOCAL_SERVICE};
+use ya_core_model::payment::local::{GetAccounts, SchedulePayment, BUS_ID as LOCAL_SERVICE};
 use ya_core_model::payment::public::{
     AcceptDebitNote, AcceptInvoice, AcceptRejectError, BUS_ID as PUBLIC_SERVICE,
 };
@@ -52,6 +52,7 @@ pub fn register_endpoints(scope: Scope) -> Scope {
         )
         .route("/payments", get().to(get_payments))
         .route("/payments/{payment_id}", get().to(get_payment))
+        .route("/accounts", get().to(get_accounts))
 }
 
 // ************************** DEBIT NOTE **************************
@@ -462,4 +463,25 @@ async fn get_debit_note_payments(db: Data<DbExecutor>, path: Path<DebitNoteId>) 
 
 async fn get_invoice_payments(db: Data<DbExecutor>, path: Path<InvoiceId>) -> HttpResponse {
     response::not_implemented() // TODO
+}
+
+// *************************** ACCOUNTS ****************************
+
+async fn get_accounts(id: Identity) -> HttpResponse {
+    let node_id = id.identity.to_string();
+    let all_accounts = match bus::service(LOCAL_SERVICE).send(GetAccounts {}).await {
+        Ok(Ok(accounts)) => accounts,
+        Ok(Err(e)) => return response::server_error(&e),
+        Err(e) => return response::server_error(&e),
+    };
+    let recv_accounts: Vec<Account> = all_accounts
+        .into_iter()
+        .filter(|account| account.send)
+        .filter(|account| account.address == node_id) // TODO: Implement proper account permission system
+        .map(|account| Account {
+            platform: account.platform,
+            address: account.address,
+        })
+        .collect();
+    response::ok(recv_accounts)
 }


### PR DESCRIPTION
* GET /provider/accounts -- lists accounts in receive mode
* GET /requestor/accounts -- lists accounts in send mode

#### Testing instructions:

Start the payment API example:
```shell
$ cargo run --example payment_api
...
[2020-09-10T09:53:41Z INFO  ethkey] eth account EthAccount address: 0xeec0ee8e040addee4c65cc09c0d3e78f68f1ef56, path: "/home/adam/yagna/core/payment/provider.key" loaded
[2020-09-10T09:53:41Z INFO  ethkey] eth account EthAccount address: 0x0ccb64ef60c185dd39f42f791e4d12e96f66588f, path: "/home/adam/yagna/core/payment/requestor.key" loaded
...
```
Copy provider and requestor addresses printed in logs.

Run the get_accounts example to assert that accounts are properly listed.
```shell
$ cargo run --example get_accounts 0xeec0ee8e040addee4c65cc09c0d3e78f68f1ef56 0x0ccb64ef60c185dd39f42f791e4d12e96f66588f
[2020-09-10T09:48:00Z INFO  get_accounts] Checking provider account...
[2020-09-10T09:48:00Z INFO  get_accounts] OK.
[2020-09-10T09:48:00Z INFO  get_accounts] Checking requestor account...
[2020-09-10T09:48:00Z INFO  get_accounts] OK.
```