### PR TITLE
Update account not registered error with hint

### DIFF
--- a/core/payment/src/error.rs
+++ b/core/payment/src/error.rs
@@ -112,7 +112,7 @@ pub mod processor {
     use ya_core_model::payment::public::SendError;
 
     #[derive(thiserror::Error, Debug)]
-    #[error("Account not registered. platform={platform} address={address} mode={mode:?}")]
+    #[error("Account not registered. Hint: Did you run `yagna payment init -r` after restarting? platform={platform} address={address} mode={mode:?}")]
     pub struct AccountNotRegistered {
         platform: String,
         address: String,

--- a/core/payment/src/error.rs
+++ b/core/payment/src/error.rs
@@ -112,7 +112,10 @@ pub mod processor {
     use ya_core_model::payment::public::SendError;
 
     #[derive(thiserror::Error, Debug)]
-    #[error("Account not registered. Hint: Did you run `yagna payment init -r` after restarting? platform={platform} address={address} mode={mode:?}")]
+    #[error(
+        "Account not registered. Hint: Did you run `yagna payment init -{}` after restarting? platform={platform} address={address} mode={mode:?}",
+        if *.mode == AccountMode::SEND {"r"} else {"p"}
+    )]
     pub struct AccountNotRegistered {
         platform: String,
         address: String,


### PR DESCRIPTION
To help users resolve this error themselves: Add a hint that solves this problem in 99% of the cases.