### PR TITLE
[ExeUnit] Fix secp256k1 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4390,31 +4390,13 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2932dc07acd2066ff2e3921a4419606b220ba6cd03a9935123856cc534877056"
-dependencies = [
- "rand 0.6.5",
- "secp256k1-sys 0.1.2",
-]
-
-[[package]]
-name = "secp256k1"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
 dependencies = [
- "secp256k1-sys 0.3.0",
+ "rand 0.6.5",
+ "secp256k1-sys",
  "serde",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab2c26f0d3552a0f12e639ae8a64afc2e3db9c52fe32f5fc6c289d38519f220"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -6281,7 +6263,7 @@ dependencies = [
  "rand 0.6.5",
  "regex",
  "reqwest",
- "secp256k1 0.17.2",
+ "secp256k1 0.19.0",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -51,7 +51,7 @@ log = "0.4.8"
 rand = "0.6"
 regex = "1.3.4"
 reqwest = { version = "0.10.7", optional = true }
-secp256k1 = { version = "0.17.2", optional = true }
+secp256k1 = { version = ">=0.17,<0.20", optional = true }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8.11"


### PR DESCRIPTION
Currently, the sgx `exe-unit` binary does not build due to secp256k1 version mismatch in `ya-client`