### PR TITLE
bump flexi_logger version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,25 +2338,9 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.15.12"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaab3caedb4149800f91e8e4899f29cd9ddf3b569b04c365ca9334f92f7542bf"
-dependencies = [
- "atty",
- "chrono",
- "glob",
- "lazy_static",
- "log",
- "regex",
- "thiserror",
- "yansi",
-]
-
-[[package]]
-name = "flexi_logger"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291b6ce7b3ed2dda82efa6aee4c6bdb55fd11bc88b06c55b01851e94b96e5322"
+checksum = "cb17f043f5161c62f37683a850da6b4a0a217da77340e63b8789a4635a98da62"
 dependencies = [
  "atty",
  "chrono",
@@ -7032,7 +7016,7 @@ dependencies = [
  "derivative",
  "dotenv",
  "env_logger 0.7.1",
- "flexi_logger 0.15.12",
+ "flexi_logger",
  "futures 0.3.8",
  "graphene-sgx",
  "hex",
@@ -7076,7 +7060,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
- "flexi_logger 0.16.3",
+ "flexi_logger",
  "log",
 ]
 

--- a/agent/provider/src/provider_agent.rs
+++ b/agent/provider/src/provider_agent.rs
@@ -25,7 +25,7 @@ use ya_agreement_utils::agreement::TypedArrayPointer;
 use ya_agreement_utils::*;
 use ya_client::cli::ProviderApi;
 use ya_client_model::payment::Account;
-use ya_file_logging::{start_logger, ReconfigurationHandle};
+use ya_file_logging::{start_logger, LoggerHandle};
 use ya_utils_actix::actix_handler::send_message;
 use ya_utils_path::SwapSave;
 
@@ -37,7 +37,7 @@ pub struct ProviderAgent {
     presets: PresetManager,
     hardware: hardware::Manager,
     accounts: Vec<Account>,
-    log_handler: ReconfigurationHandle,
+    log_handler: LoggerHandle,
 }
 
 struct GlobalsManager {

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -42,7 +42,7 @@ async-trait = "0.1.24"
 chrono = "0.4.10"
 derivative = "2.1"
 dotenv = "0.15.0"
-flexi_logger = { version = "0.15", features = ["colors"] }
+flexi_logger = { version = "0.17", features = ["colors"] }
 futures = "0.3"
 graphene-sgx = { version = "0.3", optional = true }
 hex = "0.4.2"

--- a/utils/file-logging/Cargo.toml
+++ b/utils/file-logging/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 chrono = "0.4"
-flexi_logger = { version = "0.16", features = ["colors", "compress"] }
+flexi_logger = { version = "0.17", features = ["colors", "compress"] }
 log = "0.4"

--- a/utils/file-logging/src/lib.rs
+++ b/utils/file-logging/src/lib.rs
@@ -6,7 +6,7 @@ use flexi_logger::{
 };
 use std::path::Path;
 
-pub use flexi_logger::ReconfigurationHandle;
+pub use flexi_logger::LoggerHandle;
 
 fn log_format(
     w: &mut dyn std::io::Write,
@@ -56,7 +56,7 @@ pub fn start_logger(
     default_log_spec: &str,
     log_dir: Option<&Path>,
     module_filters: &[(&str, log::LevelFilter)],
-) -> Result<ReconfigurationHandle> {
+) -> Result<LoggerHandle> {
     let log_spec = LogSpecification::env_or_parse(default_log_spec)?;
     let mut log_spec_builder = LogSpecBuilder::from_module_filters(log_spec.module_filters());
     for filter in module_filters {


### PR DESCRIPTION
Updating it in exe-unit was postponed from #895. In the mean time a new version was released.