### PR TITLE
Added 'released' flag to allocation

### DIFF
--- a/core/payment/examples/release_allocation.rs
+++ b/core/payment/examples/release_allocation.rs
@@ -1,0 +1,116 @@
+use bigdecimal::BigDecimal;
+use chrono::Utc;
+use ya_client::payment::{PaymentProviderApi, PaymentRequestorApi};
+use ya_client::web::WebClient;
+use ya_client_model::payment::{Acceptance, NewAllocation, NewInvoice};
+
+#[actix_rt::main]
+async fn main() -> anyhow::Result<()> {
+    let log_level = std::env::var("RUST_LOG").unwrap_or("info".to_owned());
+    std::env::set_var("RUST_LOG", log_level);
+    env_logger::init();
+
+    let client = WebClient::builder().build();
+    let provider: PaymentProviderApi = client.interface()?;
+    let requestor: PaymentRequestorApi = client.interface()?;
+
+    log::info!("Creating allocation...");
+    let allocation = requestor
+        .create_allocation(&NewAllocation {
+            address: None,          // Use default address (i.e. identity)
+            payment_platform: None, // Use default payment platform
+            total_amount: BigDecimal::from(10u64),
+            timeout: None,
+            make_deposit: false,
+        })
+        .await?;
+    log::info!("Allocation created.");
+
+    log::info!("Verifying allocation...");
+    let allocations = requestor.get_allocations().await?;
+    assert_eq!(allocations.len(), 1);
+    assert_eq!(allocations[0], allocation);
+    let allocation1 = requestor.get_allocation(&allocation.allocation_id).await?;
+    assert_eq!(allocation1, allocation);
+    log::info!("Done.");
+
+    log::info!("Releasing allocation...");
+    requestor
+        .release_allocation(&allocation.allocation_id)
+        .await?;
+    log::info!("Allocation released.");
+
+    log::info!("Verifying allocation removal...");
+    let allocations = requestor.get_allocations().await?;
+    assert_eq!(allocations.len(), 0);
+    let result = requestor.get_allocation(&allocation.allocation_id).await;
+    assert!(result.is_err());
+    log::info!("Done.");
+
+    log::info!("Issuing invoice...");
+    let invoice = provider
+        .issue_invoice(&NewInvoice {
+            agreement_id: "agreement_id".to_string(),
+            activity_ids: None,
+            amount: BigDecimal::from(1u64),
+            payment_due_date: Utc::now(),
+        })
+        .await?;
+    log::info!("Invoice issued.");
+
+    log::info!("Sending invoice...");
+    provider.send_invoice(&invoice.invoice_id).await?;
+    log::info!("Invoice sent.");
+
+    log::info!("Attempting to accept invoice...");
+    let result = requestor
+        .accept_invoice(
+            &invoice.invoice_id,
+            &Acceptance {
+                total_amount_accepted: invoice.amount.clone(),
+                allocation_id: allocation.allocation_id,
+            },
+        )
+        .await;
+    assert!(result.is_err());
+    log::info!("Failed to accept invoice (as expected).");
+
+    log::info!("Creating another allocation...");
+    let allocation = requestor
+        .create_allocation(&NewAllocation {
+            address: None,          // Use default address (i.e. identity)
+            payment_platform: None, // Use default payment platform
+            total_amount: BigDecimal::from(10u64),
+            timeout: None,
+            make_deposit: false,
+        })
+        .await?;
+    log::info!("Allocation created.");
+
+    log::info!("Accepting invoice...");
+    requestor
+        .accept_invoice(
+            &invoice.invoice_id,
+            &Acceptance {
+                total_amount_accepted: invoice.amount.clone(),
+                allocation_id: allocation.allocation_id.clone(),
+            },
+        )
+        .await?;
+    log::info!("Invoice accepted.");
+
+    log::info!("Releasing allocation...");
+    requestor
+        .release_allocation(&allocation.allocation_id)
+        .await?;
+    log::info!("Allocation released.");
+
+    log::info!("Verifying allocation removal...");
+    let allocations = requestor.get_allocations().await?;
+    assert_eq!(allocations.len(), 0);
+    let result = requestor.get_allocation(&allocation.allocation_id).await;
+    assert!(result.is_err());
+    log::info!("Done.");
+
+    Ok(())
+}

--- a/core/payment/migrations/2020-01-23-123456_init/up.sql
+++ b/core/payment/migrations/2020-01-23-123456_init/up.sql
@@ -90,7 +90,8 @@ CREATE TABLE pay_allocation(
     spent_amount VARCHAR(32) NOT NULL,
     remaining_amount VARCHAR(32) NOT NULL,
     timeout DATETIME NULL,
-    make_deposit BOOLEAN NOT NULL
+    make_deposit BOOLEAN NOT NULL,
+    released BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE pay_payment(

--- a/core/payment/src/api/requestor.rs
+++ b/core/payment/src/api/requestor.rs
@@ -415,8 +415,7 @@ async fn release_allocation(
     let allocation_id = path.allocation_id.clone();
     let node_id = id.identity;
     let dao: AllocationDao = db.as_dao();
-    // TODO: Introduce 'released' flag instead of deleting
-    match dao.delete(allocation_id, node_id).await {
+    match dao.release(allocation_id, node_id).await {
         Ok(true) => response::ok(Null),
         Ok(false) => response::not_found(),
         Err(e) => response::server_error(&e),

--- a/core/payment/src/models/allocation.rs
+++ b/core/payment/src/models/allocation.rs
@@ -18,6 +18,7 @@ pub struct WriteObj {
     pub remaining_amount: BigDecimalField,
     pub timeout: Option<NaiveDateTime>,
     pub make_deposit: bool,
+    pub released: bool,
 }
 
 impl WriteObj {
@@ -34,6 +35,7 @@ impl WriteObj {
             remaining_amount: allocation.total_amount.into(),
             timeout: allocation.timeout.map(|v| v.naive_utc()),
             make_deposit: allocation.make_deposit,
+            released: false,
         }
     }
 }

--- a/core/payment/src/schema.rs
+++ b/core/payment/src/schema.rs
@@ -56,6 +56,7 @@ table! {
         remaining_amount -> Text,
         timeout -> Nullable<Timestamp>,
         make_deposit -> Bool,
+        released -> Bool,
     }
 }
 


### PR DESCRIPTION
Instead of hard deleting, allocations are now released by setting a boolean flag. Allocations marked as released are filtered out from query results making them non-existent to API clients. Keeping records in the database instead of deleting allows to avoid foreign key constraint violations (allocations are referred by payments and payment orders).

----
Testing instructions:

1. Start `payment_api` with **clean database** using NGNT driver (dummy driver is too fast to test what happens when payment is completed after releasing the allocation).
```
$ cargo run --example payment_api -- --driver=ngnt
```

2. In another terminal run the `release_allocation` example.
```
$ cargo run --example release_allocation
    Finished dev [unoptimized + debuginfo] target(s) in 0.25s
     Running `/home/adam/yagna/target/debug/examples/release_allocation`
[2020-09-30T13:06:12Z INFO  release_allocation] Creating allocation...
[2020-09-30T13:06:12Z INFO  release_allocation] Allocation created.
[2020-09-30T13:06:12Z INFO  release_allocation] Verifying allocation...
[2020-09-30T13:06:12Z INFO  release_allocation] Done.
[2020-09-30T13:06:12Z INFO  release_allocation] Releasing allocation...
[2020-09-30T13:06:12Z INFO  release_allocation] Allocation released.
[2020-09-30T13:06:12Z INFO  release_allocation] Verifying allocation removal...
[2020-09-30T13:06:12Z INFO  release_allocation] Done.
[2020-09-30T13:06:12Z INFO  release_allocation] Issuing invoice...
[2020-09-30T13:06:12Z INFO  release_allocation] Invoice issued.
[2020-09-30T13:06:12Z INFO  release_allocation] Sending invoice...
[2020-09-30T13:06:12Z INFO  release_allocation] Invoice sent.
[2020-09-30T13:06:12Z INFO  release_allocation] Attempting to accept invoice...
[2020-09-30T13:06:12Z INFO  release_allocation] Failed to accept invoice (as expected).
[2020-09-30T13:06:12Z INFO  release_allocation] Creating another allocation...
[2020-09-30T13:06:12Z INFO  release_allocation] Allocation created.
[2020-09-30T13:06:12Z INFO  release_allocation] Accepting invoice...
[2020-09-30T13:06:13Z INFO  release_allocation] Invoice accepted.
[2020-09-30T13:06:13Z INFO  release_allocation] Releasing allocation...
[2020-09-30T13:06:13Z INFO  release_allocation] Allocation released.
[2020-09-30T13:06:13Z INFO  release_allocation] Verifying allocation removal...
[2020-09-30T13:06:13Z INFO  release_allocation] Done.
```

3. Look into the `payment_api` example logs. Wait for the payment to complete successfully.
```
...
[2020-09-30T13:08:00Z INFO  ya_gnt_driver::gnt::sender] tx_hash=0x2de7…9448, processed
```