### PR TITLE
Payment service panic fixed

### DIFF
--- a/agent/provider/src/payments/agreement.rs
+++ b/agent/provider/src/payments/agreement.rs
@@ -248,7 +248,7 @@ pub async fn compute_cost(
 
     let cost = payment_model.compute_cost(&usage)?;
 
-    Ok(CostInfo { cost, usage })
+    Ok(CostInfo::new(usage, cost))
 }
 
 impl ActivitiesWaiter {


### PR DESCRIPTION
### Error description
Requestor agent has been rounding up invoice amounts but not debit note amounts. Therefore, for small tasks debit notes could have had higher amounts than invoices. This lead to payment service panicking during insertion of an invoice into the database. Both provider agent and payment service have been fixed.

### Resolution
#### Provider agent: round up cost in `compute_cost` 
Use `CostInfo::new()` to round up the task cost. Otherwise, it would produce inconsistent results with `cost_summary` leading to errors in payment service.

#### Payment service: invoice amount assertion replaced
Attempting to issue an invoice with a lower amount than what has been already requested (via debit notes) would cause panic and break yagna daemon for good. Therefore, it has been replaced with a proper error.