### PR TITLE
rust 1.49 build fix

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,10 @@
 [build]
+
+[target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
 
+[target.x86_64-pc-windows-gnu]
+rustflags = ["-C", "target-feature=+crt-static"]
 
 [cargo-new]
 name = "Golem Factory"

--- a/core/activity/.cargo/config
+++ b/core/activity/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/core/persistence/.cargo/config
+++ b/core/persistence/.cargo/config
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
target feature `crt-static` should be added only for windows builds.