### PR TITLE
Market unsubscribe demand fix (the release branch)

### DIFF
--- a/core/market/decentralized/src/negotiation/notifier.rs
+++ b/core/market/decentralized/src/negotiation/notifier.rs
@@ -84,13 +84,15 @@ where
     pub async fn wait_for_event(&mut self) -> Result<(), NotifierError<Type>> {
         while let Ok(value) = self.receiver.recv().await {
             match value {
-                Notification::<Type>::NewEvent(value) => {
-                    if value == self.subscription_id {
+                Notification::<Type>::NewEvent(subscription_id) => {
+                    if subscription_id == self.subscription_id {
                         return Ok(());
                     }
                 }
                 Notification::<Type>::StopEvents(subscription_id) => {
-                    return Err(NotifierError::Unsubscribed(subscription_id));
+                    if subscription_id == self.subscription_id {
+                        return Err(NotifierError::Unsubscribed(subscription_id));
+                    }
                 }
             }
         }

--- a/core/market/decentralized/tests/test_initial_proposal.rs
+++ b/core/market/decentralized/tests/test_initial_proposal.rs
@@ -356,13 +356,15 @@ async fn test_simultaneous_query_events() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
-/// Run two query events in the same time.
-/// The same event shouldn't be returned twice.
+/// Subscribe two Demands, query events for one, unsubscribe second and subscribe Offer.
+/// This should result in single ProposalEvent.
+/// Caught after Alpha.3 release by testnet checker running simultanously
+/// two yapapi blender examples using same app-key.
 #[cfg_attr(not(feature = "market-test-suite"), ignore)]
 #[actix_rt::test]
 #[serial_test::serial]
 async fn test_unsubscribe_demand_while_query_events_for_other() -> Result<(), anyhow::Error> {
-    let network = MarketsNetwork::new(None)
+    let network = MarketsNetwork::new("test_unsubscribe_demand_while_query_events_for_other")
         .await
         .add_market_instance("Node-1")
         .await?;


### PR DESCRIPTION
* test case added
* [mkt] Notifier: throw Unsubscribed error for matching subscription id only

on par with #742 but to the release branch