### PR TITLE
Require at least one payment driver enabled

### DIFF
--- a/core/serv/src/main.rs
+++ b/core/serv/src/main.rs
@@ -227,6 +227,13 @@ enum Services {
     SgxDriver(SgxService),
 }
 
+#[cfg(not(any(
+    feature = "dummy-driver",
+    feature = "gnt-driver",
+    feature = "zksync-driver"
+)))]
+compile_error!("At least one payment driver needs to be enabled in order to make payments.");
+
 #[allow(unused)]
 async fn start_payment_drivers(data_dir: &Path) -> anyhow::Result<Vec<String>> {
     let mut drivers = vec![];


### PR DESCRIPTION
Testing instructions:

Try to compile the project without any driver features enabled. Expect an error.
```
$ cargo build --no-default-features
   Compiling yagna v0.5.0 (/home/adam/yagna)
error: At least one payment driver needs to be enabled in order to make payments.
   --> core/serv/src/main.rs:232:1
    |
232 | compile_error!("At least one payment driver needs to be enabled in order to make payments.");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: aborting due to previous error

error: could not compile `yagna`

To learn more, run the command again with --verbose.
```