### PR TITLE
Moved all query string serialization in payment api to 'serde_qs'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5279,6 +5279,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5cb0f0564a84554436c4ceff5c896308d4e09d0eb4bd0215b8f698f88084601"
+dependencies = [
+ "percent-encoding 2.1.0",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6910,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.4.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=87f106498a7a7b1519d82d0981fc21b260a89cf2#87f106498a7a7b1519d82d0981fc21b260a89cf2"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=e27bd52cc501b99b3cef8d16149779856d8c0e14#e27bd52cc501b99b3cef8d16149779856d8c0e14"
 dependencies = [
  "awc 1.0.1",
  "bytes 0.5.6",
@@ -6925,6 +6936,7 @@ dependencies = [
  "rand 0.6.5",
  "serde",
  "serde_json",
+ "serde_qs",
  "structopt",
  "thiserror",
  "url 2.2.0",
@@ -6947,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.2.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=87f106498a7a7b1519d82d0981fc21b260a89cf2#87f106498a7a7b1519d82d0981fc21b260a89cf2"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=e27bd52cc501b99b3cef8d16149779856d8c0e14#e27bd52cc501b99b3cef8d16149779856d8c0e14"
 dependencies = [
  "bigdecimal 0.1.2",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6921,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.4.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=e27bd52cc501b99b3cef8d16149779856d8c0e14#e27bd52cc501b99b3cef8d16149779856d8c0e14"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=200d42efa6bd77de071b5674efe55aeb2f6296e1#200d42efa6bd77de071b5674efe55aeb2f6296e1"
 dependencies = [
  "awc 1.0.1",
  "bytes 0.5.6",
@@ -6959,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.2.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=e27bd52cc501b99b3cef8d16149779856d8c0e14#e27bd52cc501b99b3cef8d16149779856d8c0e14"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=200d42efa6bd77de071b5674efe55aeb2f6296e1#200d42efa6bd77de071b5674efe55aeb2f6296e1"
 dependencies = [
  "bigdecimal 0.1.2",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,8 +172,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "e27bd52cc501b99b3cef8d16149779856d8c0e14"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "e27bd52cc501b99b3cef8d16149779856d8c0e14"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "200d42efa6bd77de071b5674efe55aeb2f6296e1"}
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "200d42efa6bd77de071b5674efe55aeb2f6296e1"}
 
 #ya-client = { path = "../ya-client" }
 #ya-client-model = { path = "../ya-client/model" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,8 +172,8 @@ ya-sb-router = { path = "service-bus/router" }
 ya-sb-util = { path = "service-bus/util" }
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "87f106498a7a7b1519d82d0981fc21b260a89cf2"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "87f106498a7a7b1519d82d0981fc21b260a89cf2"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "e27bd52cc501b99b3cef8d16149779856d8c0e14"}
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "e27bd52cc501b99b3cef8d16149779856d8c0e14"}
 
 #ya-client = { path = "../ya-client" }
 #ya-client-model = { path = "../ya-client/model" }

--- a/core/payment/src/api.rs
+++ b/core/payment/src/api.rs
@@ -1,6 +1,4 @@
 use actix_web::Scope;
-use chrono::{DateTime, Utc};
-use serde::{Deserialize, Deserializer};
 use ya_client_model::payment::PAYMENT_API_PATH;
 use ya_persistence::executor::DbExecutor;
 use ya_service_api_web::scope::ExtendableScope;
@@ -26,91 +24,4 @@ pub fn web_scope(db: &DbExecutor) -> Scope {
         .service(api_scope(Scope::new("")))
     // TODO: TEST
     // Scope::new(PAYMENT_API_PATH).extend(api_scope).data(db.clone())
-}
-
-pub const DEFAULT_ACK_TIMEOUT: f64 = 60.0; // seconds
-pub const DEFAULT_EVENT_TIMEOUT: f64 = 0.0; // seconds
-
-#[inline(always)]
-pub(crate) fn default_ack_timeout() -> f64 {
-    DEFAULT_ACK_TIMEOUT
-}
-
-#[inline(always)]
-pub(crate) fn default_event_timeout() -> f64 {
-    DEFAULT_EVENT_TIMEOUT
-}
-
-#[derive(Deserialize)]
-pub struct DebitNoteId {
-    pub debit_note_id: String,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct DebitNotePaymentsParams {
-    pub debit_note_id: String,
-    #[serde(default)]
-    pub max_items: Option<u32>,
-    #[serde(default)]
-    pub after_timestamp: Option<DateTime<Utc>>,
-}
-
-#[derive(Deserialize)]
-pub struct InvoiceId {
-    pub invoice_id: String,
-}
-
-#[derive(Deserialize)]
-pub struct AllocationId {
-    pub allocation_id: String,
-}
-
-#[derive(Deserialize)]
-pub struct PaymentId {
-    pub payment_id: String,
-}
-
-#[derive(Deserialize)]
-pub struct Timeout {
-    #[serde(default = "default_ack_timeout")]
-    pub timeout: f64,
-}
-
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct EventParams {
-    #[serde(default = "default_event_timeout")]
-    pub poll_timeout: f64,
-    #[serde(default)]
-    pub after_timestamp: Option<DateTime<Utc>>,
-    #[serde(default)]
-    pub max_events: Option<u32>,
-    #[serde(default)]
-    pub app_session_id: Option<String>,
-}
-
-#[derive(Deserialize)]
-pub struct FilterParams {
-    #[serde(rename = "maxItems", default)]
-    pub max_items: Option<u32>,
-    #[serde(rename = "afterTimestamp", default)]
-    pub after_timestamp: Option<DateTime<Utc>>,
-}
-
-#[derive(Deserialize)]
-pub struct AllocationIds {
-    #[serde(
-        rename = "allocationIds",
-        deserialize_with = "deserialize_comma_separated"
-    )]
-    pub allocation_ids: Vec<String>,
-}
-
-fn deserialize_comma_separated<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let s: &str = Deserialize::deserialize(deserializer)?;
-    Ok(s.split(",").map(str::to_string).collect())
 }

--- a/core/payment/src/api/allocations.rs
+++ b/core/payment/src/api/allocations.rs
@@ -15,7 +15,6 @@ use ya_service_api_web::middleware::Identity;
 use ya_service_bus::{typed as bus, RpcEndpoint};
 
 // Local uses
-use crate::api::*;
 use crate::dao::*;
 use crate::error::{DbError, Error};
 use crate::utils::response;
@@ -80,7 +79,7 @@ async fn create_allocation(
 
 async fn get_allocations(
     db: Data<DbExecutor>,
-    query: Query<FilterParams>,
+    query: Query<params::FilterParams>,
     id: Identity,
 ) -> HttpResponse {
     let node_id = id.identity;
@@ -95,7 +94,7 @@ async fn get_allocations(
 
 async fn get_allocation(
     db: Data<DbExecutor>,
-    path: Path<AllocationId>,
+    path: Path<params::AllocationId>,
     id: Identity,
 ) -> HttpResponse {
     let allocation_id = path.allocation_id.clone();
@@ -110,7 +109,7 @@ async fn get_allocation(
 
 async fn amend_allocation(
     db: Data<DbExecutor>,
-    path: Path<AllocationId>,
+    path: Path<params::AllocationId>,
     body: Json<Allocation>,
 ) -> HttpResponse {
     response::not_implemented() // TODO
@@ -118,7 +117,7 @@ async fn amend_allocation(
 
 async fn release_allocation(
     db: Data<DbExecutor>,
-    path: Path<AllocationId>,
+    path: Path<params::AllocationId>,
     id: Identity,
 ) -> HttpResponse {
     let allocation_id = path.allocation_id.clone();
@@ -133,7 +132,7 @@ async fn release_allocation(
 
 async fn get_demand_decorations(
     db: Data<DbExecutor>,
-    path: Query<AllocationIds>,
+    path: Query<params::AllocationIds>,
     id: Identity,
 ) -> HttpResponse {
     let allocation_ids = path.allocation_ids.clone();

--- a/core/payment/src/api/payments.rs
+++ b/core/payment/src/api/payments.rs
@@ -3,11 +3,11 @@ use actix_web::web::{get, Data, Path, Query};
 use actix_web::{HttpResponse, Scope};
 
 // Workspace uses
+use ya_client_model::payment::*;
 use ya_persistence::executor::DbExecutor;
 use ya_service_api_web::middleware::Identity;
 
 // Local uses
-use crate::api::*;
 use crate::dao::*;
 use crate::utils::*;
 
@@ -19,11 +19,11 @@ pub fn register_endpoints(scope: Scope) -> Scope {
 
 async fn get_payments(
     db: Data<DbExecutor>,
-    query: Query<EventParams>,
+    query: Query<params::EventParams>,
     id: Identity,
 ) -> HttpResponse {
     let node_id = id.identity;
-    let timeout_secs = query.poll_timeout;
+    let timeout_secs = query.poll_timeout.unwrap_or(params::DEFAULT_EVENT_TIMEOUT);
     let after_timestamp = query.after_timestamp.map(|d| d.naive_utc());
     let max_events = query.max_events;
     let app_session_id = &query.app_session_id;
@@ -45,7 +45,11 @@ async fn get_payments(
     }
 }
 
-async fn get_payment(db: Data<DbExecutor>, path: Path<PaymentId>, id: Identity) -> HttpResponse {
+async fn get_payment(
+    db: Data<DbExecutor>,
+    path: Path<params::PaymentId>,
+    id: Identity,
+) -> HttpResponse {
     let payment_id = path.payment_id.clone();
     let node_id = id.identity;
     let dao: PaymentDao = db.as_dao();


### PR DESCRIPTION
**Please do not merge until all `event-api/master`'s are properly merged**

Cleanup after event api, no changes to logic.
- Moved query param objects to payments model
- Updated client api to use these for serialisation
- Moved defaults to be set on the server side