### PR TITLE
Verify zksync transaction hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7684,6 +7684,7 @@ dependencies = [
  "log",
  "maplit",
  "num",
+ "serde",
  "serde_json",
  "structopt",
  "tiny-keccak 1.5.0",

--- a/core/payment-driver/zksync/Cargo.toml
+++ b/core/payment-driver/zksync/Cargo.toml
@@ -10,15 +10,16 @@ default = []
 [dependencies]
 async-trait = "0.1"
 anyhow = "1.0"
-awc = "2.0.0"
+awc = { version = "2.0", features = ["openssl"] }
 bigdecimal = { version = "0.1.0" }
 chrono = { version = "0.4", features = ["serde"] }
 futures3 = { version = "0.3", features = ["compat"], package = "futures" }
 hex = "0.4"
 lazy_static = "1.4"
 log = "0.4.8"
-num = { version = "0.2", features = ["serde"] }
 maplit = "1.0"
+num = { version = "0.2", features = ["serde"] }
+serde = "1.0"
 serde_json = "^1.0"
 tiny-keccak = "1.4.2"
 tokio = { version = "0.2", features = ["full"] }

--- a/core/payment-driver/zksync/src/dao.rs
+++ b/core/payment-driver/zksync/src/dao.rs
@@ -58,7 +58,11 @@ impl ZksyncDao {
         }
     }
 
-    pub async fn insert_payment(&self, order_id: &str, msg: &SchedulePayment) -> Result<(), GenericError> {
+    pub async fn insert_payment(
+        &self,
+        order_id: &str,
+        msg: &SchedulePayment,
+    ) -> Result<(), GenericError> {
         let recipient = msg.recipient().to_owned();
         let gnt_amount = utils::big_dec_to_u256(msg.amount());
         let gas_amount = Default::default();

--- a/core/payment-driver/zksync/src/driver.rs
+++ b/core/payment-driver/zksync/src/driver.rs
@@ -8,6 +8,7 @@ use chrono::Utc;
 use std::collections::HashMap;
 use std::str::FromStr;
 use uuid::Uuid;
+use std::str::FromStr;
 
 // Workspace uses
 use ya_payment_driver::{
@@ -333,8 +334,8 @@ impl PaymentDriverCron for ZksyncDriver {
 	                    .into_iter()
 	                    .map(|payment| utils::db_amount_to_big_dec(payment.amount))
 	                    .sum::<BigDecimal>();
-                        }
-                    };
+                    }
+                };
 
                 let order_ids = payments
                     .iter()

--- a/core/payment-driver/zksync/src/driver.rs
+++ b/core/payment-driver/zksync/src/driver.rs
@@ -8,7 +8,6 @@ use chrono::Utc;
 use std::collections::HashMap;
 use std::str::FromStr;
 use uuid::Uuid;
-use std::str::FromStr;
 
 // Workspace uses
 use ya_payment_driver::{
@@ -314,33 +313,32 @@ impl PaymentDriverCron for ZksyncDriver {
                     log::warn!("Payment failed, will be re-tried.");
                     continue;
                 }
-                let driver_name = self.get_name();
-                let details = match wallet::verify_tx(&tx_hash).await
-                {
-                    Ok(a) => a,
-                    Err(e) => {
-                        log::error!("{}", e);
-                        
-	                // Create bespoke payment details:
-	                // - Sender + receiver are the same
-	                // - Date is always now
-	                // - Amount needs to be updated to total of all PaymentEntity's
-
-                // TODO: Add token support
-                let platform =
-                    network_token_to_platform(Some(first_payment.network), None).unwrap(); // TODO: Catch error?
-                let mut details = utils::db_to_payment_details(&first_payment);
-	                details.amount = payments
-	                    .into_iter()
-	                    .map(|payment| utils::db_amount_to_big_dec(payment.amount))
-	                    .sum::<BigDecimal>();
-                    }
-                };
-
                 let order_ids = payments
                     .iter()
                     .map(|payment| payment.order_id.clone())
                     .collect();
+                let details = match wallet::verify_tx(&tx_hash).await
+                {
+                    Ok(a) => a,
+                    Err(e) => {
+                        log::warn!("Failed to get transaction details from zksync, creating bespoke details. Error={}", e);
+
+    	                // Create bespoke payment details:
+    	                // - Sender + receiver are the same
+    	                // - Date is always now
+    	                // - Amount needs to be updated to total of all PaymentEntity's
+
+	                // TODO: Add token support
+	                let platform =
+	                    network_token_to_platform(Some(first_payment.network), None).unwrap(); // TODO: Catch error?
+	                let mut details = utils::db_to_payment_details(&first_payment);
+    	                details.amount = payments
+    	                    .into_iter()
+    	                    .map(|payment| utils::db_amount_to_big_dec(payment.amount.clone()))
+    	                    .sum::<BigDecimal>();
+                        details
+                    }
+                };
                 let tx_hash = hex::decode(&tx_hash).unwrap();
                 if let Err(e) =
                     bus::notify_payment(&self.get_name(), &platform, order_ids, &details, tx_hash)

--- a/core/payment-driver/zksync/src/driver.rs
+++ b/core/payment-driver/zksync/src/driver.rs
@@ -317,25 +317,24 @@ impl PaymentDriverCron for ZksyncDriver {
                     .iter()
                     .map(|payment| payment.order_id.clone())
                     .collect();
-                let details = match wallet::verify_tx(&tx_hash).await
-                {
+                let details = match wallet::verify_tx(&tx_hash).await {
                     Ok(a) => a,
                     Err(e) => {
                         log::warn!("Failed to get transaction details from zksync, creating bespoke details. Error={}", e);
 
-    	                // Create bespoke payment details:
-    	                // - Sender + receiver are the same
-    	                // - Date is always now
-    	                // - Amount needs to be updated to total of all PaymentEntity's
+                        // Create bespoke payment details:
+                        // - Sender + receiver are the same
+                        // - Date is always now
+                        // - Amount needs to be updated to total of all PaymentEntity's
 
 	                // TODO: Add token support
 	                let platform =
 	                    network_token_to_platform(Some(first_payment.network), None).unwrap(); // TODO: Catch error?
 	                let mut details = utils::db_to_payment_details(&first_payment);
-    	                details.amount = payments
-    	                    .into_iter()
-    	                    .map(|payment| utils::db_amount_to_big_dec(payment.amount.clone()))
-    	                    .sum::<BigDecimal>();
+                        details.amount = payments
+                            .into_iter()
+                            .map(|payment| utils::db_amount_to_big_dec(payment.amount.clone()))
+                            .sum::<BigDecimal>();
                         details
                     }
                 };

--- a/core/payment-driver/zksync/src/driver.rs
+++ b/core/payment-driver/zksync/src/driver.rs
@@ -333,8 +333,8 @@ impl PaymentDriverCron for ZksyncDriver {
 	                    .into_iter()
 	                    .map(|payment| utils::db_amount_to_big_dec(payment.amount))
 	                    .sum::<BigDecimal>();
-                    }
-                };
+                        }
+                    };
 
                 let order_ids = payments
                     .iter()

--- a/core/payment-driver/zksync/src/zksync/wallet.rs
+++ b/core/payment-driver/zksync/src/zksync/wallet.rs
@@ -180,8 +180,8 @@ struct TxRespObj {
     created_at: String,
 }
 
-pub async fn verify_tx(tx_hash: &str) -> Result<PaymentDetails, GenericError> {
-    let provider_url = get_rpc_addr(*NETWORK);
+pub async fn verify_tx(tx_hash: &str, network: Network) -> Result<PaymentDetails, GenericError> {
+    let provider_url = get_rpc_addr(get_zk_network(network));
     // HACK: Get the transaction data from v0.1 api
     let api_url = provider_url.replace("/jsrpc", "/api/v0.1");
     let req_url = format!("{}/transactions_all/{}", api_url, tx_hash);

--- a/core/payment/examples/invoice_flow.rs
+++ b/core/payment/examples/invoice_flow.rs
@@ -126,7 +126,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
     assert_eq!(payments.len(), 1);
     let payment = payments.pop().unwrap();
-    assert_eq!(&payment.amount, &invoice.amount);
+    assert!(&payment.amount >= &invoice.amount);
     log::info!("Payment verified correctly.");
 
     log::info!("Verifying invoice status...");

--- a/core/payment/examples/payment_api.rs
+++ b/core/payment/examples/payment_api.rs
@@ -180,12 +180,18 @@ async fn main() -> anyhow::Result<()> {
     let provider_pass: Password = args.provider_pass.clone().into();
     let provider_account = EthAccount::load_or_generate(&args.provider_key_path, provider_pass)?;
     let provider_id = provider_account.address().to_string();
-    let provider_addr = args.provider_addr.unwrap_or(provider_id.clone()).to_lowercase();
+    let provider_addr = args
+        .provider_addr
+        .unwrap_or(provider_id.clone())
+        .to_lowercase();
 
     let requestor_pass: Password = args.requestor_pass.clone().into();
     let requestor_account = EthAccount::load_or_generate(&args.requestor_key_path, requestor_pass)?;
     let requestor_id = requestor_account.address().to_string();
-    let requestor_addr = args.requestor_addr.unwrap_or(requestor_id.clone()).to_lowercase();
+    let requestor_addr = args
+        .requestor_addr
+        .unwrap_or(requestor_id.clone())
+        .to_lowercase();
 
     log::info!(
         "Provider ID: {}\nProvider address: {}\nRequestor ID: {}\nRequestor address: {}",

--- a/core/payment/examples/payment_api.rs
+++ b/core/payment/examples/payment_api.rs
@@ -180,12 +180,12 @@ async fn main() -> anyhow::Result<()> {
     let provider_pass: Password = args.provider_pass.clone().into();
     let provider_account = EthAccount::load_or_generate(&args.provider_key_path, provider_pass)?;
     let provider_id = provider_account.address().to_string();
-    let provider_addr = args.provider_addr.unwrap_or(provider_id.clone());
+    let provider_addr = args.provider_addr.unwrap_or(provider_id.clone()).to_lowercase();
 
     let requestor_pass: Password = args.requestor_pass.clone().into();
     let requestor_account = EthAccount::load_or_generate(&args.requestor_key_path, requestor_pass)?;
     let requestor_id = requestor_account.address().to_string();
-    let requestor_addr = args.requestor_addr.unwrap_or(requestor_id.clone());
+    let requestor_addr = args.requestor_addr.unwrap_or(requestor_id.clone()).to_lowercase();
 
     log::info!(
         "Provider ID: {}\nProvider address: {}\nRequestor ID: {}\nRequestor address: {}",

--- a/core/payment/src/processor.rs
+++ b/core/payment/src/processor.rs
@@ -442,7 +442,7 @@ impl PaymentProcessor {
             .await??;
 
         // Verify if amount declared in message matches actual amount transferred on blockchain
-        if &details.amount != &payment.amount {
+        if &details.amount < &payment.amount {
             return VerifyPaymentError::amount(&details.amount, &payment.amount);
         }
 

--- a/core/payment/src/processor.rs
+++ b/core/payment/src/processor.rs
@@ -442,14 +442,14 @@ impl PaymentProcessor {
             .await??;
 
         // Verify if amount declared in message matches actual amount transferred on blockchain
-        if &details.amount != &payment.amount {
+        if &details.amount < &payment.amount {
             return VerifyPaymentError::amount(&details.amount, &payment.amount);
         }
 
         // Verify if payment shares for agreements and activities sum up to the total amount
         let agreement_sum = payment.agreement_payments.iter().map(|p| &p.amount).sum();
         let activity_sum = payment.activity_payments.iter().map(|p| &p.amount).sum();
-        if &details.amount != &(&agreement_sum + &activity_sum) {
+        if &details.amount < &(&agreement_sum + &activity_sum) {
             return VerifyPaymentError::shares(&details.amount, &agreement_sum, &activity_sum);
         }
 

--- a/core/payment/src/processor.rs
+++ b/core/payment/src/processor.rs
@@ -50,7 +50,7 @@ async fn validate_orders(
         total_amount += &order.amount.0;
     }
 
-    if &total_amount != amount {
+    if &total_amount > amount {
         return OrderValidationError::amount(&total_amount, amount);
     }
 
@@ -442,7 +442,7 @@ impl PaymentProcessor {
             .await??;
 
         // Verify if amount declared in message matches actual amount transferred on blockchain
-        if &details.amount < &payment.amount {
+        if &details.amount != &payment.amount {
             return VerifyPaymentError::amount(&details.amount, &payment.amount);
         }
 


### PR DESCRIPTION
- Remove dummy implementation of transaction verification
- Update payment service to allow larger amounts then on the invoice
- Add verify method on wallet, using the old v0.1 zksync API to query the data