### PR TITLE
Make 'driver' parameter optional for 'payment init' command

### DIFF
--- a/agent/provider/build-run-ya-provider.sh
+++ b/agent/provider/build-run-ya-provider.sh
@@ -164,7 +164,7 @@ main() {
     fi
 
     say "Register provider's payment account"
-    ensure ../target/debug/yagna payment init ngnt -p
+    ensure ../target/debug/yagna payment init -p
 
     sleep 10s # wait for other nodes (optional)
 

--- a/agent/provider/readme.md
+++ b/agent/provider/readme.md
@@ -401,7 +401,7 @@ you can now start Provider Agent.
 
 At first, you need to register provider's payment account:
 ```bash
-cargo run payment init ngnt -p
+cargo run payment init -p
 ```
 
 Then start the Provider Agent:
@@ -449,7 +449,7 @@ sed -e "s/__GENERATED_APP_KEY__/$APP_KEY/" -i.bckp .env
 1. We need to acquire funds from faucet on testnet (rinkeby).
 This can last a little bit long. Retry if not succeed at first.
 ```bash
-cargo run payment init ngnt -r
+cargo run payment init -r
 ```
 2. Check if you got credit on your account:
 ```bash

--- a/core/payment/src/accounts.rs
+++ b/core/payment/src/accounts.rs
@@ -1,3 +1,4 @@
+use crate::DEFAULT_PAYMENT_DRIVER;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::path::{Path, PathBuf};
@@ -5,8 +6,6 @@ use tokio::fs;
 use ya_core_model::driver::{driver_bus_id, AccountMode, Init};
 use ya_core_model::identity;
 use ya_service_bus::typed as bus;
-
-pub const DEFAULT_PAYMENT_DRIVER: &str = "ngnt";
 
 fn accounts_path(data_dir: &Path) -> PathBuf {
     match env::var("ACCOUNT_LIST").ok() {

--- a/core/payment/src/cli.rs
+++ b/core/payment/src/cli.rs
@@ -1,5 +1,5 @@
 use crate::accounts::{init_account, Account};
-use crate::DEFAULT_PAYMENT_PLATFORM;
+use crate::{DEFAULT_PAYMENT_DRIVER, DEFAULT_PAYMENT_PLATFORM};
 use structopt::*;
 use ya_core_model::{identity as id_api, payment::local as pay};
 use ya_service_api::{CliCtx, CommandOutput, ResponseTable};
@@ -9,12 +9,13 @@ use ya_service_bus::{typed as bus, RpcEndpoint};
 #[derive(StructOpt, Debug)]
 pub enum PaymentCli {
     Init {
-        driver: String,
         address: Option<String>,
         #[structopt(long, short)]
         requestor: bool,
         #[structopt(long, short)]
         provider: bool,
+        #[structopt(long, default_value = DEFAULT_PAYMENT_DRIVER)]
+        driver: String,
     },
     Status {
         address: Option<String>,

--- a/core/payment/src/lib.rs
+++ b/core/payment/src/lib.rs
@@ -24,6 +24,7 @@ pub mod migrations {
 }
 
 pub const DEFAULT_PAYMENT_PLATFORM: &str = "NGNT";
+pub const DEFAULT_PAYMENT_DRIVER: &str = "ngnt";
 
 pub struct PaymentService;
 


### PR DESCRIPTION
In order to simplify the usage of the command driver parameter has been transformed into `--driver` flag and made optional with 'ngnt' being the default value.

----
Testing instructions:

1. Start yagna service with a clean data directory.
```
$ cargo run service run
```
2. Init default driver for the default wallet.
```
$ cargo run payment init -r
```
3. Verify if the wallet has been successfully initialized.
```
$ cargo run payment accounts

┌────────────┬──────────────────────────────────────────────┬──────────┬────────┬────────┐
│  platform  │  address                                     │  driver  │  send  │  recv  │
├────────────┼──────────────────────────────────────────────┼──────────┼────────┼────────┤
│  NGNT      │  0x6215f071f0d6806e84c72a7cb0cff7f9810e0bae  │  ngnt    │  X     │  X     │
└────────────┴──────────────────────────────────────────────┴──────────┴────────┴────────┘
```