### PR TITLE
[std-utils] automatic error logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5961,6 +5961,7 @@ dependencies = [
 name = "ya-std-utils"
 version = "0.1.0"
 dependencies = [
+ "backtrace",
  "log 0.4.11",
 ]
 

--- a/core/market/decentralized/src/rest_api/common.rs
+++ b/core/market/decentralized/src/rest_api/common.rs
@@ -3,7 +3,7 @@ use actix_web::{HttpResponse, Responder, Scope};
 use std::sync::Arc;
 
 use ya_service_api_web::middleware::Identity;
-use ya_std_utils::ResultExt;
+use ya_std_utils::LogErr;
 
 use super::PathAgreement;
 use crate::db::model::OwnerType;
@@ -31,8 +31,7 @@ async fn get_agreement(
     let p_result = market.get_agreement(&p_agreement_id, &id).await;
 
     if p_result.is_err() && r_result.is_err() {
-        Err(AgreementError::NotFound(r_agreement_id))
-            .inspect_err(|e| log::error!("[GetAgreement] {}", e))
+        Err(AgreementError::NotFound(r_agreement_id)).log_err()
     } else if r_result.is_err() {
         p_result.map(|agreement| HttpResponse::Ok().json(agreement))
     } else if p_result.is_err() {

--- a/core/market/decentralized/src/rest_api/provider.rs
+++ b/core/market/decentralized/src/rest_api/provider.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use ya_client::model::market::{Offer, Proposal};
 use ya_service_api_web::middleware::Identity;
-use ya_std_utils::ResultExt;
+use ya_std_utils::LogErr;
 
 use crate::db::model::OwnerType;
 use crate::market::MarketService;
@@ -36,7 +36,7 @@ async fn subscribe(
     market
         .subscribe_offer(&body.into_inner(), &id)
         .await
-        .inspect_err(|e| log::error!("[SubscribeOffer] {}", e))
+        .log_err()
         .map(|id| HttpResponse::Created().json(id))
 }
 
@@ -45,7 +45,7 @@ async fn get_offers(market: Data<Arc<MarketService>>, id: Identity) -> impl Resp
     market
         .get_offers(Some(id))
         .await
-        .inspect_err(|e| log::error!("[GetOffer] {}", e))
+        .log_err()
         .map(|offers| HttpResponse::Ok().json(offers))
 }
 
@@ -58,7 +58,7 @@ async fn unsubscribe(
     market
         .unsubscribe_offer(&path.into_inner().subscription_id, &id)
         .await
-        .inspect_err(|e| log::error!("[UnsubscribeOffer] {}", e))
+        .log_err()
         .map(|_| HttpResponse::Ok().json("Ok"))
 }
 
@@ -76,7 +76,7 @@ async fn collect(
         .provider_engine
         .query_events(&subscription_id, timeout, max_events)
         .await
-        .inspect_err(|e| log::error!("[QueryEvents] {}", e))
+        .log_err()
         .map(|events| HttpResponse::Ok().json(events))
 }
 
@@ -96,7 +96,7 @@ async fn counter_proposal(
         .provider_engine
         .counter_proposal(&subscription_id, &proposal_id, &proposal, &id)
         .await
-        .inspect_err(|e| log::error!("[CounterProposal] {}", e))
+        .log_err()
         .map(|proposal_id| HttpResponse::Ok().json(proposal_id))
 }
 
@@ -142,7 +142,7 @@ async fn approve_agreement(
         .provider_engine
         .approve_agreement(id, &agreement_id, timeout)
         .await
-        .inspect_err(|e| log::error!("[ApproveAgreement] {}", e))
+        .log_err()
         .map(|_| HttpResponse::NoContent().finish())
 }
 

--- a/core/market/decentralized/src/rest_api/requestor.rs
+++ b/core/market/decentralized/src/rest_api/requestor.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use ya_client::model::market::{AgreementProposal, Demand, Proposal};
 use ya_service_api_web::middleware::Identity;
-use ya_std_utils::ResultExt;
+use ya_std_utils::LogErr;
 
 use crate::db::model::OwnerType;
 use crate::market::MarketService;
@@ -40,7 +40,7 @@ async fn subscribe(
     market
         .subscribe_demand(&body.into_inner(), &id)
         .await
-        .inspect_err(|e| log::error!("[SubscribeDemand] {}", e))
+        .log_err()
         .map(|id| HttpResponse::Created().json(id))
 }
 
@@ -62,7 +62,7 @@ async fn unsubscribe(
     market
         .unsubscribe_demand(&subscription_id, &id)
         .await
-        .inspect_err(|e| log::error!("[UnsubscribeDemand] {}", e))
+        .log_err()
         .map(|_| HttpResponse::Ok().json("Ok"))
 }
 
@@ -80,7 +80,7 @@ async fn collect(
         .requestor_engine
         .query_events(&subscription_id, timeout, max_events)
         .await
-        .inspect_err(|e| log::error!("[QueryEvents] {}", e))
+        .log_err()
         .map(|events| HttpResponse::Ok().json(events))
 }
 
@@ -100,7 +100,7 @@ async fn counter_proposal(
         .requestor_engine
         .counter_proposal(&subscription_id, &proposal_id, &proposal, &id)
         .await
-        .inspect_err(|e| log::error!("[CounterProposal] {}", e))
+        .log_err()
         .map(|proposal_id| HttpResponse::Ok().json(proposal_id))
 }
 
@@ -145,7 +145,7 @@ async fn create_agreement(
         .requestor_engine
         .create_agreement(id, &proposal_id, valid_to)
         .await
-        .inspect_err(|e| log::error!("[CreateAgreement] {}", e))
+        .log_err()
         .map(|agreement_id| HttpResponse::Ok().json(agreement_id.into_client()))
 }
 
@@ -160,7 +160,7 @@ async fn confirm_agreement(
         .requestor_engine
         .confirm_agreement(id, &agreement_id)
         .await
-        .inspect_err(|e| log::error!("[ConfirmAgreement] {}", e))
+        .log_err()
         .map(|_| HttpResponse::NoContent().finish())
 }
 
@@ -177,7 +177,7 @@ async fn wait_for_approval(
         .requestor_engine
         .wait_for_approval(&agreement_id, timeout)
         .await
-        .inspect_err(|e| log::error!("[WaitForApproval] {}", e))
+        .log_err()
         .map(|status| HttpResponse::Ok().json(status.to_string()))
 }
 

--- a/utils/std-utils/Cargo.toml
+++ b/utils/std-utils/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
+backtrace = "0.3.50"

--- a/utils/std-utils/src/lib.rs
+++ b/utils/std-utils/src/lib.rs
@@ -1,3 +1,3 @@
 mod result;
 
-pub use result::ResultExt;
+pub use result::LogErr;

--- a/utils/std-utils/src/result.rs
+++ b/utils/std-utils/src/result.rs
@@ -1,30 +1,47 @@
+use log::{Level, Record};
+
 pub trait LogErr<T, E: std::error::Error> {
     /// If Result is `Err`, this function logs it on error level
     /// and returns the same Result. In case of `Ok` nothing happens.
     fn log_err(self) -> Result<T, E>;
+    fn log_err_msg(self, message: &str) -> Result<T, E>;
 }
 
 impl<T, E: std::error::Error> LogErr<T, E> for Result<T, E> {
     fn log_err(self) -> Result<T, E> {
-        match self {
-            Err(e) => {
-                backtrace::trace(|frame| {
-                    let mut cont = true;
-                    backtrace::resolve_frame(frame, |symbol| {
-                        if let Some(name) = symbol.name().map(|s| s.to_string()) {
-                            if name.starts_with("<ya") {
-                                let name = name.strip_prefix("<").unwrap();
-                                let name = name.split(" as ").next().unwrap();
-                                log::error!("Error at {}: {}", name, &e);
-                                cont = false
+        self.log_err_msg("")
+    }
+
+    fn log_err_msg(self, message: &str) -> Result<T, E> {
+        if let Err(e) = self {
+            backtrace::trace(|frame| {
+                let mut cont = true;
+                backtrace::resolve_frame(frame, |symbol| {
+                    if let Some(name) = symbol.name() {
+                        let module_path = name.to_string();
+                        if module_path.starts_with("<ya") {
+                            let module_path = module_path.strip_prefix("<").unwrap();
+                            let module_path = module_path.split(" as ").next().unwrap();
+                            let mut msg = message;
+                            if msg.len() == 0 {
+                                msg = "Error occurred";
                             }
+                            log::logger().log(
+                                &Record::builder()
+                                    .level(Level::Error)
+                                    .args(format_args!("{}: {}", msg, e))
+                                    .module_path(Some(module_path))
+                                    .build(),
+                            );
+                            cont = false
                         }
-                    });
-                    cont
+                    }
                 });
-                Err(e)
-            }
-            _ => self,
+                cont
+            });
+            Err(e)
+        } else {
+            self
         }
     }
 }

--- a/utils/std-utils/src/result.rs
+++ b/utils/std-utils/src/result.rs
@@ -1,21 +1,30 @@
-pub trait ResultExt<T, E> {
+pub trait LogErr<T, E: std::error::Error> {
     /// If Result is `Err`, this function logs it on error level
     /// and returns the same Result. In case of `Ok` nothing happens.
-    fn inspect_err<F>(self, fun: F) -> Result<T, E>
-    where
-        F: FnOnce(&E);
+    fn log_err(self) -> Result<T, E>;
 }
 
-impl<T, E> ResultExt<T, E> for Result<T, E> {
-    fn inspect_err<F>(self, fun: F) -> Result<T, E>
-    where
-        F: FnOnce(&E),
-    {
-        if let Err(e) = self {
-            fun(&e);
-            Err(e)
-        } else {
-            self
+impl<T, E: std::error::Error> LogErr<T, E> for Result<T, E> {
+    fn log_err(self) -> Result<T, E> {
+        match self {
+            Err(e) => {
+                backtrace::trace(|frame| {
+                    let mut cont = true;
+                    backtrace::resolve_frame(frame, |symbol| {
+                        if let Some(name) = symbol.name().map(|s| s.to_string()) {
+                            if name.starts_with("<ya") {
+                                let name = name.strip_prefix("<").unwrap();
+                                let name = name.split(" as ").next().unwrap();
+                                log::error!("Error at {}: {}", name, &e);
+                                cont = false
+                            }
+                        }
+                    });
+                    cont
+                });
+                Err(e)
+            }
+            _ => self,
         }
     }
 }


### PR DESCRIPTION
Seems slow, but it was fun to do it.

Use `cargo test -p ya-market-decentralized --features ya-market-decentralized/market-test-suite --test test_rest_api -- --test-threads 1` to see how it works