### PR TITLE
[ExeUnit] Better SGX errors

### DIFF
--- a/exe-unit/src/handlers/local.rs
+++ b/exe-unit/src/handlers/local.rs
@@ -6,6 +6,7 @@ use crate::state::State;
 use crate::{report, ExeUnit};
 use actix::prelude::*;
 use futures::FutureExt;
+use std::path::Path;
 use ya_client_model::activity;
 use ya_client_model::activity::RuntimeEvent;
 use ya_core_model::activity::local::SetState as SetActivityState;
@@ -111,6 +112,12 @@ impl<R: Runtime> Handler<Initialize> for ExeUnit<R> {
                     use ya_core_model::activity::local::Credentials;
                     use ya_core_model::net::RemoteEndpoint;
                     use ya_core_model::sgx::VerifyAttestationEvidence;
+
+                    let att_dev = Path::new("/dev/attestation");
+                    if !att_dev.exists() {
+                        let msg = format!("'{}' does not exist", att_dev.display());
+                        return Err(Error::Attestation(msg));
+                    }
 
                     let quote = SgxQuote::hasher()
                         .data(&crypto.requestor_pub_key.serialize())

--- a/exe-unit/src/handlers/local.rs
+++ b/exe-unit/src/handlers/local.rs
@@ -6,7 +6,6 @@ use crate::state::State;
 use crate::{report, ExeUnit};
 use actix::prelude::*;
 use futures::FutureExt;
-use std::path::Path;
 use ya_client_model::activity;
 use ya_client_model::activity::RuntimeEvent;
 use ya_core_model::activity::local::SetState as SetActivityState;
@@ -113,7 +112,7 @@ impl<R: Runtime> Handler<Initialize> for ExeUnit<R> {
                     use ya_core_model::net::RemoteEndpoint;
                     use ya_core_model::sgx::VerifyAttestationEvidence;
 
-                    let att_dev = Path::new("/dev/attestation");
+                    let att_dev = std::path::Path::new("/dev/attestation");
                     if !att_dev.exists() {
                         let msg = format!("'{}' does not exist", att_dev.display());
                         return Err(Error::Attestation(msg));

--- a/exe-unit/src/lib.rs
+++ b/exe-unit/src/lib.rs
@@ -1,7 +1,7 @@
 use actix::prelude::*;
 use chrono::Utc;
 use futures::channel::{mpsc, oneshot};
-use futures::{FutureExt, SinkExt, TryFutureExt};
+use futures::{FutureExt, SinkExt};
 use std::path::PathBuf;
 use std::time::Duration;
 

--- a/exe-unit/src/runtime/process.rs
+++ b/exe-unit/src/runtime/process.rs
@@ -78,7 +78,10 @@ impl RuntimeProcess {
         match result.status.success() {
             true => {
                 let stdout = vec_to_string(result.stdout).unwrap_or_else(String::new);
-                Ok(serde_json::from_str(&stdout)?)
+                Ok(serde_json::from_str(&stdout).map_err(|e| {
+                    let msg = format!("Invalid offer template [{}]: {:?}", binary.display(), e);
+                    Error::Other(msg)
+                })?)
             }
             false => {
                 log::warn!(


### PR DESCRIPTION
- shutdown with an error message instead of panicking when unable to build `SgxQuote`
- check for `/dev/attestation` during supervisor initialization
- clearer error message when unable to parse offer template