### PR TITLE
Allow to add modes for already registered payment accounts

### DIFF
--- a/core/payment/src/processor.rs
+++ b/core/payment/src/processor.rs
@@ -79,8 +79,16 @@ impl DriverRegistry {
         }
 
         match self.accounts.entry((msg.platform, msg.address)) {
-            Entry::Occupied(_) => return Err(RegisterAccountError::AlreadyRegistered),
-            Entry::Vacant(entry) => entry.insert((msg.driver, msg.mode)),
+            Entry::Occupied(mut entry) => {
+                let (driver, mode) = entry.get_mut();
+                if driver != &msg.driver {
+                    return Err(RegisterAccountError::AlreadyRegistered);
+                }
+                *mode |= msg.mode;
+            }
+            Entry::Vacant(entry) => {
+                entry.insert((msg.driver, msg.mode));
+            }
         };
         Ok(())
     }


### PR DESCRIPTION
Once a payment account had been registered, it was impossible to change the mode (send/receive). Now, when re-registering the account with a new mode it would be added to the already registered mode. This allows to call `payment init -r` for the default identity.

----
Testing instructions:

1. Start yagna service with a clean data directory.
```
$ cargo run service run
```
2. Init NGNT driver for the default wallet.
```
$ cargo run payment init -r ngnt
```
3. Verify if the default wallet has been successfully initialized.
```
$ cargo run payment accounts

┌────────────┬──────────────────────────────────────────────┬──────────┬────────┬────────┐
│  platform  │  address                                     │  driver  │  send  │  recv  │
├────────────┼──────────────────────────────────────────────┼──────────┼────────┼────────┤
│  NGNT      │  0x6215f071f0d6806e84c72a7cb0cff7f9810e0bae  │  ngnt    │  X     │  X     │
└────────────┴──────────────────────────────────────────────┴──────────┴────────┴────────┘
```