### PR TITLE
Decentralized Market as default + ver bump + .env-template refresh

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -15,12 +15,15 @@ YAGNA_DATADIR="."
 #GSB_URL=tcp://127.0.0.1:7464
 
 ## REST API
-# Default URL for all APIs.
+#
+# Default HOST:PORT for all REST APIs.
 #YAGNA_API_URL=http://127.0.0.1:7465
-# Specific API URLs.
-#YAGNA_MARKET_URL=http://3.249.139.167:8080/market-api/v1/  # this is default
-#YAGNA_ACTIVITY_URL=http://127.0.0.1:5001/activity-api/v1/
-#YAGNA_PAYMENT_URL=http://127.0.0.1:5001/payment-api/v1/
+#
+# Specific API URLs
+# (default values are derived from YAGNA_API_URL)
+#YAGNA_MARKET_URL=http://127.0.0.1:7465/market-api/v1/
+#YAGNA_ACTIVITY_URL=http://127.0.0.1:7465/activity-api/v1/
+#YAGNA_PAYMENT_URL=http://127.0.0.1:7465/payment-api/v1/
 
 # Central Net Mk1 hub.
 #CENTRAL_NET_HOST=3.249.139.167:7464
@@ -35,7 +38,7 @@ YAGNA_DATADIR="."
 
 # Ethereum chain: rinkeby or mainnet
 #CHAIN=rinkeby
-ETH_FAUCET_ADDRESS=http://faucet.testnet.golem.network:4000/donate
+#ETH_FAUCET_ADDRESS=http://faucet.testnet.golem.network:4000/donate
 #GETH_ADDRESS=http://1.geth.testnet.golem.network:55555
 #NGNT_CONTRACT_ADDRESS=0xd94e3DC39d4Cad1DAd634e7eb585A57A19dC7EFE
 #NGNT_FAUCET_CONTRACT_ADDRESS=0x59259943616265A03d775145a2eC371732E2B06C
@@ -53,7 +56,7 @@ ETH_FAUCET_ADDRESS=http://faucet.testnet.golem.network:4000/donate
 
 # Grace period for killing exe-unit ie. delay between SIGTERM and SIGKILL is send.
 # Minimum is 1s.
-# PROCESS_KILL_TIMEOUT_SECONDS=5
+#PROCESS_KILL_TIMEOUT_SECONDS=5
 
 ## Agents
 
@@ -63,4 +66,4 @@ EXE_UNIT_PATH=../exe-unit/resources/local-debug-exeunits-descriptor.json
 # Subnetwork identifier. You can set this value to filter nodes
 # with other identifiers than selected. Useful for test purposes.
 # Can be any arbitrary string, not only a number.
-#SUBNET=1234567890
+#SUBNET=testnet

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6147,7 +6147,7 @@ dependencies = [
 
 [[package]]
 name = "yagna"
-version = "0.3.4-alpha.0"
+version = "0.4.0"
 dependencies = [
  "actix-rt",
  "actix-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yagna"
-version = "0.3.4-alpha.0"
+version = "0.4.0"
 description = "Open platform and marketplace for distributed computations"
 readme = "README.md"
 authors = ["Golem Factory <contact@golem.network>"]
@@ -10,7 +10,7 @@ license = "GPL-3.0"
 edition = "2018"
 
 [features]
-default = ['market-forwarding', 'gnt-driver', 'gftp/bin']
+default = ['market-decentralized', 'gnt-driver', 'gftp/bin']
 static-openssl = ["openssl/vendored"]
 market-forwarding = ['ya-market-forwarding']
 market-decentralized = ['ya-market-decentralized', 'gftp/bin']
@@ -120,7 +120,6 @@ ya-market-forwarding = { path = "core/market/forwarding" }
 ya-market-resolver = { path = "core/market/resolver" }
 ya-net = { path = "core/net" }
 ya-payment = { path = "core/payment" }
-
 
 ## CORE UTILS
 ya-core-model = { path = "core/model" }

--- a/core/market/decentralized/readme.md
+++ b/core/market/decentralized/readme.md
@@ -1,13 +1,5 @@
 # Decentralized market Mk1
 
-## Running yagna with decentralized market
-
-You can enable decentralized market using cargo features.
-Run yagna daemon with flags:
-```
-cargo run --no-default-features --features market-decentralized --features gnt-driver service run
-```
-
 ## Running decentralized market test suite
 
 To test market-test-suite run:
@@ -31,20 +23,4 @@ add `env_logger::init();` on the beginning.
 
 ```
 RUST_LOG=debug cargo test -p ya-market-decentralized --features ya-market-decentralized/market-test-suite 
-```
-
-### Building .deb
-Prerequisites: 
-- You need cargo-deb installed (`cargo install cargo-deb`).
-- Build .deb on the oldest operating system version, you want to support.
-Otherwise linking with GLIBC will fail.
-
-Build yagna with all binaries needed in .deb:
-```
-cargo build --release --no-default-features --features market-decentralized --features gnt-driver --workspace
-```
-
-Run cargo-deb using binaries compiled in the previous step:
-```
-cargo deb --deb-version $(git rev-parse --short HEAD) --no-build
 ```


### PR DESCRIPTION
Decentralized Market is already a default in Alpha.dwa release.
Now after all teams confirmed that we can go, I'm making it a default in master.

It is worth noting that @maaktweluit has confirmed decentralized market impl is compatible with the test-harness via
https://github.com/golemfactory/yagna-integration/runs/1197888812?check_suite_focus=true

Also refreshing `.env-template` as requested by @Wiezzel 