### PR TITLE
[service-bus] q&d fix for connection panic

### DIFF
--- a/service-bus/bus/src/connection.rs
+++ b/service-bus/bus/src/connection.rs
@@ -457,6 +457,12 @@ where
     H: CallRequestHandler + 'static,
 {
     fn handle(&mut self, item: Result<GsbMessage, ProtocolError>, ctx: &mut Self::Context) {
+        if let Err(e) = item.as_ref() {
+            log::error!("protocol error {}", e);
+            ctx.stop();
+            return;
+        }
+
         match item.unwrap() {
             GsbMessage::RegisterReply(r) => {
                 if let Some(code) = register_reply_code(r.code) {


### PR DESCRIPTION
quick & dirty fix for daemon crashing (windows)

```
thread 'main' panicked at 'called Result::unwrap() on an Err value: Io(Os { code: 10054, kind: ConnectionReset, message: "Istniejące połączenie zostało gwałtownie zamknięte przez zdalnego hosta." })', D:\a\yagna\yagna\service-bus\bus\src\connection.rs:460:20
```