### PR TITLE
Changed default payment accounts logic

### DIFF
--- a/core/payment/src/accounts.rs
+++ b/core/payment/src/accounts.rs
@@ -1,4 +1,3 @@
-use crate::DEFAULT_PAYMENT_DRIVER;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::path::{Path, PathBuf};
@@ -51,9 +50,9 @@ pub async fn init_accounts(data_dir: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Get default node ID from identity service and save it in `ACCOUNT_LIST` file as default payment account.
+/// Get default node ID from identity service and save it in `ACCOUNT_LIST` file as default payment account for every driver.
 /// If `ACCOUNT_LIST` file already exists, do nothing.
-pub async fn save_default_account(data_dir: &Path) -> anyhow::Result<()> {
+pub async fn save_default_account(data_dir: &Path, drivers: Vec<String>) -> anyhow::Result<()> {
     let accounts_path = accounts_path(data_dir);
     if accounts_path.exists() {
         log::debug!("Accounts file {} already exists.", accounts_path.display());
@@ -69,13 +68,16 @@ pub async fn save_default_account(data_dir: &Path) -> anyhow::Result<()> {
         .await??
         .ok_or(anyhow::anyhow!("Default identity not found"))?
         .node_id;
-    let default_account = vec![Account {
-        driver: DEFAULT_PAYMENT_DRIVER.to_string(),
-        address: default_node_id.to_string(),
-        send: true,
-        receive: true,
-    }];
-    let text = serde_json::to_string(&default_account)?;
+    let default_accounts: Vec<Account> = drivers
+        .into_iter()
+        .map(|driver| Account {
+            driver,
+            address: default_node_id.to_string(),
+            send: false,
+            receive: true,
+        })
+        .collect();
+    let text = serde_json::to_string(&default_accounts)?;
     fs::write(accounts_path, text).await?;
     log::debug!("Default payment account saved successfully.");
     Ok(())

--- a/core/serv/src/main.rs
+++ b/core/serv/src/main.rs
@@ -228,25 +228,29 @@ enum Services {
 }
 
 #[allow(unused)]
-async fn start_payment_drivers(data_dir: &Path) -> anyhow::Result<()> {
+async fn start_payment_drivers(data_dir: &Path) -> anyhow::Result<Vec<String>> {
+    let mut drivers = vec![];
     #[cfg(feature = "dummy-driver")]
     {
-        use ya_dummy_driver::PaymentDriverService;
+        use ya_dummy_driver::{PaymentDriverService, DRIVER_NAME};
         PaymentDriverService::gsb(&()).await?;
+        drivers.push(DRIVER_NAME.to_owned());
     }
     #[cfg(feature = "gnt-driver")]
     {
-        use ya_gnt_driver::PaymentDriverService;
+        use ya_gnt_driver::{PaymentDriverService, DRIVER_NAME};
         let db_executor = DbExecutor::from_data_dir(data_dir, "gnt-driver")?;
         PaymentDriverService::gsb(&db_executor).await?;
+        drivers.push(DRIVER_NAME.to_owned());
     }
     #[cfg(feature = "zksync-driver")]
     {
-        use ya_zksync_driver::PaymentDriverService;
+        use ya_zksync_driver::{PaymentDriverService, DRIVER_NAME};
         let db_executor = DbExecutor::from_data_dir(data_dir, "zksync-driver")?;
         PaymentDriverService::gsb(&db_executor).await?;
+        drivers.push(DRIVER_NAME.to_owned());
     }
-    Ok(())
+    Ok(drivers)
 }
 
 #[derive(StructOpt, Debug)]
@@ -337,9 +341,9 @@ impl ServiceCommand {
 
                 let context: ServiceContext = ctx.clone().try_into()?;
                 Services::gsb(&context).await?;
-                start_payment_drivers(&ctx.data_dir).await?;
+                let drivers = start_payment_drivers(&ctx.data_dir).await?;
 
-                payment_accounts::save_default_account(&ctx.data_dir)
+                payment_accounts::save_default_account(&ctx.data_dir, drivers)
                     .await
                     .unwrap_or_else(|e| {
                         log::error!("Saving default payment account failed: {}", e)


### PR DESCRIPTION
Instead of the default driver in send+receive mode, initialize all drivers in receive mode only. This improves the UX for the providers
since they can now support all drivers out of the box and also don't need to wait for lengthy initialization of the send mode.

----
Testing instructions:
1. Start yagna daemon with a clear data dir.
```
$ cargo run service run
```
2. Check if payment accounts have been properly initialized.
```
$ cargo run payment accounts
┌────────────┬──────────────────────────────────────────────┬──────────┬────────┬────────┐
│  platform  │  address                                     │  driver  │  send  │  recv  │
├────────────┼──────────────────────────────────────────────┼──────────┼────────┼────────┤
│  NGNT      │  0x440a129a33a5a515e9e2c38159ec1ad1e433f0c4  │  ngnt    │        │  X     │
│  ZK-NGNT   │  0x440a129a33a5a515e9e2c38159ec1ad1e433f0c4  │  zksync  │        │  X     │
└────────────┴──────────────────────────────────────────────┴──────────┴────────┴────────┘
```
