### PR TITLE
Fix/provider round cost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7747,6 +7747,7 @@ dependencies = [
  "log-derive",
  "nix 0.17.0",
  "notify",
+ "num-bigint",
  "num_cpus",
  "path-clean",
  "semver 0.10.0",

--- a/agent/provider/Cargo.toml
+++ b/agent/provider/Cargo.toml
@@ -34,6 +34,7 @@ libc = "0.2"
 log = "0.4.8"
 log-derive = "0.4"
 notify = "4.0.15"
+num-bigint = "0.2.6"
 num_cpus = "1.13.0"
 path-clean = "0.1.0"
 semver = { version = "0.10.0", features = ["serde"] }

--- a/agent/provider/src/payments/payments.rs
+++ b/agent/provider/src/payments/payments.rs
@@ -1,6 +1,6 @@
 use actix::prelude::*;
 use anyhow::{anyhow, Error, Result};
-use bigdecimal::BigDecimal;
+use bigdecimal::{BigDecimal, Zero};
 use chrono::Utc;
 use log;
 use serde_json::json;
@@ -131,7 +131,7 @@ impl Payments {
             agreements: HashMap::new(),
             context: Arc::new(provider_ctx),
             invoices_to_pay: vec![],
-            earnings: BigDecimal::from(0.0),
+            earnings: BigDecimal::zero(),
         }
     }
 


### PR DESCRIPTION
NGNT precision is 18 decimal places. Rounding up prevents payment errors.