### PR TITLE
Payment API: examples adjusted for event API

### DIFF
--- a/core/payment/examples/debit_note_flow.rs
+++ b/core/payment/examples/debit_note_flow.rs
@@ -1,11 +1,16 @@
 use bigdecimal::BigDecimal;
 use chrono::Utc;
 use std::time::Duration;
+use structopt::StructOpt;
 use ya_client::payment::PaymentApi;
 use ya_client::web::{rest_api_url, WebClient};
-use ya_client_model::payment::{
-    Acceptance, DocumentStatus, NewAllocation, NewDebitNote, PAYMENT_API_PATH,
-};
+use ya_client_model::payment::{Acceptance, DocumentStatus, NewAllocation, NewDebitNote};
+
+#[derive(Clone, Debug, StructOpt)]
+struct Args {
+    #[structopt(long)]
+    app_session_id: Option<String>,
+}
 
 #[actix_rt::main]
 async fn main() -> anyhow::Result<()> {
@@ -13,14 +18,19 @@ async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", log_level);
     env_logger::init();
 
+    let args: Args = Args::from_args();
+
     // Create requestor / provider PaymentApi
-    let rest_api_url = format!("{}{}", rest_api_url(), PAYMENT_API_PATH);
-    let provider_url = format!("{}provider/", &rest_api_url);
-    std::env::set_var("YAGNA_PAYMENT_URL", provider_url);
-    let provider: PaymentApi = WebClient::builder().build().interface()?;
-    let requestor_url = format!("{}requestor/", &rest_api_url);
-    std::env::set_var("YAGNA_PAYMENT_URL", requestor_url);
-    let requestor: PaymentApi = WebClient::builder().build().interface()?;
+    let provider_url = format!("{}provider/", rest_api_url()).parse().unwrap();
+    let provider: PaymentApi = WebClient::builder()
+        .api_url(provider_url)
+        .build()
+        .interface()?;
+    let requestor_url = format!("{}requestor/", rest_api_url()).parse().unwrap();
+    let requestor: PaymentApi = WebClient::builder()
+        .api_url(requestor_url)
+        .build()
+        .interface()?;
 
     let debit_note_date = Utc::now();
 
@@ -46,7 +56,7 @@ async fn main() -> anyhow::Result<()> {
             Some(&debit_note_date),
             Some(Duration::from_secs(10)),
             None,
-            None,
+            args.app_session_id.clone(),
         )
         .await
         .unwrap();
@@ -146,7 +156,7 @@ async fn main() -> anyhow::Result<()> {
     log::info!("Waiting for payment...");
     let timeout = Some(Duration::from_secs(300)); // Should be enough for GNT transfer
     let mut payments = provider
-        .get_payments(Some(&now), timeout, None, None)
+        .get_payments(Some(&now), timeout, None, args.app_session_id.clone())
         .await?;
     assert_eq!(payments.len(), 1);
     let payment = payments.pop().unwrap();

--- a/core/payment/examples/market_decoration.rs
+++ b/core/payment/examples/market_decoration.rs
@@ -1,7 +1,7 @@
 use bigdecimal::BigDecimal;
 use futures::StreamExt;
-use ya_client::payment::PaymentRequestorApi;
-use ya_client::web::WebClient;
+use ya_client::payment::PaymentApi;
+use ya_client::web::{rest_api_url, WebClient};
 use ya_client_model::payment::NewAllocation;
 
 #[actix_rt::main]
@@ -10,13 +10,17 @@ async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", log_level);
     env_logger::init();
 
+    let requestor_url = format!("{}requestor/", rest_api_url()).parse().unwrap();
     let client = match std::env::var("YAGNA_APPKEY").ok() {
-        Some(token) => WebClient::with_token(&token),
-        None => WebClient::builder().build(),
+        Some(token) => WebClient::builder()
+            .api_url(requestor_url)
+            .auth_token(&token)
+            .build(),
+        None => WebClient::builder().api_url(requestor_url).build(),
     };
-    let requestor: PaymentRequestorApi = client.interface()?;
+    let requestor: PaymentApi = client.interface()?;
 
-    let accounts = requestor.get_accounts().await?;
+    let accounts = requestor.get_requestor_accounts().await?;
 
     let allocation_ids = futures::stream::iter(accounts)
         .then(move |account| {
@@ -41,7 +45,7 @@ async fn main() -> anyhow::Result<()> {
         .await;
 
     log::info!("Decorating demand...");
-    let requestor: PaymentRequestorApi = client.interface()?;
+    let requestor: PaymentApi = client.interface()?;
     let decoration = requestor.get_demand_decorations(allocation_ids).await?;
     log::info!("Properties: {:?}", decoration.properties);
     log::info!("Constraints: {:?}", decoration.constraints);

--- a/core/payment/examples/payment_api.rs
+++ b/core/payment/examples/payment_api.rs
@@ -73,6 +73,8 @@ struct Args {
     requestor_addr: Option<String>,
     #[structopt(long, default_value = "agreement_id")]
     agreement_id: String,
+    #[structopt(long)]
+    app_session_id: Option<String>,
 }
 
 pub async fn start_dummy_driver() -> anyhow::Result<()> {
@@ -265,7 +267,7 @@ async fn main() -> anyhow::Result<()> {
         approved_date: None,
         state: market::agreement::State::Proposal,
         timestamp: Utc::now(),
-        app_session_id: None,
+        app_session_id: args.app_session_id,
         proposed_signature: None,
         approved_signature: None,
         committed_signature: None,
@@ -294,19 +296,18 @@ async fn main() -> anyhow::Result<()> {
             role: "".to_string(),
         };
 
-        let provider_api_scope = Scope::new("/provider")
+        let provider_api_scope = Scope::new(&format!("provider/{}", PAYMENT_API_PATH))
+            .data(db.clone())
             .extend(ya_payment::api::api_scope)
             .wrap(DummyAuth::new(provider_identity));
-        let requestor_api_scope = Scope::new("/requestor")
+        let requestor_api_scope = Scope::new(&format!("requestor/{}", PAYMENT_API_PATH))
+            .data(db.clone())
             .extend(ya_payment::api::api_scope)
             .wrap(DummyAuth::new(requestor_identity));
-        let payment_service = Scope::new(PAYMENT_API_PATH)
-            .data(db.clone())
-            .service(provider_api_scope)
-            .service(requestor_api_scope);
         App::new()
             .wrap(middleware::Logger::default())
-            .service(payment_service)
+            .service(provider_api_scope)
+            .service(requestor_api_scope)
     })
     .bind(rest_addr)?
     .run()

--- a/core/payment/examples/validate_allocation.rs
+++ b/core/payment/examples/validate_allocation.rs
@@ -1,6 +1,6 @@
 use bigdecimal::BigDecimal;
-use ya_client::payment::PaymentRequestorApi;
-use ya_client::web::WebClient;
+use ya_client::payment::PaymentApi;
+use ya_client::web::{rest_api_url, WebClient};
 use ya_client_model::payment::NewAllocation;
 use ya_core_model::payment::local as pay;
 use ya_service_bus::typed as bus;
@@ -31,8 +31,11 @@ async fn main() -> anyhow::Result<()> {
     std::env::set_var("RUST_LOG", log_level);
     env_logger::init();
 
-    let client = WebClient::builder().build();
-    let requestor: PaymentRequestorApi = client.interface()?;
+    let requestor_url = format!("{}requestor/", rest_api_url()).parse().unwrap();
+    let requestor: PaymentApi = WebClient::builder()
+        .api_url(requestor_url)
+        .build()
+        .interface()?;
 
     let (requestor_balance, payment_platform) = get_requestor_balance_and_platform().await?;
     let payment_platform = Some(payment_platform);

--- a/core/payment/src/api/debit_notes.rs
+++ b/core/payment/src/api/debit_notes.rs
@@ -130,8 +130,11 @@ async fn issue_debit_note(
     let debit_note = body.into_inner();
     let activity_id = debit_note.activity_id.clone();
 
-    let agreement = match get_agreement_for_activity(activity_id.clone(), ya_core_model::Role::Provider)
-        .await
+    let agreement = match get_agreement_for_activity(
+        activity_id.clone(),
+        ya_core_model::Role::Provider,
+    )
+    .await
     {
         Ok(Some(agreement_id)) => agreement_id,
         Ok(None) => return response::bad_request(&format!("Activity not found: {}", &activity_id)),


### PR DESCRIPTION
* Removed remaining deprecated references to `PaymentProviderApi` and `PaymentRequestorApi`.
* Introduced `--app-session-id` parameter for `payment_api`, `invoice_flow`, and `debit_note_flow` examples in order to test event filtering.
* Changed the way provider and requestor sub-services are used to avoid the hack with `YAGNA_PAYMENT_URL`.

----
Testing instructions:

1. Run `payment_api` example with `--app-session-id=whatever`.
2. Try running `debit_note_flow` and `invoice_flow` with `--app-session-id=somthing-else` (should fail on event unwrapping :x: ).
3. Run `debit_note_flow` and `invoice_flow` with `--app-session-id=whatever` (should work :heavy_check_mark: ).
4. Run all other examples (should work :heavy_check_mark: ).