### PR TITLE
[Windows] Fix for 'An existing connection was forcibly closed by the remote host' on GSB server when client shuts down.

### DIFF
--- a/service-bus/router/src/lib.rs
+++ b/service-bus/router/src/lib.rs
@@ -524,7 +524,7 @@ where
                     router.lock().await.handle_message(addr.clone(), msg)
                 })
                 .await
-                .unwrap_or_else(|e| log::error!("Error handling messages: {:?}", e));
+                .unwrap_or_else(|e| handle_message_error(e));
 
             router.lock().await.disconnect(&addr);
         });
@@ -548,6 +548,19 @@ where
                 future::ready(())
             })
             .await;
+    }
+}
+
+fn handle_message_error(e: anyhow::Error) {
+    match e.root_cause().downcast_ref::<std::io::Error>() {
+        Some(err) => {
+            if err.kind() == std::io::ErrorKind::ConnectionReset {
+                log::trace!("Ignoring TCP connection reset from GSB client...");
+            } else {
+                log::error!("Error handling messages: {:?}", err)
+            }
+        }
+        None => log::error!("Error handling messages: {:?}", e),
     }
 }
 


### PR DESCRIPTION
'An existing connection was forcibly closed by the remote host' on GSB server when client shuts down. This can be observed eg. after Yagna CLI calls to Yagna Daemon - a CLI command leaves 'An existing connection was forcibly closed by the remote host' in Daemon logs.

This is caused by the fact that TcpStream drop() implementation on Windows sends an RST frame to the server.

Proposed resolution:

Add code to ignore the RST (ConnectionReset) received from the GSB client.

No more 'An existing connection was forcibly closed by the remote host' error on Yagna CLI calls on both Windows and Linux.