### PR TITLE
Payment driver: ValidateAllocation

### DIFF
--- a/core/model/src/driver.rs
+++ b/core/model/src/driver.rs
@@ -3,6 +3,7 @@ use bitflags::bitflags;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+use ya_client_model::payment::Allocation;
 use ya_service_bus::RpcMessage;
 
 pub fn driver_bus_id<T: Display>(driver_name: T) -> String {
@@ -208,5 +209,30 @@ impl GetTransactionBalance {
 impl RpcMessage for GetTransactionBalance {
     const ID: &'static str = "GetTransactionBalance";
     type Item = BigDecimal;
+    type Error = GenericError;
+}
+
+// ************************** VALIDATE ALLOCATION **************************
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidateAllocation {
+    pub address: String,
+    pub amount: BigDecimal,
+    pub existing_allocations: Vec<Allocation>,
+}
+
+impl ValidateAllocation {
+    pub fn new(address: String, amount: BigDecimal, existing: Vec<Allocation>) -> Self {
+        ValidateAllocation {
+            address,
+            amount,
+            existing_allocations: existing,
+        }
+    }
+}
+
+impl RpcMessage for ValidateAllocation {
+    const ID: &'static str = "ValidateAllocation";
+    type Item = bool;
     type Error = GenericError;
 }

--- a/core/model/src/payment.rs
+++ b/core/model/src/payment.rs
@@ -4,14 +4,16 @@ use ya_service_bus::RpcMessage;
 
 #[derive(Clone, Debug, Serialize, Deserialize, thiserror::Error)]
 pub enum RpcMessageError {
-    #[error("Send error: {0}")]
+    #[error("{0}")]
     Send(#[from] public::SendError),
-    #[error("Accept/reject error: {0}")]
+    #[error("{0}")]
     AcceptReject(#[from] public::AcceptRejectError),
-    #[error("Cancel error: {0}")]
+    #[error("{0}")]
     Cancel(#[from] public::CancelError),
     #[error("{0}")]
     Generic(#[from] local::GenericError),
+    #[error("{0}")]
+    ValidateAllocation(#[from] local::ValidateAllocationError),
 }
 
 pub mod local {
@@ -322,6 +324,27 @@ pub mod local {
     pub struct InvoiceStats {
         pub requestor: InvoiceStatusNotes,
         pub provider: InvoiceStatusNotes,
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct ValidateAllocation {
+        pub platform: String,
+        pub address: String,
+        pub amount: BigDecimal,
+    }
+
+    impl RpcMessage for ValidateAllocation {
+        const ID: &'static str = "ValidateAllocation";
+        type Item = bool;
+        type Error = ValidateAllocationError;
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize, thiserror::Error)]
+    pub enum ValidateAllocationError {
+        #[error("Account not registered")]
+        AccountNotRegistered,
+        #[error("Error while validating allocation: {0}")]
+        Other(String),
     }
 }
 

--- a/core/payment-driver/base/src/bus.rs
+++ b/core/payment-driver/base/src/bus.rs
@@ -52,6 +52,9 @@ pub async fn bind_service<Driver: PaymentDriver + 'static>(db: &DbExecutor, driv
         )
         .bind_with_processor(
             move |db, dr, c, m| async move { dr.verify_payment(db, c, m).await }
+        )
+        .bind_with_processor(
+            move |db, dr, c, m| async move { dr.validate_allocation(db, c, m).await }
         );
 
     log::debug!("Successfully bound payment driver service to service bus");

--- a/core/payment-driver/base/src/driver.rs
+++ b/core/payment-driver/base/src/driver.rs
@@ -8,10 +8,7 @@
 
 // Local uses
 use crate::dao::DbExecutor;
-use crate::model::{
-    Ack, GenericError, GetAccountBalance, GetTransactionBalance, Init, PaymentDetails,
-    SchedulePayment, VerifyPayment,
-};
+use crate::model::*;
 
 // Public revealed uses, required to implement this trait
 pub use async_trait::async_trait;
@@ -61,4 +58,11 @@ pub trait PaymentDriver {
         caller: String,
         msg: VerifyPayment,
     ) -> Result<PaymentDetails, GenericError>;
+
+    async fn validate_allocation(
+        &self,
+        db: DbExecutor,
+        caller: String,
+        msg: ValidateAllocation,
+    ) -> Result<bool, GenericError>;
 }

--- a/core/payment-driver/dummy/src/service.rs
+++ b/core/payment-driver/dummy/src/service.rs
@@ -16,7 +16,8 @@ pub fn bind_service() {
         .bind(get_account_balance)
         .bind(get_transaction_balance)
         .bind(schedule_payment)
-        .bind(verify_payment);
+        .bind(verify_payment)
+        .bind(validate_allocation);
 
     log::debug!("Successfully bound payment driver service to service bus");
 }
@@ -110,4 +111,12 @@ async fn verify_payment(
     let json_str = std::str::from_utf8(confirmation.confirmation.as_slice()).unwrap();
     let details = serde_json::from_str(&json_str).unwrap();
     Ok(details)
+}
+
+async fn validate_allocation(
+    _db: (),
+    _caller: String,
+    _msg: ValidateAllocation,
+) -> Result<bool, GenericError> {
+    Ok(true)
 }

--- a/core/payment-driver/gnt/src/service.rs
+++ b/core/payment-driver/gnt/src/service.rs
@@ -14,7 +14,8 @@ pub fn bind_service(db: &DbExecutor, processor: GNTDriverProcessor) {
         .bind_with_processor(get_account_balance)
         .bind_with_processor(get_transaction_balance)
         .bind_with_processor(schedule_payment)
-        .bind_with_processor(verify_payment);
+        .bind_with_processor(verify_payment)
+        .bind_with_processor(validate_allocation);
 
     log::debug!("Successfully bound payment driver service to service bus");
 }
@@ -116,6 +117,16 @@ async fn verify_payment(
         |e| Err(GenericError::new(e)),
         |payment_details| Ok(payment_details),
     )
+}
+
+async fn validate_allocation(
+    _db: DbExecutor,
+    _processor: GNTDriverProcessor,
+    _caller: String,
+    _msg: ValidateAllocation,
+) -> Result<bool, GenericError> {
+    log::debug!("Validate allocation: {:?}", _msg);
+    Ok(true) // TODO: Implement proper check
 }
 
 async fn account_event(

--- a/core/payment-driver/zksync/src/driver.rs
+++ b/core/payment-driver/zksync/src/driver.rs
@@ -16,10 +16,7 @@ use ya_payment_driver::{
     dao::DbExecutor,
     db::models::PaymentEntity,
     driver::{async_trait, BigDecimal, IdentityError, IdentityEvent, PaymentDriver},
-    model::{
-        Ack, GenericError, GetAccountBalance, GetTransactionBalance, Init, PaymentConfirmation,
-        PaymentDetails, SchedulePayment, VerifyPayment,
-    },
+    model::*,
     utils,
 };
 
@@ -199,6 +196,21 @@ impl PaymentDriver for ZksyncDriver {
         //     None => Err(GenericError::new("Payment not ready to be checked")),
         // }
         from_confirmation(msg.confirmation())
+    }
+
+    async fn validate_allocation(
+        &self,
+        _db: DbExecutor,
+        _caller: String,
+        msg: ValidateAllocation,
+    ) -> Result<bool, GenericError> {
+        let account_balance = wallet::account_balance(&msg.address).await?;
+        let total_allocated_amount: BigDecimal = msg
+            .existing_allocations
+            .into_iter()
+            .map(|allocation| allocation.remaining_amount)
+            .sum();
+        Ok(msg.amount <= (account_balance - total_allocated_amount))
     }
 }
 

--- a/core/payment/src/dao/allocation.rs
+++ b/core/payment/src/dao/allocation.rs
@@ -44,8 +44,14 @@ pub fn spend_from_allocation(
 }
 
 impl<'c> AllocationDao<'c> {
-    pub async fn create(&self, allocation: NewAllocation, owner_id: NodeId) -> DbResult<String> {
-        let allocation = WriteObj::new(allocation, owner_id);
+    pub async fn create(
+        &self,
+        allocation: NewAllocation,
+        owner_id: NodeId,
+        payment_platform: String,
+        address: String,
+    ) -> DbResult<String> {
+        let allocation = WriteObj::new(allocation, owner_id, payment_platform, address);
         let allocation_id = allocation.id.clone();
         do_with_transaction(self.pool, move |conn| {
             diesel::insert_into(dsl::pay_allocation)
@@ -93,6 +99,22 @@ impl<'c> AllocationDao<'c> {
         readonly_transaction(self.pool, move |conn| {
             let allocations: Vec<ReadObj> = dsl::pay_allocation
                 .filter(dsl::owner_id.eq(owner_id))
+                .filter(dsl::released.eq(false))
+                .load(conn)?;
+            Ok(allocations.into_iter().map(Into::into).collect())
+        })
+        .await
+    }
+
+    pub async fn get_for_address(
+        &self,
+        payment_platform: String,
+        address: String,
+    ) -> DbResult<Vec<Allocation>> {
+        readonly_transaction(self.pool, move |conn| {
+            let allocations: Vec<ReadObj> = dsl::pay_allocation
+                .filter(dsl::payment_platform.eq(payment_platform))
+                .filter(dsl::address.eq(address))
                 .filter(dsl::released.eq(false))
                 .load(conn)?;
             Ok(allocations.into_iter().map(Into::into).collect())

--- a/core/payment/src/models/allocation.rs
+++ b/core/payment/src/models/allocation.rs
@@ -1,5 +1,4 @@
 use crate::schema::pay_allocation;
-use crate::DEFAULT_PAYMENT_PLATFORM;
 use chrono::{NaiveDateTime, TimeZone, Utc};
 use uuid::Uuid;
 use ya_client_model::payment::{Allocation, NewAllocation};
@@ -22,14 +21,17 @@ pub struct WriteObj {
 }
 
 impl WriteObj {
-    pub fn new(allocation: NewAllocation, owner_id: NodeId) -> Self {
+    pub fn new(
+        allocation: NewAllocation,
+        owner_id: NodeId,
+        payment_platform: String,
+        address: String,
+    ) -> Self {
         Self {
             id: Uuid::new_v4().to_string(),
             owner_id,
-            payment_platform: allocation
-                .payment_platform
-                .unwrap_or(DEFAULT_PAYMENT_PLATFORM.to_string()),
-            address: allocation.address.unwrap_or(owner_id.to_string()),
+            payment_platform,
+            address,
             total_amount: allocation.total_amount.clone().into(),
             spent_amount: Default::default(),
             remaining_amount: allocation.total_amount.into(),

--- a/core/payment/src/service.rs
+++ b/core/payment/src/service.rs
@@ -31,7 +31,8 @@ mod local {
             .bind_with_processor(notify_payment)
             .bind_with_processor(get_status)
             .bind_with_processor(get_invoice_stats)
-            .bind_with_processor(get_accounts);
+            .bind_with_processor(get_accounts)
+            .bind_with_processor(validate_allocation);
 
         // Initialize counters to 0 value. Otherwise they won't appear on metrics endpoint
         // until first change to value will be made.
@@ -198,6 +199,17 @@ mod local {
             );
         }
         Ok(output_stats)
+    }
+
+    async fn validate_allocation(
+        db: DbExecutor,
+        processor: PaymentProcessor,
+        sender: String,
+        msg: ValidateAllocation,
+    ) -> Result<bool, ValidateAllocationError> {
+        Ok(processor
+            .validate_allocation(msg.platform, msg.address, msg.amount)
+            .await?)
     }
 }
 


### PR DESCRIPTION
Added a new GSB endpoint to the payment driver API to validate whether an allocation could be created (check available funds).

----
Testing:
a) Regression: Just run `payment_api --driver=zksync` + `invoice_flow`
b) Insufficient funds: change line 39 in `invoice_flow` to make an allocation for 1000000 GNT. Run `payment_api --driver=zksync` + `invoice_flow`. Should fail with an error like this:
```
[2020-11-16T14:36:02Z INFO  invoice_flow] Issuing invoice...
[2020-11-16T14:36:02Z INFO  invoice_flow] Invoice issued.
[2020-11-16T14:36:02Z INFO  invoice_flow] Sending invoice...
[2020-11-16T14:36:02Z INFO  invoice_flow] Invoice sent.
[2020-11-16T14:36:02Z INFO  invoice_flow] Creating allocation...
Error: request for http://127.0.0.1:7465/payment-api/v1/requestor/allocations resulted in HTTP status code: 400 Bad Request: Insufficient funds to make allocation
```
c) Invalid account: change line 37 in `invoice_flow` and put there some bogus address. Run `payment_api --driver=zksync` + `invoice_flow`. Should fail with an error like this:
```
[2020-11-16T14:35:23Z INFO  invoice_flow] Issuing invoice...
[2020-11-16T14:35:23Z INFO  invoice_flow] Invoice issued.
[2020-11-16T14:35:23Z INFO  invoice_flow] Sending invoice...
[2020-11-16T14:35:23Z INFO  invoice_flow] Invoice sent.
[2020-11-16T14:35:23Z INFO  invoice_flow] Creating allocation...
Error: request for http://127.0.0.1:7465/payment-api/v1/requestor/allocations resulted in HTTP status code: 400 Bad Request: Account not registered
```
