### PR TITLE
Provider agent: runtime testing

### DIFF
--- a/agent/provider/src/provider_agent.rs
+++ b/agent/provider/src/provider_agent.rs
@@ -131,6 +131,7 @@ impl ProviderAgent {
         log::info!("Payment accounts: {:#?}", accounts);
         let registry = config.registry()?;
         registry.validate()?;
+        registry.test_runtimes()?;
 
         // Generate session id from node name and process id to make sure it's unique.
         let name = args


### PR DESCRIPTION
On startup, runtimes are executed with a `test` command. If the command is not supported, the test result is ignored and the execution flow remains unaltered