### PR TITLE
NGNT driver: wait for ETH before requesting NGNT

### DIFF
--- a/core/payment-driver/gnt/src/gnt/ethereum.rs
+++ b/core/payment-driver/gnt/src/gnt/ethereum.rs
@@ -184,6 +184,11 @@ impl EthereumClient {
             .await?;
         Ok(tx_receipt)
     }
+
+    pub async fn get_balance(&self, address: Address) -> EthereumClientResult<U256> {
+        let balance = self.web3.eth().balance(address, None).compat().await?;
+        Ok(balance)
+    }
 }
 
 #[cfg(test)]

--- a/core/payment-driver/gnt/src/gnt/faucet.rs
+++ b/core/payment-driver/gnt/src/gnt/faucet.rs
@@ -12,7 +12,6 @@ use trust_dns_resolver::TokioAsyncResolver;
 
 const MAX_ETH_FAUCET_REQUESTS: u32 = 6;
 const ETH_FAUCET_SLEEP: time::Duration = time::Duration::from_secs(2);
-const INIT_ETH_SLEEP: time::Duration = time::Duration::from_secs(15);
 const ETH_FAUCET_ADDRESS_ENV_VAR: &str = "ETH_FAUCET_ADDRESS";
 const DEFAULT_ETH_FAUCET_ADDRESS: &str = "http://faucet.testnet.golem.network:4000/donate";
 
@@ -125,9 +124,7 @@ impl EthFaucetConfig {
                     tokio::time::delay_for(ETH_FAUCET_SLEEP).await;
                 }
             } else {
-                log::info!("Succesfully requested Eth, waiting...");
-                tokio::time::delay_for(INIT_ETH_SLEEP).await;
-                log::info!("Finished requesting Eth from faucet");
+                log::info!("Successfully requested Eth.");
                 return Ok(());
             }
         }


### PR DESCRIPTION
Instead of sleeping a fixed amount of time, check the account balance periodically until ETH from faucet is received or timeout (3 minutes) is reached.