### PR TITLE
Replace awc with hyper to bypass trust-dns issue on win 10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2091,10 +2091,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+dependencies = [
+ "bytes 0.5.6",
+ "http 0.2.1",
+]
+
+[[package]]
 name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+
+[[package]]
+name = "httpdate"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
@@ -2141,7 +2157,7 @@ dependencies = [
  "futures-cpupool",
  "h2 0.1.26",
  "http 0.1.21",
- "http-body",
+ "http-body 0.1.0",
  "httparse",
  "iovec",
  "itoa",
@@ -2157,7 +2173,31 @@ dependencies = [
  "tokio-tcp",
  "tokio-threadpool",
  "tokio-timer 0.2.13",
- "want",
+ "want 0.2.0",
+]
+
+[[package]]
+name = "hyper"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.2.6",
+ "http 0.2.1",
+ "http-body 0.3.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project",
+ "socket2",
+ "tokio 0.2.22",
+ "tower-service",
+ "tracing",
+ "want 0.3.0",
 ]
 
 [[package]]
@@ -4827,6 +4867,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+
+[[package]]
 name = "tracing"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5127,6 +5173,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
  "futures 0.1.29",
+ "log 0.4.11",
+ "try-lock",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
  "log 0.4.11",
  "try-lock",
 ]
@@ -5493,7 +5549,6 @@ dependencies = [
  "actix-http",
  "actix-rt",
  "anyhow",
- "awc",
  "bigdecimal",
  "bitflags 1.2.1",
  "chrono",
@@ -5506,6 +5561,7 @@ dependencies = [
  "ethkey",
  "futures 0.3.5",
  "hex",
+ "hyper 0.13.8",
  "lazy_static",
  "libsqlite3-sys",
  "log 0.4.11",

--- a/core/payment-driver/gnt/Cargo.toml
+++ b/core/payment-driver/gnt/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = { version = "0.1", features = ["with-diesel"] }
-ya-core-model = { version = "0.1", features = ["driver", "identity"] }
+ya-core-model = { version = "0.1", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.2"
@@ -16,7 +16,6 @@ actix-connect="1.0.1"
 actix-http="1.0.1"
 actix-rt = "1.0"
 anyhow = "1.0"
-awc = "1.0.1"
 bigdecimal = "0.1.0"
 bitflags = "1.2"
 chrono = { version = "0.4", features = ["serde"] }
@@ -26,6 +25,7 @@ ethereum-tx-sign = { git = "https://github.com/bidzyyys/ethereum-tx-sign" }
 ethereum-types = "0.6.0"
 futures3 = { version = "0.3", features = ["compat"], package = "futures" }
 hex = "0.4"
+hyper = "0.13"
 lazy_static = "1.4.0"
 log = "0.4.8"
 num-bigint = "0.2"

--- a/core/payment-driver/gnt/src/gnt/faucet.rs
+++ b/core/payment-driver/gnt/src/gnt/faucet.rs
@@ -1,7 +1,10 @@
 use crate::utils;
 use crate::{GNTDriverError, GNTDriverResult};
-use actix_rt::Arbiter;
 use ethereum_types::Address;
+use hyper::body::HttpBody as _;
+use hyper::client::HttpConnector;
+use hyper::http::uri::InvalidUri;
+use hyper::{Body, Uri};
 use std::{env, time};
 
 const MAX_ETH_FAUCET_REQUESTS: u32 = 6;
@@ -11,7 +14,7 @@ const ETH_FAUCET_ADDRESS_ENV_VAR: &str = "ETH_FAUCET_ADDRESS";
 const DEFAULT_ETH_FAUCET_ADDRESS: &str = "http://faucet.testnet.golem.network:4000/donate";
 
 pub struct EthFaucetConfig {
-    faucet_address: awc::http::Uri,
+    faucet_address: hyper::Uri,
 }
 
 impl EthFaucetConfig {
@@ -27,27 +30,37 @@ impl EthFaucetConfig {
 
     pub async fn request_eth(&self, address: Address) -> GNTDriverResult<()> {
         log::debug!("request eth");
-        let (resolver, bg) = trust_dns_resolver::AsyncResolver::from_system_conf().unwrap();
-        Arbiter::spawn(bg);
-        let tcp_connector = actix_connect::new_connector(resolver);
-        let client = awc::Client::build()
-            .connector(
-                actix_http::client::Connector::new()
-                    .connector(tcp_connector)
-                    .finish(),
-            )
-            .finish();
+        let client = hyper::Client::new();
         let request_url = format!("{}/{}", &self.faucet_address, utils::addr_to_str(address));
 
-        async fn try_request_eth(client: &awc::Client, url: &str) -> GNTDriverResult<()> {
+        async fn try_request_eth(
+            client: &hyper::Client<HttpConnector, Body>,
+            url: &str,
+        ) -> GNTDriverResult<()> {
+            let uri: Uri = url.parse().map_err(|e: InvalidUri| {
+                GNTDriverError::LibraryError(format!("URL parse() error: {}", e.to_string()))
+            })?;
             let body = client
-                .get(url)
-                .send()
+                .get(uri)
                 .await
-                .map_err(|e| GNTDriverError::LibraryError(e.to_string()))?
-                .body()
+                .map_err(|e| {
+                    GNTDriverError::LibraryError(format!(
+                        "Faucet request - Send() error: {}",
+                        e.to_string()
+                    ))
+                })?
+                .body_mut()
+                .data()
                 .await
-                .map_err(|e| GNTDriverError::LibraryError(e.to_string()))?;
+                .ok_or(GNTDriverError::LibraryError(String::from(
+                    "Faucet request returned empty response...",
+                )))?
+                .map_err(|e| {
+                    GNTDriverError::LibraryError(format!(
+                        "Faucet request - Body() error: {}",
+                        e.to_string()
+                    ))
+                })?;
             let resp = std::string::String::from_utf8_lossy(body.as_ref());
             if resp.contains("sufficient funds") || resp.contains("txhash") {
                 log::debug!("resp: {}", resp);


### PR DESCRIPTION
For some windows 10 users the faucet's simlpe http get request gets a timeout instantly.
When investigating this is caused by trust-dns not being able to resolve the hostname, when using a direct IP it works.

This PR solves it by replacing `awc` for `hyper` to resolve the issue.

Payment task: https://golemproject.atlassian.net/browse/PAY-62

Originally fixed in: https://github.com/golemfactory/yagna/pull/517
Extension/replacement of fix in: https://github.com/golemfactory/yagna/pull/499

Original bug in actix: https://github.com/actix/actix-web/issues/1047