### PR TITLE
ZkSync faucet

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -6,7 +6,7 @@ NODE_NAME=__YOUR_NODE_NAME_GOES_HERE__
 
 # Log level.
 # Default is info, but if you want to debug this is a magic setup, to skip payment driver overwhelming logs
-#RUST_LOG=debug,tokio_core=info,tokio_reactor=info,hyper=info
+#RUST_LOG=debug,tokio_core=info,tokio_reactor=info,hyper=info,reqwest=info
 
 # Application working directory path.
 YAGNA_DATADIR="."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4af87564ff659dee8f9981540cac9418c45e910c8072fdedd643a262a38fcaf"
 dependencies = [
- "actix-http",
+ "actix-http 1.0.1",
  "actix-rt",
  "actix_derive",
  "bitflags 1.2.1",
@@ -78,12 +78,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-connect"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177837a10863f15ba8d3ae3ec12fac1099099529ed20083a27fdfe247381d0dc"
+dependencies = [
+ "actix-codec 0.3.0",
+ "actix-rt",
+ "actix-service",
+ "actix-utils 2.0.0",
+ "derive_more 0.99.11",
+ "either",
+ "futures-util",
+ "http 0.2.1",
+ "log 0.4.11",
+ "trust-dns-proto 0.19.5",
+ "trust-dns-resolver 0.19.5",
+]
+
+[[package]]
 name = "actix-files"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "193b22cb1f7b4ff12a4eb2415d6d19e47e44ea93e05930b30d05375ea29d3529"
 dependencies = [
- "actix-http",
+ "actix-http 1.0.1",
  "actix-service",
  "actix-web",
  "bitflags 1.2.1",
@@ -105,7 +124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c16664cc4fdea8030837ad5a845eb231fb93fc3c5c171edfefb52fad92ce9019"
 dependencies = [
  "actix-codec 0.2.0",
- "actix-connect",
+ "actix-connect 1.0.2",
  "actix-rt",
  "actix-service",
  "actix-threadpool",
@@ -143,7 +162,54 @@ dependencies = [
  "serde_urlencoded",
  "sha1",
  "slab 0.4.2",
- "time",
+ "time 0.1.44",
+]
+
+[[package]]
+name = "actix-http"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05dd80ba8f27c4a34357c07e338c8f5c38f8520e6d626ca1727d8fecc41b0cab"
+dependencies = [
+ "actix-codec 0.3.0",
+ "actix-connect 2.0.0",
+ "actix-rt",
+ "actix-service",
+ "actix-threadpool",
+ "actix-utils 2.0.0",
+ "base64 0.12.3",
+ "bitflags 1.2.1",
+ "brotli2",
+ "bytes 0.5.6",
+ "cookie 0.14.2",
+ "copyless",
+ "derive_more 0.99.11",
+ "either",
+ "encoding_rs",
+ "flate2",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "fxhash",
+ "h2 0.2.6",
+ "http 0.2.1",
+ "httparse",
+ "indexmap",
+ "itoa",
+ "language-tags",
+ "lazy_static",
+ "log 0.4.11",
+ "mime 0.3.16",
+ "percent-encoding 2.1.0",
+ "pin-project",
+ "rand 0.7.3",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sha-1",
+ "slab 0.4.2",
+ "time 0.2.22",
 ]
 
 [[package]]
@@ -306,7 +372,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3158e822461040822f0dbf1735b9c2ce1f95f93b651d7a7aded00b1efbb1f635"
 dependencies = [
  "actix-codec 0.2.0",
- "actix-http",
+ "actix-http 1.0.1",
  "actix-macros",
  "actix-router",
  "actix-rt",
@@ -317,7 +383,7 @@ dependencies = [
  "actix-tls",
  "actix-utils 1.0.6",
  "actix-web-codegen",
- "awc",
+ "awc 1.0.1",
  "bytes 0.5.6",
  "derive_more 0.99.11",
  "encoding_rs",
@@ -331,7 +397,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "time",
+ "time 0.1.44",
  "url 2.1.1",
 ]
 
@@ -721,7 +787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7601d4d1d7ef2335d6597a41b5fe069f6ab799b85f53565ab390e7b7065aac5"
 dependencies = [
  "actix-codec 0.2.0",
- "actix-http",
+ "actix-http 1.0.1",
  "actix-rt",
  "actix-service",
  "base64 0.11.0",
@@ -731,6 +797,29 @@ dependencies = [
  "log 0.4.11",
  "mime 0.3.16",
  "openssl",
+ "percent-encoding 2.1.0",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+]
+
+[[package]]
+name = "awc"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150e00c06683ab44c5f97d033950e5d87a7a042d06d77f5eecb443cbd23d0575"
+dependencies = [
+ "actix-codec 0.3.0",
+ "actix-http 2.0.0",
+ "actix-rt",
+ "actix-service",
+ "base64 0.12.3",
+ "bytes 0.5.6",
+ "derive_more 0.99.11",
+ "futures-core",
+ "log 0.4.11",
+ "mime 0.3.16",
  "percent-encoding 2.1.0",
  "rand 0.7.3",
  "serde",
@@ -751,6 +840,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base-x"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
 
 [[package]]
 name = "base64"
@@ -1134,7 +1229,7 @@ dependencies = [
  "num-traits",
  "rustc-serialize",
  "serde",
- "time",
+ "time 0.1.44",
  "winapi 0.3.9",
 ]
 
@@ -1216,6 +1311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce90df4c658c62f12d78f7508cf92f9173e5184a539c10bfe54a3107b3ffd0f2"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,8 +1328,19 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 dependencies = [
- "time",
+ "time 0.1.44",
  "url 1.7.2",
+]
+
+[[package]]
+name = "cookie"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1373a16a4937bc34efec7b391f9c1500c30b8478a701a4f44c9165cc0475a6e0"
+dependencies = [
+ "percent-encoding 2.1.0",
+ "time 0.2.22",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -1643,6 +1755,12 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "dotenv"
@@ -2756,7 +2874,7 @@ dependencies = [
  "log 0.3.9",
  "mime 0.2.6",
  "num_cpus",
- "time",
+ "time 0.1.44",
  "traitobject",
  "typeable",
  "unicase 1.4.2",
@@ -2781,7 +2899,7 @@ dependencies = [
  "log 0.4.11",
  "net2",
  "rustc_version",
- "time",
+ "time 0.1.44",
  "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor",
@@ -5435,6 +5553,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "standback"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e0831040d2cf2bdfd51b844be71885783d489898a192f254ae25d57cce725c"
+dependencies = [
+ "version_check 0.9.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5445,6 +5572,55 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "serde",
+ "serde_derive",
+ "syn 1.0.45",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn 1.0.45",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stream-cipher"
@@ -5714,6 +5890,44 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b7151c9065e80917fbf285d9a5d1432f60db41d170ccafc749a136b41a93af"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check 0.9.2",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.24",
+ "quote 1.0.7",
+ "standback",
+ "syn 1.0.45",
 ]
 
 [[package]]
@@ -6335,7 +6549,7 @@ dependencies = [
  "ascii",
  "base64 0.10.1",
  "chunked_transfer",
- "cookie",
+ "cookie 0.12.0",
  "encoding",
  "lazy_static",
  "qstring",
@@ -6917,7 +7131,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e90c91653a82525747f213c865d7f8509b77d62f98d106533f0121fa5d9c5c66"
 dependencies = [
- "awc",
+ "awc 1.0.1",
  "backtrace",
  "bytes 0.5.6",
  "chrono",
@@ -6938,7 +7152,7 @@ name = "ya-client"
 version = "0.4.0"
 source = "git+https://github.com/golemfactory/ya-client.git?rev=e7a293bef1a5f2b7d9a26801ed2b7e8590828bc3#e7a293bef1a5f2b7d9a26801ed2b7e8590828bc3"
 dependencies = [
- "awc",
+ "awc 1.0.1",
  "backtrace",
  "bytes 0.5.6",
  "chrono",
@@ -7097,11 +7311,11 @@ name = "ya-gnt-driver"
 version = "0.1.0"
 dependencies = [
  "actix",
- "actix-connect",
- "actix-http",
+ "actix-connect 1.0.2",
+ "actix-http 1.0.1",
  "actix-rt",
  "anyhow",
- "awc",
+ "awc 1.0.1",
  "bigdecimal",
  "bitflags 1.2.1",
  "chrono",
@@ -7146,7 +7360,7 @@ dependencies = [
  "actix-web",
  "anyhow",
  "appdirs",
- "awc",
+ "awc 1.0.1",
  "base64 0.12.3",
  "chrono",
  "diesel",
@@ -7180,7 +7394,7 @@ dependencies = [
 name = "ya-market-decentralized"
 version = "0.1.0"
 dependencies = [
- "actix-http",
+ "actix-http 1.0.1",
  "actix-rt",
  "actix-service",
  "actix-web",
@@ -7232,7 +7446,7 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "anyhow",
- "awc",
+ "awc 1.0.1",
  "chrono",
  "diesel",
  "diesel_migrations",
@@ -7601,7 +7815,7 @@ dependencies = [
  "actix-web",
  "actix-web-httpauth",
  "anyhow",
- "awc",
+ "awc 1.0.1",
  "env_logger 0.7.1",
  "futures 0.3.6",
  "log 0.4.11",
@@ -7668,12 +7882,12 @@ name = "ya-transfer"
 version = "0.1.0"
 dependencies = [
  "actix-files",
- "actix-http",
+ "actix-http 1.0.1",
  "actix-rt",
  "actix-web",
  "anyhow",
  "async-compression",
- "awc",
+ "awc 1.0.1",
  "bytes 0.5.6",
  "env_logger 0.7.1",
  "futures 0.3.6",
@@ -7752,6 +7966,7 @@ dependencies = [
  "actix",
  "anyhow",
  "async-trait",
+ "awc 2.0.0",
  "bigdecimal",
  "chrono",
  "dotenv",
@@ -7759,6 +7974,7 @@ dependencies = [
  "ethkey",
  "futures 0.3.6",
  "hex",
+ "lazy_static",
  "log 0.4.11",
  "num",
  "serde_json",
@@ -7868,7 +8084,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "thiserror",
- "time",
+ "time 0.1.44",
  "tokio 0.2.22",
  "tokio-byteorder",
 ]

--- a/core/payment-driver/zksync/Cargo.toml
+++ b/core/payment-driver/zksync/Cargo.toml
@@ -11,14 +11,16 @@ default = []
 actix = "0.9"
 async-trait = "0.1"
 anyhow = "1.0"
-num = { version = "0.2", features = ["serde"] }
+awc = "2.0.0"
 bigdecimal = { version = "0.1.0" }
 zksync = { git = "https://github.com/matter-labs/zksync", branch = "master"}
 zksync_eth_signer = { git = "https://github.com/matter-labs/zksync", branch = "master"}
 chrono = { version = "0.4", features = ["serde"] }
 futures3 = { version = "0.3", features = ["compat"], package = "futures" }
 hex = "0.4"
+lazy_static = "1.4"
 log = "0.4.8"
+num = { version = "0.2", features = ["serde"] }
 serde_json = "^1.0"
 tiny-keccak = "1.4.2"
 tokio = { version = "0.2", features = ["full"] }

--- a/core/payment-driver/zksync/src/faucet.rs
+++ b/core/payment-driver/zksync/src/faucet.rs
@@ -1,0 +1,65 @@
+// External crates
+use bigdecimal::BigDecimal;
+use chrono::{Duration, Utc};
+use lazy_static::lazy_static;
+use std::str::FromStr;
+use std::{env, time};
+use zksync::zksync_types::H160;
+
+// Workspace uses
+use ya_core_model::driver::GenericError;
+
+// Local uses
+use crate::zksync::account_balance;
+
+const DEFAULT_FAUCET_ADDR: &str = "http://3.249.139.167:5778/zk/donatex";
+
+lazy_static! {
+    static ref FAUCET_ADDR: String =
+        env::var("ZKSYNC_FAUCET_ADDR").unwrap_or(DEFAULT_FAUCET_ADDR.to_string());
+    static ref MIN_BALANCE: BigDecimal = BigDecimal::from(50);
+    static ref MAX_WAIT: Duration = Duration::minutes(1);
+}
+
+pub async fn request_ngnt(address: &str) -> Result<(), GenericError> {
+    let addr = H160::from_str(&address[2..]).map_err(GenericError::new)?;
+    let balance = account_balance(addr).await?;
+    if balance >= *MIN_BALANCE {
+        return Ok(());
+    }
+
+    log::info!(
+        "Requesting NGNT from zkSync faucet... address = {}",
+        address
+    );
+    let client = awc::Client::new();
+    let response = client
+        .get(format!("{}/{}", *FAUCET_ADDR, address))
+        .send()
+        .await
+        .map_err(GenericError::new)?
+        .body()
+        .await
+        .map_err(GenericError::new)?;
+    let response = String::from_utf8_lossy(response.as_ref());
+    log::info!("Funds requested. Response = {}", response);
+    // TODO: Verify tx hash
+
+    wait_for_ngnt(addr).await?;
+    Ok(())
+}
+
+async fn wait_for_ngnt(addr: H160) -> Result<(), GenericError> {
+    log::info!("Waiting for NGNT from faucet...");
+    let wait_until = Utc::now() + *MAX_WAIT;
+    while Utc::now() < wait_until {
+        if account_balance(addr).await? >= *MIN_BALANCE {
+            log::info!("Received NGNT from faucet.");
+            return Ok(());
+        }
+        tokio::time::delay_for(time::Duration::from_secs(3)).await;
+    }
+    let msg = "Waiting for NGNT timed out.";
+    log::error!("{}", msg);
+    Err(GenericError::new(msg))
+}

--- a/core/payment-driver/zksync/src/lib.rs
+++ b/core/payment-driver/zksync/src/lib.rs
@@ -3,12 +3,14 @@
 #[macro_use]
 extern crate log;
 
+mod faucet;
 mod service;
 mod utils;
 pub mod zksync;
 
 pub const PLATFORM_NAME: &'static str = "ZK-NGNT";
 pub const DRIVER_NAME: &'static str = "zksync";
+pub const ZKSYNC_TOKEN_NAME: &'static str = "GNT";
 
 pub struct PaymentDriverService;
 

--- a/core/payment-driver/zksync/src/utils.rs
+++ b/core/payment-driver/zksync/src/utils.rs
@@ -74,3 +74,28 @@ fn increase_least_significant_digit(amount: &BigUint) -> BigUint {
     }
     amount.clone() // zero
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_increase_least_significant_digit() {
+        let amount = BigUint::from_str("999000").unwrap();
+        let increased = increase_least_significant_digit(&amount);
+        let expected = BigUint::from_str("1000000").unwrap();
+        assert_eq!(increased, expected);
+    }
+
+    #[test]
+    fn test_pack_up() {
+        let amount = BigUint::from_str("12300285190700000000").unwrap();
+        let packable = pack_up(&amount);
+        assert!(
+            zksync::utils::is_token_amount_packable(&packable),
+            "Not packable!"
+        );
+        assert!(packable >= amount, "To little!");
+    }
+}

--- a/core/payment-driver/zksync/src/utils.rs
+++ b/core/payment-driver/zksync/src/utils.rs
@@ -1,9 +1,10 @@
 // External uses
 use bigdecimal::BigDecimal;
 use futures3::{Future, FutureExt};
+use lazy_static::lazy_static;
 use num::bigint::ToBigInt;
 use num::pow::pow;
-use num::BigUint;
+use num::{BigInt, BigUint};
 use std::pin::Pin;
 use tokio::task;
 use zksync::utils::{closest_packable_token_amount, is_token_amount_packable};
@@ -15,10 +16,10 @@ use ya_core_model::driver::GenericError;
 use ya_core_model::identity;
 use ya_service_bus::{typed as bus, RpcEndpoint};
 
-// Copied from core/payment-driver/gnt/utils.rs
-
-// TODO: Get token decimals from zksync-provider / wallet
-const PRECISION: u64 = 1_000_000_000_000_000_000;
+lazy_static! {
+    // TODO: Get token decimals from zksync-provider / wallet
+    static ref PRECISION: BigDecimal = BigDecimal::from(1_000_000_000_000_000_000u64);
+}
 
 pub fn sign_tx(
     node_id: NodeId,
@@ -40,7 +41,7 @@ pub fn sign_tx(
 }
 
 pub fn big_dec_to_big_uint(v: BigDecimal) -> Result<BigUint, GenericError> {
-    let v = v * Into::<BigDecimal>::into(PRECISION);
+    let v = v * &(*PRECISION);
     let v = v
         .to_bigint()
         .ok_or(GenericError::new("Failed to convert to bigint"))?;
@@ -50,9 +51,9 @@ pub fn big_dec_to_big_uint(v: BigDecimal) -> Result<BigUint, GenericError> {
     Ok(v)
 }
 
-pub fn big_uint_to_big_dec(v: BigUint) -> Result<BigDecimal, GenericError> {
-    let v: BigDecimal = v.to_string().parse().map_err(GenericError::new)?;
-    Ok(v / Into::<BigDecimal>::into(PRECISION))
+pub fn big_uint_to_big_dec(v: BigUint) -> BigDecimal {
+    let v: BigDecimal = Into::<BigInt>::into(v).into();
+    v / &(*PRECISION)
 }
 
 /// Find the closest **bigger** packable amount

--- a/core/payment-driver/zksync/src/zksync.rs
+++ b/core/payment-driver/zksync/src/zksync.rs
@@ -1,18 +1,78 @@
 // External uses
 use async_trait::async_trait;
 use bigdecimal::{BigDecimal, Zero};
+use lazy_static::lazy_static;
 use num::BigUint;
+use std::env;
+use std::str::FromStr;
 use tiny_keccak::keccak256;
-use zksync::{Provider, Network};
-use zksync::zksync_types::{tx::{PackedEthSignature, TxEthSignature}, Address, H160};
+use zksync::zksync_types::{
+    tx::{PackedEthSignature, TxEthSignature},
+    Address, H160,
+};
+use zksync::{Network, Provider, Wallet, WalletCredentials};
 use zksync_eth_signer::{error::SignerError, EthereumSigner, RawTransaction};
 
 // Workspace uses
+use ya_core_model::driver::GenericError;
 
 // Local uses
-use crate::utils::{sign_tx, big_uint_to_big_dec};
+use crate::utils::{big_uint_to_big_dec, sign_tx};
 use crate::ZKSYNC_TOKEN_NAME;
-use ya_core_model::driver::GenericError;
+
+lazy_static! {
+    pub static ref NETWORK: Network = {
+        let chain_id = env::var("CHAIN_ID")
+            .unwrap_or("rinkeby".to_string())
+            .to_lowercase();
+        match chain_id.as_str() {
+            "rinkeby" => Network::Rinkeby,
+            "mainnet" => Network::Mainnet,
+            _ => panic!(format!("Invalid chain id: {}", chain_id)),
+        }
+    };
+    static ref PROVIDER: Provider = Provider::new(*NETWORK);
+}
+
+pub fn get_provider() -> Provider {
+    (*PROVIDER).clone()
+}
+
+pub async fn get_wallet(addr: &str) -> Result<Wallet<YagnaEthSigner>, GenericError> {
+    let addr = Address::from_str(&addr[2..]).map_err(GenericError::new)?;
+    let provider = get_provider();
+    let signer = YagnaEthSigner::new(addr);
+    let credentials = WalletCredentials::from_eth_signer(addr, signer, *NETWORK)
+        .await
+        .map_err(GenericError::new)?;
+    let wallet = Wallet::new(provider, credentials)
+        .await
+        .map_err(GenericError::new)?;
+    Ok(wallet)
+}
+
+pub async fn unlock_wallet<S: EthereumSigner + Clone>(
+    wallet: Wallet<S>,
+) -> Result<(), GenericError> {
+    if !wallet
+        .is_signing_key_set()
+        .await
+        .map_err(GenericError::new)?
+    {
+        log::info!("Unlocking wallet... address = {}", wallet.signer.address);
+        let unlock = wallet
+            .start_change_pubkey()
+            .fee_token(ZKSYNC_TOKEN_NAME)
+            .map_err(GenericError::new)?
+            .send()
+            .await
+            .map_err(GenericError::new)?;
+        info!("Unlock tx: {:?}", unlock);
+        let tx_info = unlock.wait_for_commit().await.map_err(GenericError::new)?;
+        log::info!("Wallet unlocked. tx_info = {:?}", tx_info);
+    }
+    Ok(())
+}
 
 pub struct YagnaEthSigner {
     eth_address: Address,
@@ -79,8 +139,7 @@ fn convert_to_eth_byte_order(signature: Vec<u8>) -> Vec<u8> {
 }
 
 pub async fn account_balance(addr: H160) -> Result<BigDecimal, GenericError> {
-    // TODO: Make chainid from a config like GNT driver
-    let provider = Provider::new(Network::Rinkeby);
+    let provider = get_provider();
     let acc_info = provider
         .account_info(addr)
         .await

--- a/core/payment/examples/payment_api.rs
+++ b/core/payment/examples/payment_api.rs
@@ -160,7 +160,7 @@ fn fake_sign_tx(sign_tx: Box<dyn Fn(Vec<u8>) -> Pin<Box<dyn Future<Output = Vec<
 async fn main() -> anyhow::Result<()> {
     std::env::set_var(
         "RUST_LOG",
-        "debug,tokio_core=info,tokio_reactor=info,hyper=info",
+        "debug,tokio_core=info,tokio_reactor=info,hyper=info,reqwest=info",
     );
     env_logger::init();
     dotenv::dotenv().expect("Failed to read .env file");


### PR DESCRIPTION
Added a faucet integration for the zkSync payment driver. If account is initialized in send mode the driver requests funds via an HTTP request and waits for deposit (max. 1 minute).

Moved wallet unlocking from `schedule_payment` to `init`.

----
Testing: Try payment_api + invoice_flow **without** importing keys from PoC.