### PR TITLE
REST API logging macro added to Market APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ members = [
     "service-bus/util",
     "utils/actix_utils",
     "utils/agreement-utils",
+    "utils/api-macros",
     "utils/compile-time-utils",
     "utils/path",
     "utils/process",
@@ -168,6 +169,7 @@ ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev =
 gftp = { path = "core/gftp" }
 tokio-process-ns = { path = "exe-unit/tokio-process-ns" }
 ya-agreement-utils = { path = "utils/agreement-utils" }
+ya-api-macros = { path = "utils/api-macros" }
 ya-std-utils = { path = "utils/std-utils" }
 ya-compile-time-utils = { path = "utils/compile-time-utils" }
 ya-exe-unit = { path = "exe-unit" }

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -12,6 +12,7 @@ testing = ["actix-http", "actix-rt", "actix-service", "env_logger"]
 
 [dependencies]
 ya-agreement-utils = "0.1"
+ya-api-macros = "0.1"
 ya-std-utils = "0.1"
 ya-client = "0.4"
 ya-core-model = { version = "0.2", features = ["market", "net"] }

--- a/core/market/src/rest_api.rs
+++ b/core/market/src/rest_api.rs
@@ -5,7 +5,7 @@
 //! No market logic is allowed here.
 
 use actix_web::{error::InternalError, http::StatusCode, web::PathConfig};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use ya_client::model::ErrorMessage;
 
@@ -29,29 +29,29 @@ pub fn path_config() -> PathConfig {
     })
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone)]
 pub struct PathAgreement {
     pub agreement_id: String,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct PathSubscription {
     pub subscription_id: SubscriptionId,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct PathSubscriptionProposal {
     pub subscription_id: SubscriptionId,
     pub proposal_id: ProposalId,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct QueryTimeout {
     #[serde(rename = "timeout", default = "default_query_timeout")]
     pub timeout: f32,
 }
 
-#[derive(Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct QueryTimeoutCommandIndex {
     #[serde(rename = "timeout")]
     pub timeout: Option<f32>,
@@ -59,7 +59,7 @@ pub struct QueryTimeoutCommandIndex {
     pub command_index: Option<usize>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct QueryTimeoutMaxEvents {
     /// number of seconds to wait
     #[serde(rename = "timeout", default = "default_event_timeout")]

--- a/core/market/src/rest_api/common.rs
+++ b/core/market/src/rest_api/common.rs
@@ -15,6 +15,7 @@ pub fn register_endpoints(scope: Scope) -> Scope {
 }
 
 #[actix_web::get("/agreements/{agreement_id}")]
+#[ya_api_macros::log_api_call(name = "GetAgreement", path = "path", id = "id")]
 async fn get_agreement(
     market: Data<Arc<MarketService>>,
     path: Path<PathAgreement>,

--- a/core/market/src/rest_api/provider.rs
+++ b/core/market/src/rest_api/provider.rs
@@ -28,6 +28,7 @@ pub fn register_endpoints(scope: Scope) -> Scope {
 }
 
 #[actix_web::post("/offers")]
+#[ya_api_macros::log_api_call(name = "SubscribeOffer", body = "body", id = "id")]
 async fn subscribe(
     market: Data<Arc<MarketService>>,
     body: Json<DemandOfferBase>,
@@ -41,6 +42,7 @@ async fn subscribe(
 }
 
 #[actix_web::get("/offers")]
+#[ya_api_macros::log_api_call(name = "GetOffers", id = "id")]
 async fn get_offers(market: Data<Arc<MarketService>>, id: Identity) -> impl Responder {
     market
         .get_offers(Some(id))
@@ -50,6 +52,7 @@ async fn get_offers(market: Data<Arc<MarketService>>, id: Identity) -> impl Resp
 }
 
 #[actix_web::delete("/offers/{subscription_id}")]
+#[ya_api_macros::log_api_call(name = "UnsubscribeOffer", path = "path", id = "id")]
 async fn unsubscribe(
     market: Data<Arc<MarketService>>,
     path: Path<PathSubscription>,
@@ -63,6 +66,7 @@ async fn unsubscribe(
 }
 
 #[actix_web::get("/offers/{subscription_id}/events")]
+#[ya_api_macros::log_api_call(name = "CollectDemands", path = "path", query = "query", id = "_id")]
 async fn collect(
     market: Data<Arc<MarketService>>,
     path: Path<PathSubscription>,
@@ -81,6 +85,12 @@ async fn collect(
 }
 
 #[actix_web::post("/offers/{subscription_id}/proposals/{proposal_id}")]
+#[ya_api_macros::log_api_call(
+    name = "CounterProposalOffer",
+    path = "path",
+    body = "body",
+    id = "id"
+)]
 async fn counter_proposal(
     market: Data<Arc<MarketService>>,
     path: Path<PathSubscriptionProposal>,
@@ -101,6 +111,7 @@ async fn counter_proposal(
 }
 
 #[actix_web::get("/offers/{subscription_id}/proposals/{proposal_id}")]
+#[ya_api_macros::log_api_call(name = "GetProposalDemand", path = "path", id = "_id")]
 async fn get_proposal(
     market: Data<Arc<MarketService>>,
     path: Path<PathSubscriptionProposal>,
@@ -121,6 +132,7 @@ async fn get_proposal(
 }
 
 #[actix_web::delete("/offers/{subscription_id}/proposals/{proposal_id}")]
+#[ya_api_macros::log_api_call(name = "RejectProposalDemand", path = "path", id = "id")]
 async fn reject_proposal(
     market: Data<Arc<MarketService>>,
     path: Path<PathSubscriptionProposal>,
@@ -140,6 +152,7 @@ async fn reject_proposal(
 }
 
 #[actix_web::post("/agreements/{agreement_id}/approve")]
+#[ya_api_macros::log_api_call(name = "ApproveAgreement", path = "path", query = "query", id = "id")]
 async fn approve_agreement(
     market: Data<Arc<MarketService>>,
     path: Path<PathAgreement>,
@@ -157,6 +170,7 @@ async fn approve_agreement(
 }
 
 #[actix_web::post("/agreements/{agreement_id}/reject")]
+#[ya_api_macros::log_api_call(name = "RejectAgreement", path = "_path", id = "_id")]
 async fn reject_agreement(
     _market: Data<Arc<MarketService>>,
     _path: Path<PathAgreement>,
@@ -166,6 +180,7 @@ async fn reject_agreement(
 }
 
 #[actix_web::post("/agreements/{agreement_id}/terminate")]
+#[ya_api_macros::log_api_call(name = "TerminateAgreement", path = "_path", id = "_id")]
 async fn terminate_agreement(
     _market: Data<Arc<MarketService>>,
     _path: Path<PathAgreement>,

--- a/core/market/src/rest_api/requestor.rs
+++ b/core/market/src/rest_api/requestor.rs
@@ -32,6 +32,7 @@ pub fn register_endpoints(scope: Scope) -> Scope {
 }
 
 #[actix_web::post("/demands")]
+#[ya_api_macros::log_api_call(name = "SubscribeDemand", body = "body", id = "id")]
 async fn subscribe(
     market: Data<Arc<MarketService>>,
     body: Json<DemandOfferBase>,
@@ -45,6 +46,7 @@ async fn subscribe(
 }
 
 #[actix_web::get("/demands")]
+#[ya_api_macros::log_api_call(name = "GetDemands", id = "id")]
 async fn get_demands(market: Data<Arc<MarketService>>, id: Identity) -> impl Responder {
     market
         .get_demands(Some(id))
@@ -53,6 +55,7 @@ async fn get_demands(market: Data<Arc<MarketService>>, id: Identity) -> impl Res
 }
 
 #[actix_web::delete("/demands/{subscription_id}")]
+#[ya_api_macros::log_api_call(name = "UnsubscribeDemand", path = "path", id = "id")]
 async fn unsubscribe(
     market: Data<Arc<MarketService>>,
     path: Path<PathSubscription>,
@@ -67,6 +70,7 @@ async fn unsubscribe(
 }
 
 #[actix_web::get("/demands/{subscription_id}/events")]
+#[ya_api_macros::log_api_call(name = "CollectOffers", path = "path", query = "query", id = "_id")]
 async fn collect(
     market: Data<Arc<MarketService>>,
     path: Path<PathSubscription>,
@@ -85,6 +89,12 @@ async fn collect(
 }
 
 #[actix_web::post("/demands/{subscription_id}/proposals/{proposal_id}")]
+#[ya_api_macros::log_api_call(
+    name = "CounterProposalDemand",
+    path = "path",
+    body = "body",
+    id = "id"
+)]
 async fn counter_proposal(
     market: Data<Arc<MarketService>>,
     path: Path<PathSubscriptionProposal>,
@@ -105,6 +115,7 @@ async fn counter_proposal(
 }
 
 #[actix_web::get("/demands/{subscription_id}/proposals/{proposal_id}")]
+#[ya_api_macros::log_api_call(name = "GetProposalOffer", path = "path", id = "_id")]
 async fn get_proposal(
     market: Data<Arc<MarketService>>,
     path: Path<PathSubscriptionProposal>,
@@ -125,6 +136,7 @@ async fn get_proposal(
 }
 
 #[actix_web::delete("/demands/{subscription_id}/proposals/{proposal_id}")]
+#[ya_api_macros::log_api_call(name = "RejectProposalOffer", path = "path", id = "id")]
 async fn reject_proposal(
     market: Data<Arc<MarketService>>,
     path: Path<PathSubscriptionProposal>,
@@ -144,6 +156,7 @@ async fn reject_proposal(
 }
 
 #[actix_web::post("/agreements")]
+#[ya_api_macros::log_api_call(name = "CreateAgreement", body = "body", id = "id")]
 async fn create_agreement(
     market: Data<Arc<MarketService>>,
     body: Json<AgreementProposal>,
@@ -160,6 +173,7 @@ async fn create_agreement(
 }
 
 #[actix_web::post("/agreements/{agreement_id}/confirm")]
+#[ya_api_macros::log_api_call(name = "ConfirmAgreement", path = "path", id = "id")]
 async fn confirm_agreement(
     market: Data<Arc<MarketService>>,
     path: Path<PathAgreement>,
@@ -175,6 +189,7 @@ async fn confirm_agreement(
 }
 
 #[actix_web::post("/agreements/{agreement_id}/wait")]
+#[ya_api_macros::log_api_call(name = "WaitForApproval", path = "path", query = "query", id = "_id")]
 async fn wait_for_approval(
     market: Data<Arc<MarketService>>,
     path: Path<PathAgreement>,
@@ -192,6 +207,7 @@ async fn wait_for_approval(
 }
 
 #[actix_web::delete("/agreements/{agreement_id}")]
+#[ya_api_macros::log_api_call(name = "CancelAgreement", path = "_path", id = "_id")]
 async fn cancel_agreement(
     _market: Data<Arc<MarketService>>,
     _path: Path<PathAgreement>,
@@ -201,6 +217,7 @@ async fn cancel_agreement(
 }
 
 #[actix_web::post("/agreements/{agreement_id}/terminate")]
+#[ya_api_macros::log_api_call(name = "TerminateAgreement", path = "_path", id = "_id")]
 async fn terminate_agreement(
     _market: Data<Arc<MarketService>>,
     _path: Path<PathAgreement>,

--- a/utils/api-macros/Cargo.toml
+++ b/utils/api-macros/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ya-api-macros"
+version = "0.1.0"
+authors = ["Golem Factory <contact@golem.network>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies.quote]
+version = "1.0.3"
+
+[dependencies.syn]
+version = "^1"
+features = ["full"]

--- a/utils/api-macros/src/lib.rs
+++ b/utils/api-macros/src/lib.rs
@@ -1,0 +1,128 @@
+//! Macros for use with Tokio
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+
+use quote::quote;
+
+/// Marks async function to be wrapped in logging calls.
+///
+/// ## Usage
+///
+/// ```rust
+/// #[api_macros::log_api_call]
+/// async fn api_method(serv, body, identity) {
+///     ...method body...
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn log_api_call(attributes: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input = syn::parse_macro_input!(item as syn::ItemFn);
+    let attrs = &input.attrs;
+    let vis = &input.vis;
+    let sig = &mut input.sig;
+    let body = &input.block;
+    let name = &sig.ident;
+
+    if sig.asyncness.is_none() {
+        return syn::Error::new_spanned(sig.fn_token, "only async fn is supported")
+            .to_compile_error()
+            .into();
+    }
+
+    let context_ref: syn::AttributeArgs = syn::parse_macro_input!(attributes);
+
+    let name_opt = get_attrib_param(&context_ref, "name");
+
+    if name_opt.is_none() {
+        return syn::Error::new_spanned(sig.fn_token, "name parameter is required in macro")
+            .to_compile_error()
+            .into();
+    }
+
+    let id_param = get_attrib_param(&context_ref, "id");
+
+    let body_quote = match get_attrib_param(&context_ref, "body") {
+        Some(body_str) => {
+            let body_ident = syn::Ident::new(&body_str, name.span());
+            quote! {
+                log::debug!("Body {}", serde_json::to_string_pretty(&#body_ident.0).unwrap_or(format!("{:?}", &#body_ident)) );
+            }
+        }
+        _ => quote! {},
+    };
+
+    let path_quote = match get_attrib_param(&context_ref, "path") {
+        Some(path) => {
+            let path_ident = syn::Ident::new(&path, name.span());
+            quote! {
+                log::debug!("Path {}", serde_json::to_string(&#path_ident.as_ref()).unwrap_or(String::from("(error)")));
+            }
+        }
+        _ => quote! {},
+    };
+
+    let query_quote = match get_attrib_param(&context_ref, "query") {
+        Some(query) => {
+            let query_ident = syn::Ident::new(&query, name.span());
+            quote! {
+                log::debug!("Query {}", serde_json::to_string(&#query_ident.0).unwrap_or(String::from("(error)")));
+            }
+        }
+        _ => quote! {},
+    };
+
+    let log_info_quote = match id_param {
+        Some(id_str) => {
+            let id_ident = syn::Ident::new(&id_str, name.span());
+
+            quote! {
+                log::info!("API call: {}(), Identity: [{:?}]", #name_opt, #id_ident.identity);
+            }
+        }
+        _ => quote! {
+            log::info!("API call: {}()", #name_opt);
+        },
+    };
+
+    sig.asyncness = None;
+
+    (quote! {
+        #(#attrs)*
+        async #vis #sig {
+            #log_info_quote
+            #path_quote
+            #query_quote
+            #body_quote
+            { #body }
+        }
+    })
+    .into()
+}
+
+fn get_lit_value(lit: &syn::Lit) -> Option<String> {
+    match lit {
+        syn::Lit::Str(s) => Some(s.value()),
+        _ => None,
+    }
+}
+
+fn get_attrib_param(attrs: &syn::AttributeArgs, ident: &str) -> Option<String> {
+    let mut result: Option<String> = None;
+
+    for attr in attrs {
+        match attr {
+            syn::NestedMeta::Meta(meta) => match meta {
+                syn::Meta::NameValue(mnv) => {
+                    if mnv.path.is_ident(ident) {
+                        result = get_lit_value(&mnv.lit);
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    result
+}


### PR DESCRIPTION
Proposal of a generic REST API log macro to decorate REST API webmethods.

The macro wraps the API methods in log calls on various levels:
- INFO: webmethod logical name, identity if specified
- DEBUG: query, path and body