### PR TITLE
Fix zkSync crate version to a particular revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,8 +17,8 @@ dependencies = [
  "log 0.4.11",
  "parking_lot 0.10.2",
  "pin-project 0.4.27",
- "smallvec 1.4.2",
- "tokio 0.2.22",
+ "smallvec 1.5.0",
+ "tokio 0.2.23",
  "tokio-util 0.2.0",
 ]
 
@@ -33,7 +33,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log 0.4.11",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-util 0.2.0",
 ]
 
@@ -49,7 +49,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project 0.4.27",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-util 0.3.1",
 ]
 
@@ -89,8 +89,8 @@ dependencies = [
  "futures-util",
  "http 0.2.1",
  "log 0.4.11",
- "trust-dns-proto 0.19.5",
- "trust-dns-resolver 0.19.5",
+ "trust-dns-proto 0.19.6",
+ "trust-dns-resolver 0.19.6",
 ]
 
 [[package]]
@@ -226,7 +226,7 @@ dependencies = [
  "serde_urlencoded",
  "sha-1",
  "slab 0.4.2",
- "time 0.2.22",
+ "time 0.2.23",
 ]
 
 [[package]]
@@ -263,8 +263,8 @@ dependencies = [
  "copyless",
  "futures-channel",
  "futures-util",
- "smallvec 1.4.2",
- "tokio 0.2.22",
+ "smallvec 1.5.0",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -322,7 +322,7 @@ dependencies = [
  "lazy_static",
  "log 0.4.11",
  "num_cpus",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "threadpool",
 ]
 
@@ -464,8 +464,8 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "socket2",
- "time 0.2.22",
- "tinyvec 1.0.1",
+ "time 0.2.23",
+ "tinyvec",
  "url 2.2.0",
 ]
 
@@ -684,15 +684,15 @@ dependencies = [
  "futures-core",
  "memchr",
  "pin-project-lite",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "xz2",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d373d78ded7d0b3fa8039375718cde0aace493f2e34fb60f51cbf567562ca801"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -1444,7 +1444,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784ad0fbab4f3e9cef09f20e0aea6000ae08d2cb98ac4c0abc53df18803d702f"
 dependencies = [
  "percent-encoding 2.1.0",
- "time 0.2.22",
+ "time 0.2.23",
  "version_check 0.9.2",
 ]
 
@@ -1614,8 +1614,8 @@ dependencies = [
  "crossterm_winapi",
  "lazy_static",
  "libc",
- "mio 0.7.5",
- "parking_lot 0.11.0",
+ "mio 0.7.6",
+ "parking_lot 0.11.1",
  "signal-hook",
  "winapi 0.3.9",
 ]
@@ -2176,7 +2176,7 @@ dependencies = [
  "fixed-hash 0.6.1",
  "impl-rlp",
  "impl-serde 0.3.1",
- "primitive-types 0.7.2",
+ "primitive-types 0.7.3",
  "uint 0.8.5",
 ]
 
@@ -2662,7 +2662,7 @@ dependencies = [
  "structopt",
  "tempdir",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "url 2.2.0",
  "ya-core-model",
  "ya-service-bus",
@@ -2754,7 +2754,7 @@ dependencies = [
  "serde_json",
  "strip-ansi-escapes",
  "structopt",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "url 2.2.0",
  "vergen",
  "ya-compile-time-utils",
@@ -2815,7 +2815,7 @@ dependencies = [
  "http 0.2.1",
  "indexmap",
  "slab 0.4.2",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-util 0.3.1",
  "tracing",
  "tracing-futures",
@@ -3039,7 +3039,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.1",
  "socket2",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tower-service",
  "tracing",
  "want 0.3.0",
@@ -3067,7 +3067,7 @@ dependencies = [
  "bytes 0.5.6",
  "hyper 0.13.9",
  "native-tls",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-tls 0.3.1",
 ]
 
@@ -3379,9 +3379,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
  "scopeguard",
 ]
@@ -3503,7 +3503,7 @@ checksum = "f3fc63816bd5f8bde5eb31ce471f9633adc69ba1c55b44191b4d5fc7e263e8ab"
 dependencies = [
  "log 0.4.11",
  "metrics-core",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -3565,9 +3565,9 @@ dependencies = [
 
 [[package]]
 name = "metrics-util"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d11f8090a8886339f9468a04eeea0711e4cf27538b134014664308041307a1c5"
+checksum = "277619f040719a5a23d75724586d5601286e8fa53451cfaaca3b8c627c2c2378"
 dependencies = [
  "crossbeam-epoch 0.8.2",
  "serde",
@@ -3650,13 +3650,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
+checksum = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
 dependencies = [
  "libc",
  "log 0.4.11",
- "miow 0.3.5",
+ "miow 0.3.6",
  "ntapi",
  "winapi 0.3.9",
 ]
@@ -3681,7 +3681,7 @@ checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
 dependencies = [
  "log 0.4.11",
  "mio 0.6.22",
- "miow 0.3.5",
+ "miow 0.3.6",
  "winapi 0.3.9",
 ]
 
@@ -3710,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
@@ -3741,9 +3741,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a1cda389c26d6b88f3d2dc38aa1b750fe87d298cc5d795ec9e975f402f00372"
+checksum = "6fcc7939b5edc4e4f86b1b4a04bb1498afaaf871b1a6691838ed06fcb48d3a3f"
 dependencies = [
  "lazy_static",
  "libc",
@@ -3994,9 +3994,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opaque-debug"
@@ -4197,12 +4197,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
- "lock_api 0.4.1",
+ "lock_api 0.4.2",
  "parking_lot_core 0.8.0",
 ]
 
@@ -4247,7 +4247,7 @@ dependencies = [
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "winapi 0.3.9",
 ]
 
@@ -4262,7 +4262,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "winapi 0.3.9",
 ]
 
@@ -4435,9 +4435,9 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55c21c64d0eaa4d7ed885d959ef2d62d9e488c27c0e02d9aa5ce6c877b7d5f8"
+checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
 dependencies = [
  "fixed-hash 0.6.1",
  "impl-codec 0.4.2",
@@ -4673,7 +4673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
 dependencies = [
  "log 0.4.11",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "scheduled-thread-pool",
 ]
 
@@ -4989,9 +4989,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-tls 0.3.1",
- "trust-dns-resolver 0.19.5",
+ "trust-dns-resolver 0.19.6",
  "url 2.2.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -5004,6 +5004,16 @@ name = "resolv-conf"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
+dependencies = [
+ "hostname",
+ "quick-error",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error",
@@ -5198,7 +5208,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
 dependencies = [
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
 ]
 
 [[package]]
@@ -5570,7 +5580,7 @@ dependencies = [
  "futures 0.1.30",
  "libc",
  "mio 0.6.22",
- "mio 0.7.5",
+ "mio 0.7.6",
  "signal-hook-registry",
  "tokio-reactor",
 ]
@@ -5617,15 +5627,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -5656,9 +5666,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "standback"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e0831040d2cf2bdfd51b844be71885783d489898a192f254ae25d57cce725c"
+checksum = "cf906c8b8fc3f6ecd1046e01da1d8ddec83e48c8b08b84dcc02b585a6bedf5a8"
 dependencies = [
  "version_check 0.9.2",
 ]
@@ -5919,9 +5929,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
+checksum = "4bd2d183bd3fac5f5fe38ddbeb4dc9aec4a39a9d7d59e7491d900302da01cbe1"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -5996,9 +6006,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b7151c9065e80917fbf285d9a5d1432f60db41d170ccafc749a136b41a93af"
+checksum = "bcdaeea317915d59b2b4cd3b5efcd156c309108664277793f5351700c02ce98b"
 dependencies = [
  "const_fn",
  "libc",
@@ -6052,12 +6062,6 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
-
-[[package]]
-name = "tinyvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
@@ -6097,9 +6101,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -6137,7 +6141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac46f27b0d0bb37aa3a38ccfea54b029e85ea0145a0a47adfad8601097407567"
 dependencies = [
  "byteorder",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -6214,9 +6218,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2 1.0.24",
  "quote 1.0.7",
@@ -6230,7 +6234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
 dependencies = [
  "openssl",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -6239,7 +6243,7 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "nix 0.11.1",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -6281,7 +6285,7 @@ dependencies = [
  "futures-core",
  "libc",
  "redox_syscall",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "xattr",
 ]
 
@@ -6356,7 +6360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
 dependencies = [
  "native-tls",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -6420,7 +6424,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project-lite",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -6434,7 +6438,7 @@ dependencies = [
  "futures-sink",
  "log 0.4.11",
  "pin-project-lite",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -6494,17 +6498,17 @@ dependencies = [
  "lazy_static",
  "log 0.4.11",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "socket2",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "url 2.2.0",
 ]
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.19.5"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd7061ba6f4d4d9721afedffbfd403f20f39a4301fee1b70d6fcd09cca69f28"
+checksum = "53861fcb288a166aae4c508ae558ed18b53838db728d4d310aad08270a7d4c2b"
 dependencies = [
  "async-trait",
  "backtrace",
@@ -6514,9 +6518,9 @@ dependencies = [
  "lazy_static",
  "log 0.4.11",
  "rand 0.7.3",
- "smallvec 1.4.2",
+ "smallvec 1.5.0",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "url 2.2.0",
 ]
 
@@ -6533,17 +6537,17 @@ dependencies = [
  "lazy_static",
  "log 0.4.11",
  "lru-cache",
- "resolv-conf",
- "smallvec 1.4.2",
- "tokio 0.2.22",
+ "resolv-conf 0.6.3",
+ "smallvec 1.5.0",
+ "tokio 0.2.23",
  "trust-dns-proto 0.18.0-alpha.2",
 ]
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.19.5"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f23cdfdc3d8300b3c50c9e84302d3bd6d860fb9529af84ace6cf9665f181b77"
+checksum = "6759e8efc40465547b0dfce9500d733c65f969a4cbbfbe3ccf68daaa46ef179e"
 dependencies = [
  "backtrace",
  "cfg-if 0.1.10",
@@ -6552,11 +6556,11 @@ dependencies = [
  "lazy_static",
  "log 0.4.11",
  "lru-cache",
- "resolv-conf",
- "smallvec 1.4.2",
+ "resolv-conf 0.7.0",
+ "smallvec 1.5.0",
  "thiserror",
- "tokio 0.2.22",
- "trust-dns-proto 0.19.5",
+ "tokio 0.2.23",
+ "trust-dns-proto 0.19.6",
 ]
 
 [[package]]
@@ -6630,18 +6634,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "f1e9a0b71dba18b6fa17c7b3dcf1440bb3522552deb2f84bf47dabd9fb7e5570"
 dependencies = [
- "tinyvec 0.3.4",
+ "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
 
 [[package]]
 name = "unicode-width"
@@ -7041,7 +7045,7 @@ dependencies = [
  "jsonrpc-core 14.2.0",
  "log 0.4.11",
  "native-tls",
- "parking_lot 0.11.0",
+ "parking_lot 0.11.1",
  "rlp",
  "rustc-hex",
  "secp256k1 0.17.2",
@@ -7242,7 +7246,7 @@ dependencies = [
  "shlex",
  "structopt",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "uuid 0.8.1",
  "ya-client-model 0.2.0",
  "ya-core-model",
@@ -7420,7 +7424,7 @@ dependencies = [
  "structopt",
  "tempdir",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-util 0.2.0",
  "url 2.2.0",
  "winapi 0.3.9",
@@ -7467,8 +7471,8 @@ dependencies = [
  "serde_json",
  "sha3 0.9.1",
  "thiserror",
- "tokio 0.2.22",
- "trust-dns-resolver 0.19.5",
+ "tokio 0.2.23",
+ "trust-dns-resolver 0.19.6",
  "uint 0.7.1",
  "ureq",
  "uuid 0.8.1",
@@ -7507,7 +7511,7 @@ dependencies = [
  "sha2 0.9.2",
  "structopt",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "uuid 0.8.1",
  "ya-client-model 0.2.0",
  "ya-core-model",
@@ -7552,7 +7556,7 @@ dependencies = [
  "sha3 0.8.2",
  "structopt",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "uuid 0.8.1",
  "ya-agreement-utils",
  "ya-client 0.4.0",
@@ -7598,7 +7602,7 @@ dependencies = [
  "metrics-core",
  "metrics-runtime",
  "percent-encoding 2.1.0",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "url 2.2.0",
  "ya-core-model",
  "ya-service-api",
@@ -7656,7 +7660,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "uint 0.7.1",
  "uuid 0.8.1",
  "ya-agreement-utils",
@@ -7693,7 +7697,7 @@ dependencies = [
  "num",
  "r2d2",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "ya-client-model 0.2.0",
  "ya-core-model",
  "ya-persistence",
@@ -7714,7 +7718,7 @@ dependencies = [
  "r2d2",
  "serde_json",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "ya-client-model 0.2.0",
  "ya-core-model",
 ]
@@ -7755,7 +7759,7 @@ dependencies = [
  "strum_macros",
  "sys-info",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "url 2.2.0",
  "winapi 0.3.9",
  "ya-agreement-utils",
@@ -7783,7 +7787,7 @@ dependencies = [
  "log 0.4.11",
  "serde_json",
  "structopt",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "url 2.2.0",
  "uuid 0.8.1",
  "ya-agreement-utils",
@@ -7804,7 +7808,7 @@ dependencies = [
  "prost-build 0.6.1",
  "serde",
  "serde_json",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-util 0.2.0",
 ]
 
@@ -7821,7 +7825,7 @@ dependencies = [
  "prost-build 0.5.0",
  "serial_test 0.4.0",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-util 0.2.0",
  "url 2.2.0",
 ]
@@ -7839,7 +7843,7 @@ dependencies = [
  "log 0.4.11",
  "prost 0.5.0",
  "structopt",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-util 0.2.0",
  "url 2.2.0",
  "uuid 0.8.1",
@@ -7955,7 +7959,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-util 0.2.0",
  "url 2.2.0",
  "ya-sb-proto",
@@ -8008,7 +8012,7 @@ dependencies = [
  "structopt",
  "tempdir",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-byteorder",
  "tokio-tar",
  "tokio-util 0.2.0",
@@ -8037,7 +8041,7 @@ name = "ya-utils-futures"
 version = "0.1.0"
 dependencies = [
  "futures 0.3.8",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -8062,7 +8066,7 @@ dependencies = [
  "libc",
  "nix 0.17.0",
  "shared_child",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -8091,7 +8095,7 @@ dependencies = [
  "num",
  "serde_json",
  "tiny-keccak 1.5.0",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "uuid 0.8.1",
  "ya-client-model 0.2.0",
  "ya-payment-driver",
@@ -8118,7 +8122,7 @@ dependencies = [
  "log 0.4.11",
  "openssl",
  "structopt",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "url 2.2.0",
  "ya-activity",
  "ya-compile-time-utils",
@@ -8198,14 +8202,14 @@ dependencies = [
  "flate2",
  "thiserror",
  "time 0.1.44",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-byteorder",
 ]
 
 [[package]]
 name = "zksync"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/zksync#62acd7f0713138df37d5094d5125441fa3f448af"
+source = "git+https://github.com/matter-labs/zksync?rev=899ca93052420c33583755cd2162143f461f36b3#899ca93052420c33583755cd2162143f461f36b3"
 dependencies = [
  "bellman_ce",
  "ethabi 12.0.0",
@@ -8218,7 +8222,7 @@ dependencies = [
  "serde_json",
  "sha2 0.8.2",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "web3 0.13.0",
  "zksync_contracts",
  "zksync_crypto",
@@ -8231,7 +8235,7 @@ dependencies = [
 [[package]]
 name = "zksync_basic_types"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync#62acd7f0713138df37d5094d5125441fa3f448af"
+source = "git+https://github.com/matter-labs/zksync?rev=899ca93052420c33583755cd2162143f461f36b3#899ca93052420c33583755cd2162143f461f36b3"
 dependencies = [
  "web3 0.13.0",
 ]
@@ -8239,7 +8243,7 @@ dependencies = [
 [[package]]
 name = "zksync_contracts"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync#62acd7f0713138df37d5094d5125441fa3f448af"
+source = "git+https://github.com/matter-labs/zksync?rev=899ca93052420c33583755cd2162143f461f36b3#899ca93052420c33583755cd2162143f461f36b3"
 dependencies = [
  "ethabi 12.0.0",
  "serde_json",
@@ -8248,7 +8252,7 @@ dependencies = [
 [[package]]
 name = "zksync_crypto"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync#62acd7f0713138df37d5094d5125441fa3f448af"
+source = "git+https://github.com/matter-labs/zksync?rev=899ca93052420c33583755cd2162143f461f36b3#899ca93052420c33583755cd2162143f461f36b3"
 dependencies = [
  "anyhow",
  "fnv",
@@ -8265,7 +8269,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_client"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync#62acd7f0713138df37d5094d5125441fa3f448af"
+source = "git+https://github.com/matter-labs/zksync?rev=899ca93052420c33583755cd2162143f461f36b3#899ca93052420c33583755cd2162143f461f36b3"
 dependencies = [
  "anyhow",
  "ethabi 12.0.0",
@@ -8280,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "zksync_eth_signer"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync#62acd7f0713138df37d5094d5125441fa3f448af"
+source = "git+https://github.com/matter-labs/zksync?rev=899ca93052420c33583755cd2162143f461f36b3#899ca93052420c33583755cd2162143f461f36b3"
 dependencies = [
  "async-trait",
  "hex",
@@ -8298,7 +8302,7 @@ dependencies = [
 [[package]]
 name = "zksync_types"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync#62acd7f0713138df37d5094d5125441fa3f448af"
+source = "git+https://github.com/matter-labs/zksync?rev=899ca93052420c33583755cd2162143f461f36b3#899ca93052420c33583755cd2162143f461f36b3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -8317,7 +8321,7 @@ dependencies = [
 [[package]]
 name = "zksync_utils"
 version = "1.0.0"
-source = "git+https://github.com/matter-labs/zksync#62acd7f0713138df37d5094d5125441fa3f448af"
+source = "git+https://github.com/matter-labs/zksync?rev=899ca93052420c33583755cd2162143f461f36b3#899ca93052420c33583755cd2162143f461f36b3"
 dependencies = [
  "anyhow",
  "bigdecimal",

--- a/core/payment-driver/zksync/Cargo.toml
+++ b/core/payment-driver/zksync/Cargo.toml
@@ -22,8 +22,8 @@ serde_json = "^1.0"
 tiny-keccak = "1.4.2"
 tokio = { version = "0.2", features = ["full"] }
 uuid = { version = "0.8", features = ["v4"] }
-zksync = { git = "https://github.com/matter-labs/zksync", branch = "master"}
-zksync_eth_signer = { git = "https://github.com/matter-labs/zksync", branch = "master"}
+zksync = { git = "https://github.com/matter-labs/zksync", rev = "899ca93052420c33583755cd2162143f461f36b3"}
+zksync_eth_signer = { git = "https://github.com/matter-labs/zksync", rev = "899ca93052420c33583755cd2162143f461f36b3"}
 
 ## yagna dependencies
 ya-payment-driver = "0.1.0"


### PR DESCRIPTION
We don't want new commits in zkSync break our release.