### PR TITLE
 Payment service: allow receiving funds without account init

### DIFF
--- a/core/model/src/payment.rs
+++ b/core/model/src/payment.rs
@@ -125,6 +125,32 @@ pub mod local {
         }
     }
 
+    #[derive(Clone, Debug, Serialize, Deserialize, thiserror::Error)]
+    #[error("")]
+    pub struct NoError {} // This is needed because () doesn't implement Display
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct RegisterDriver {
+        pub driver_name: String,
+        pub platform: String,
+        pub recv_init_required: bool, // Is account initialization required for receiving payments
+    }
+
+    impl RpcMessage for RegisterDriver {
+        const ID: &'static str = "RegisterDriver";
+        type Item = ();
+        type Error = NoError;
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct UnregisterDriver(pub String);
+
+    impl RpcMessage for UnregisterDriver {
+        const ID: &'static str = "UnregisterDriver";
+        type Item = ();
+        type Error = NoError;
+    }
+
     #[derive(Clone, Debug, Serialize, Deserialize)]
     pub struct RegisterAccount {
         pub platform: String,
@@ -135,8 +161,10 @@ pub mod local {
 
     #[derive(Clone, Debug, Serialize, Deserialize, thiserror::Error)]
     pub enum RegisterAccountError {
-        #[error("Account already registered")]
-        AlreadyRegistered,
+        #[error("Account already registered: address={0}, driver={1}")]
+        AlreadyRegistered(String, String),
+        #[error("Driver not registered: {0}")]
+        DriverNotRegistered(String),
         #[error("Error while registering account: {0}")]
         Other(String),
     }
@@ -153,18 +181,10 @@ pub mod local {
         pub address: String,
     }
 
-    #[derive(Clone, Debug, Serialize, Deserialize, thiserror::Error)]
-    pub enum UnregisterAccountError {
-        #[error("Account not registered")]
-        NotRegistered,
-        #[error("Error while unregistering account: {0}")]
-        Other(String),
-    }
-
     impl RpcMessage for UnregisterAccount {
         const ID: &'static str = "UnregisterAccount";
         type Item = ();
-        type Error = UnregisterAccountError;
+        type Error = NoError;
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/core/payment-driver/base/src/bus.rs
+++ b/core/payment-driver/base/src/bus.rs
@@ -1,10 +1,10 @@
 /*
-    Collection of interactions a PaymendDriver can have with ya_service_bus
+    Collection of interactions a PaymentDriver can have with ya_service_bus
 
     All interactions with the bus from the driver should go through this mod.
 */
 
-// Extrernal crates
+// External crates
 use std::sync::Arc;
 
 // Workspace uses
@@ -23,8 +23,11 @@ use ya_service_bus::{
 use crate::dao::DbExecutor;
 use crate::driver::PaymentDriver;
 
-pub async fn bind_service<Driver: PaymentDriver + 'static>(db: &DbExecutor, driver: Arc<Driver>) {
-    log::debug!("Binding payment driver service to service bus");
+pub async fn bind_service<Driver: PaymentDriver + 'static>(
+    db: &DbExecutor,
+    driver: Arc<Driver>,
+) -> anyhow::Result<()> {
+    log::debug!("Binding payment driver service to service bus...");
     let bus_id = driver_bus_id(driver.get_name());
 
     /* Short variable names explained:
@@ -33,8 +36,8 @@ pub async fn bind_service<Driver: PaymentDriver + 'static>(db: &DbExecutor, driv
         c = caller
         m = message
     */
-    #[rustfmt::skip] // Keep move's neatly alligned
-    ServiceBinder::new(&bus_id, db, driver)
+    #[rustfmt::skip] // Keep move's neatly aligned
+    ServiceBinder::new(&bus_id, db, driver.clone())
         .bind_with_processor(
             move |db, dr, c, m| async move { dr.init(db, c, m).await }
         )
@@ -57,14 +60,23 @@ pub async fn bind_service<Driver: PaymentDriver + 'static>(db: &DbExecutor, driv
             move |db, dr, c, m| async move { dr.validate_allocation(db, c, m).await }
         );
 
-    log::debug!("Successfully bound payment driver service to service bus");
-    log::debug!("Subscribing to identity events");
+    log::debug!("Successfully bound payment driver service to service bus.");
+
+    log::debug!("Subscribing to identity events...");
     let message = identity::Subscribe { endpoint: bus_id };
-    let result = service(identity::BUS_ID).send(message).await;
-    match result {
-        Err(e) => log::error!("init app-key listener error: {}", e),
-        _ => log::debug!("Successfully subscribed payment driver service to identity events"),
-    }
+    service(identity::BUS_ID).send(message).await??;
+    log::debug!("Successfully subscribed payment driver service to identity events.");
+
+    log::debug!("Registering driver in payment service...");
+    let message = payment_srv::RegisterDriver {
+        driver_name: driver.get_name(),
+        platform: driver.get_platform(),
+        recv_init_required: driver.recv_init_required(),
+    };
+    service(payment_srv::BUS_ID).send(message).await?.unwrap(); // Unwrap on purpose because it's NoError
+    log::debug!("Successfully registered driver in payment service.");
+
+    Ok(())
 }
 
 pub async fn list_unlocked_identities() -> Result<Vec<NodeId>, GenericError> {

--- a/core/payment-driver/base/src/driver.rs
+++ b/core/payment-driver/base/src/driver.rs
@@ -35,6 +35,7 @@ pub trait PaymentDriver {
     // used by bus to bind service
     fn get_name(&self) -> String;
     fn get_platform(&self) -> String;
+    fn recv_init_required(&self) -> bool;
 
     async fn get_transaction_balance(
         &self,

--- a/core/payment-driver/dummy/src/lib.rs
+++ b/core/payment-driver/dummy/src/lib.rs
@@ -8,6 +8,7 @@ pub struct PaymentDriverService;
 impl PaymentDriverService {
     pub async fn gsb<Context>(_context: &Context) -> anyhow::Result<()> {
         self::service::bind_service();
+        self::service::register_in_payment_service().await?;
         Ok(())
     }
 }

--- a/core/payment-driver/dummy/src/service.rs
+++ b/core/payment-driver/dummy/src/service.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use uuid::Uuid;
 use ya_core_model::driver::*;
 use ya_core_model::payment::local as payment_srv;
+use ya_service_bus::typed::service;
 use ya_service_bus::{typed as bus, RpcEndpoint};
 
 pub fn bind_service() {
@@ -20,6 +21,19 @@ pub fn bind_service() {
         .bind(validate_allocation);
 
     log::debug!("Successfully bound payment driver service to service bus");
+}
+
+pub async fn register_in_payment_service() -> anyhow::Result<()> {
+    log::debug!("Registering driver in payment service...");
+    let message = payment_srv::RegisterDriver {
+        driver_name: DRIVER_NAME.to_string(),
+        platform: PLATFORM_NAME.to_string(),
+        recv_init_required: false,
+    };
+    service(payment_srv::BUS_ID).send(message).await?.unwrap(); // Unwrap on purpose because it's NoError
+    log::debug!("Successfully registered driver in payment service.");
+
+    Ok(())
 }
 
 async fn init(_db: (), _caller: String, msg: Init) -> Result<Ack, GenericError> {

--- a/core/payment-driver/gnt/src/lib.rs
+++ b/core/payment-driver/gnt/src/lib.rs
@@ -99,7 +99,8 @@ impl PaymentDriverService {
         let driver = GntDriver::new(db.clone()).await?;
         let processor = GNTDriverProcessor::new(driver);
         self::service::bind_service(&db, processor);
-        self::service::subscribe_to_identity_events().await;
+        self::service::subscribe_to_identity_events().await?;
+        self::service::register_in_payment_service().await?;
         Ok(())
     }
 }

--- a/core/payment-driver/gnt/src/service.rs
+++ b/core/payment-driver/gnt/src/service.rs
@@ -1,8 +1,10 @@
 use crate::processor::GNTDriverProcessor;
-use crate::DRIVER_NAME;
+use crate::{DRIVER_NAME, PLATFORM_NAME};
 use bigdecimal::BigDecimal;
 use ya_core_model::driver::*;
+use ya_core_model::payment::local as payment_srv;
 use ya_persistence::executor::DbExecutor;
+use ya_service_bus::typed::service;
 use ya_service_bus::{typed as bus, RpcEndpoint};
 
 pub fn bind_service(db: &DbExecutor, processor: GNTDriverProcessor) {
@@ -20,15 +22,26 @@ pub fn bind_service(db: &DbExecutor, processor: GNTDriverProcessor) {
     log::debug!("Successfully bound payment driver service to service bus");
 }
 
-pub async fn subscribe_to_identity_events() {
-    if let Err(e) = bus::service(ya_core_model::identity::BUS_ID)
+pub async fn subscribe_to_identity_events() -> anyhow::Result<()> {
+    bus::service(ya_core_model::identity::BUS_ID)
         .send(ya_core_model::identity::Subscribe {
             endpoint: driver_bus_id(DRIVER_NAME),
         })
-        .await
-    {
-        log::error!("init app-key listener error: {}", e)
-    }
+        .await??;
+    Ok(())
+}
+
+pub async fn register_in_payment_service() -> anyhow::Result<()> {
+    log::debug!("Registering driver in payment service...");
+    let message = payment_srv::RegisterDriver {
+        driver_name: DRIVER_NAME.to_string(),
+        platform: PLATFORM_NAME.to_string(),
+        recv_init_required: false,
+    };
+    service(payment_srv::BUS_ID).send(message).await?.unwrap(); // Unwrap on purpose because it's NoError
+    log::debug!("Successfully registered driver in payment service.");
+
+    Ok(())
 }
 
 async fn init(

--- a/core/payment-driver/zksync/src/driver.rs
+++ b/core/payment-driver/zksync/src/driver.rs
@@ -130,6 +130,10 @@ impl PaymentDriver for ZksyncDriver {
         PLATFORM_NAME.to_string()
     }
 
+    fn recv_init_required(&self) -> bool {
+        false
+    }
+
     async fn get_transaction_balance(
         &self,
         _db: DbExecutor,

--- a/core/payment-driver/zksync/src/service.rs
+++ b/core/payment-driver/zksync/src/service.rs
@@ -35,7 +35,7 @@ impl ZksyncService {
         let driver = ZksyncDriver::new(db.clone());
         driver.load_active_accounts().await;
         let driver_rc = Arc::new(driver);
-        bus::bind_service(&db, driver_rc.clone()).await;
+        bus::bind_service(&db, driver_rc.clone()).await?;
         log::debug!("Driver loaded");
 
         // Start cron

--- a/core/payment/examples/payment_api.rs
+++ b/core/payment/examples/payment_api.rs
@@ -195,6 +195,10 @@ async fn main() -> anyhow::Result<()> {
     ya_sb_router::bind_gsb_router(None).await?;
     log::debug!("bind_gsb_router()");
 
+    let processor = PaymentProcessor::new(db.clone());
+    ya_payment::service::bind_service(&db, processor);
+    log::debug!("bind_service()");
+
     let (driver_name, platform) = match args.driver {
         Driver::Dummy => {
             start_dummy_driver().await?;
@@ -209,10 +213,6 @@ async fn main() -> anyhow::Result<()> {
             (zksync::DRIVER_NAME, zksync::PLATFORM_NAME)
         }
     };
-
-    let processor = PaymentProcessor::new(db.clone());
-    ya_payment::service::bind_service(&db, processor);
-    log::debug!("bind_service()");
 
     bus::service(driver_bus_id(driver_name))
         .call(Init::new(provider_id.clone(), AccountMode::RECV))

--- a/core/payment/src/service.rs
+++ b/core/payment/src/service.rs
@@ -26,6 +26,8 @@ mod local {
 
         ServiceBinder::new(BUS_ID, db, processor)
             .bind_with_processor(schedule_payment)
+            .bind_with_processor(register_driver)
+            .bind_with_processor(unregister_driver)
             .bind_with_processor(register_account)
             .bind_with_processor(unregister_account)
             .bind_with_processor(notify_payment)
@@ -67,6 +69,26 @@ mod local {
         Ok(())
     }
 
+    async fn register_driver(
+        db: DbExecutor,
+        processor: PaymentProcessor,
+        sender: String,
+        msg: RegisterDriver,
+    ) -> Result<(), NoError> {
+        processor.register_driver(msg).await;
+        Ok(())
+    }
+
+    async fn unregister_driver(
+        db: DbExecutor,
+        processor: PaymentProcessor,
+        sender: String,
+        msg: UnregisterDriver,
+    ) -> Result<(), NoError> {
+        processor.unregister_driver(msg).await;
+        Ok(())
+    }
+
     async fn register_account(
         db: DbExecutor,
         processor: PaymentProcessor,
@@ -81,8 +103,9 @@ mod local {
         processor: PaymentProcessor,
         sender: String,
         msg: UnregisterAccount,
-    ) -> Result<(), UnregisterAccountError> {
-        processor.unregister_account(msg).await
+    ) -> Result<(), NoError> {
+        processor.unregister_account(msg).await;
+        Ok(())
     }
 
     async fn get_accounts(


### PR DESCRIPTION
Driver registration separated from account registration. Receiving funds and checking account status made possible without prior initialization.

----
Testing instructions:

1. Run `payment_api` with a custom provider address.
```
$ cargo run --example payment_api -- --driver=zksync --provider-addr=0x5b663b55D1D0A2703922713C20CBf14508d18819
```

2. Run `invoice_flow` to trigger a payment and look for errors.
```
$ cargo run --example invoice_flow
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
     Running `/home/adam/yagna/target/debug/examples/invoice_flow`
[2020-12-07T12:44:18Z INFO  invoice_flow] Issuing invoice...
[2020-12-07T12:44:18Z INFO  invoice_flow] Invoice issued.
[2020-12-07T12:44:18Z INFO  invoice_flow] Sending invoice...
[2020-12-07T12:44:18Z INFO  invoice_flow] Invoice sent.
[2020-12-07T12:44:18Z INFO  invoice_flow] Creating allocation...
[2020-12-07T12:44:18Z INFO  invoice_flow] Allocation created.
[2020-12-07T12:44:18Z INFO  invoice_flow] Accepting invoice...
[2020-12-07T12:44:18Z INFO  invoice_flow] Invoice accepted.
[2020-12-07T12:44:18Z INFO  invoice_flow] Waiting for payment...
[2020-12-07T12:44:50Z INFO  invoice_flow] Payment verified correctly.
[2020-12-07T12:44:50Z INFO  invoice_flow] Verifying invoice status...
[2020-12-07T12:44:50Z INFO  invoice_flow] Invoice status verified correctly.
```

3. Check account status.
```
$ cargo run payment status 0x5b663b55D1D0A2703922713C20CBf14508d18819
---
amount: "1.23002852"
incoming:
  accepted:
    agreementsCount: 1
    totalAmount: "1.230028519070000"
  confirmed:
    agreementsCount: 1
    totalAmount: "1.230028519070000"
  requested:
    agreementsCount: 1
    totalAmount: "1.230028519070000"
...
```