### PR TITLE
[sgx] exeunit: call VerifyAttestationEvidence remotely

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5599,7 +5599,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=9cdc79ef45fd7f26cb4314bf3dffc5afc765bf0d#9cdc79ef45fd7f26cb4314bf3dffc5afc765bf0d"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=8f369a35058b7ea2bbc708ec19d3a7e7496e0a13#8f369a35058b7ea2bbc708ec19d3a7e7496e0a13"
 dependencies = [
  "awc",
  "backtrace",
@@ -5608,9 +5608,13 @@ dependencies = [
  "envy",
  "failure",
  "futures 0.3.5",
+ "graphene",
  "hex",
+ "lazy_static",
  "log 0.4.11",
+ "openssl",
  "rand 0.6.5",
+ "secp256k1 0.17.2",
  "serde",
  "serde_json",
  "structopt",
@@ -5622,7 +5626,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=9cdc79ef45fd7f26cb4314bf3dffc5afc765bf0d#9cdc79ef45fd7f26cb4314bf3dffc5afc765bf0d"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=8f369a35058b7ea2bbc708ec19d3a7e7496e0a13#8f369a35058b7ea2bbc708ec19d3a7e7496e0a13"
 dependencies = [
  "bigdecimal",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5719,7 +5719,6 @@ dependencies = [
  "ya-client-model",
  "ya-compile-time-utils",
  "ya-core-model",
- "ya-net",
  "ya-runtime-api",
  "ya-sb-router",
  "ya-service-bus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5719,6 +5719,7 @@ dependencies = [
  "ya-client-model",
  "ya-compile-time-utils",
  "ya-core-model",
+ "ya-net",
  "ya-runtime-api",
  "ya-sb-router",
  "ya-service-bus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,8 +141,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "9cdc79ef45fd7f26cb4314bf3dffc5afc765bf0d" }
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "9cdc79ef45fd7f26cb4314bf3dffc5afc765bf0d" }
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "8f369a35058b7ea2bbc708ec19d3a7e7496e0a13" }
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "8f369a35058b7ea2bbc708ec19d3a7e7496e0a13" }
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/core/model/src/net.rs
+++ b/core/model/src/net.rs
@@ -173,7 +173,7 @@ pub trait RemoteEndpoint {
 impl RemoteEndpoint for NodeId {
     fn service(&self, bus_addr: &str) -> bus::Endpoint {
         bus::service(format!(
-            "{}/{}",
+            "{}{}",
             net_service(self),
             extract_exported_part(bus_addr)
         ))

--- a/core/model/src/sgx.rs
+++ b/core/model/src/sgx.rs
@@ -1,4 +1,9 @@
+pub use graphene::AttestationResponse;
 use serde::{Deserialize, Serialize};
+use ya_service_bus::RpcMessage;
+
+/// Public SGX bus address.
+pub const BUS_ID: &str = "/public/sgx";
 
 /// Error message for SGX service bus API.
 #[derive(thiserror::Error, Clone, Debug, Serialize, Deserialize)]
@@ -8,26 +13,16 @@ pub enum Error {
     Attestation(String),
 }
 
-pub mod local {
-    use super::*;
-    pub use graphene::AttestationResponse;
-    use ya_service_bus::RpcMessage;
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerifyAttestationEvidence {
+    pub production: bool,
+    pub ias_nonce: Option<String>,
+    pub enclave_quote: Vec<u8>,
+}
 
-    /// Local SGX bus address.
-    pub const BUS_ID: &str = "/local/sgx";
-
-    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-    #[serde(rename_all = "camelCase")]
-    pub struct VerifyAttestationEvidence {
-        pub production: bool,
-        pub ias_api_key: String,
-        pub ias_nonce: Option<String>,
-        pub enclave_quote: Vec<u8>,
-    }
-
-    impl RpcMessage for VerifyAttestationEvidence {
-        const ID: &'static str = "VerifyAttestationEvidence";
-        type Item = AttestationResponse;
-        type Error = Error;
-    }
+impl RpcMessage for VerifyAttestationEvidence {
+    const ID: &'static str = "VerifyAttestationEvidence";
+    type Item = AttestationResponse;
+    type Error = Error;
 }

--- a/core/sgx/src/service.rs
+++ b/core/sgx/src/service.rs
@@ -1,26 +1,23 @@
+use anyhow::Result;
+use graphene::IasClient;
+use std::env;
+use ya_core_model::sgx::Error;
+use ya_core_model::sgx::{AttestationResponse, VerifyAttestationEvidence, BUS_ID};
+use ya_service_bus::typed as bus;
+
 pub fn bind_gsb() {
-    local::bind_gsb();
+    let _ = bus::bind(&BUS_ID, verify_attestation_evidence);
 }
 
-mod local {
-    use anyhow::Result;
-    use graphene::IasClient;
-    use ya_core_model::sgx::local::{AttestationResponse, VerifyAttestationEvidence, BUS_ID};
-    use ya_core_model::sgx::Error;
-    use ya_service_bus::typed as bus;
-
-    pub fn bind_gsb() {
-        let _ = bus::bind(&BUS_ID, verify_attestation_evidence);
-    }
-
-    async fn verify_attestation_evidence(
-        msg: VerifyAttestationEvidence,
-    ) -> Result<AttestationResponse, Error> {
-        let ias = IasClient::new(msg.production, &msg.ias_api_key);
-        let response = ias
-            .verify_attestation_evidence(&msg.enclave_quote, msg.ias_nonce)
-            .await
-            .map_err(|e| Error::Attestation(format!("{}", e)))?;
-        Ok(response)
-    }
+async fn verify_attestation_evidence(
+    msg: VerifyAttestationEvidence,
+) -> Result<AttestationResponse, Error> {
+    let ias_api_key = env::var("IAS_API_KEY")
+        .map_err(|_| Error::Attestation("IAS_API_KEY variable not set".into()))?;
+    let ias = IasClient::new(msg.production, &ias_api_key);
+    let response = ias
+        .verify_attestation_evidence(&msg.enclave_quote, msg.ias_nonce)
+        .await
+        .map_err(|e| Error::Attestation(format!("{}", e)))?;
+    Ok(response)
 }

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -28,7 +28,6 @@ ya-agreement-utils = "0.1"
 ya-client-model = "0.1"
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.1", features = ["activity", "appkey"], path="../core/model" }
-ya-net = { version = "0.1", optional = true }
 ya-runtime-api = { version = "0.1", path = "runtime-api", features = ["server"] }
 ya-service-bus = "0.2"
 ya-transfer = "0.1"

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -28,6 +28,7 @@ ya-agreement-utils = "0.1"
 ya-client-model = "0.1"
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.1", features = ["activity", "appkey"], path="../core/model" }
+ya-net = { version = "0.1", optional = true }
 ya-runtime-api = { version = "0.1", path = "runtime-api", features = ["server"] }
 ya-service-bus = "0.2"
 ya-transfer = "0.1"


### PR DESCRIPTION
ExeUnit manifest must contain env var definition pointing to a yagna instance exporting `sgx/VerifyAttestationEvidence` GSB endpoint.

```
loader.env.IAS_SERVICE_ADDRESS = 0x9adc25a2bc8f1c698cc3cc34bd7c86b8954898c9
```

This yagna instance must have the `IAS_API_KEY` env variable set.