### PR TITLE
Clean up log messages around faucet request.

### DIFF
--- a/core/payment-driver/gnt/src/gnt/faucet.rs
+++ b/core/payment-driver/gnt/src/gnt/faucet.rs
@@ -51,9 +51,9 @@ impl EthFaucetConfig {
         log::info!("Requesting Eth from faucet");
         let client = awc::Client::new();
         let request_url = format!("{}/{}", &self.faucet_address, utils::addr_to_str(address));
+        log::debug!("faucet request url: {}", request_url);
 
         async fn try_request_eth(client: &awc::Client, url: &str) -> GNTDriverResult<()> {
-            log::debug!("url: {}", url);
             let body = client
                 .get(url)
                 .send()

--- a/core/payment-driver/gnt/src/gnt/faucet.rs
+++ b/core/payment-driver/gnt/src/gnt/faucet.rs
@@ -63,7 +63,7 @@ impl EthFaucetConfig {
                 .await
                 .map_err(|e| GNTDriverError::LibraryError(e.to_string()))?;
             let resp = std::string::String::from_utf8_lossy(body.as_ref());
-            log::debug!("resp: {}", resp);
+            log::debug!("raw faucet response: {}", resp);
             if resp.contains("sufficient funds") || resp.contains("txhash") {
                 return Ok(());
             }
@@ -82,7 +82,7 @@ impl EthFaucetConfig {
                     );
                 } else {
                     log::warn!(
-                        "Failed to request Eth from Faucet, retrying ({}/{}): {:?}",
+                        "Retrying ({}/{}) to request Eth from Faucet after failure: {:?}",
                         i + 1,
                         MAX_ETH_FAUCET_REQUESTS,
                         e


### PR DESCRIPTION
Resolves #650 

```
[2020-10-07T11:40:59Z INFO  ya_gnt_driver::gnt::faucet] Requesting Eth from faucet
[2020-10-07T11:41:00Z WARN  ya_gnt_driver::gnt::faucet] Failed to request Eth from Faucet, retrying (1/6): LibraryError("Failed to connect to host: Timeout out while establishing connection")
[2020-10-07T11:41:03Z WARN  ya_gnt_driver::gnt::faucet] Failed to request Eth from Faucet, retrying (2/6): LibraryError("Failed to connect to host: Timeout out while establishing connection")
[2020-10-07T11:41:06Z WARN  ya_gnt_driver::gnt::faucet] Failed to request Eth from Faucet, retrying (3/6): LibraryError("Failed to connect to host: Timeout out while establishing connection")
[2020-10-07T11:41:09Z WARN  ya_gnt_driver::gnt::faucet] Failed to request Eth from Faucet, retrying (4/6): LibraryError("Failed to connect to host: Timeout out while establishing connection")
[2020-10-07T11:41:12Z WARN  ya_gnt_driver::gnt::faucet] Failed to request Eth from Faucet, retrying (5/6): LibraryError("Failed to connect to host: Timeout out while establishing connection")
[2020-10-07T11:41:15Z ERROR ya_gnt_driver::gnt::faucet] Failed to request Eth from Faucet, tried 6 times.: LibraryError("Failed to connect to host: Timeout out while establishing connection")
```