### PR TITLE
ZkSync driver: retry submitting transaction

### DIFF
--- a/core/payment-driver/zksync/src/driver.rs
+++ b/core/payment-driver/zksync/src/driver.rs
@@ -4,7 +4,8 @@
     Please limit the logic in this file, use local mods to handle the calls.
 */
 // Extrnal crates
-use chrono::Utc;
+use chrono::{Duration, TimeZone, Utc};
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::str::FromStr;
 use uuid::Uuid;
@@ -31,6 +32,10 @@ use crate::{
     zksync::wallet,
     DEFAULT_NETWORK, DRIVER_NAME,
 };
+
+lazy_static! {
+    static ref TX_SUMBIT_TIMEOUT: Duration = Duration::minutes(15);
+}
 
 pub struct ZksyncDriver {
     active_accounts: AccountsRc,
@@ -89,22 +94,28 @@ impl ZksyncDriver {
 
     async fn handle_payment(&self, payment: PaymentEntity, nonce: &mut u32) {
         let details = utils::db_to_payment_details(&payment);
-        let tx_id = self.dao.insert_transaction(&details, Utc::now()).await;
         let tx_nonce = nonce.to_owned();
 
         match wallet::make_transfer(&details, tx_nonce, payment.network).await {
             Ok(tx_hash) => {
+                let tx_id = self.dao.insert_transaction(&details, Utc::now()).await;
                 self.dao
-                    .transaction_success(&tx_id, &tx_hash, &payment.order_id)
+                    .transaction_sent(&tx_id, &tx_hash, &payment.order_id)
                     .await;
                 *nonce += 1;
             }
             Err(e) => {
-                self.dao
-                    .transaction_failed(&tx_id, &e, &payment.order_id)
-                    .await;
-                log::error!("NGNT transfer failed: {}", e);
-                //return Err(e);
+                let deadline =
+                    Utc.from_utc_datetime(&payment.payment_due_date) + *TX_SUMBIT_TIMEOUT;
+                if Utc::now() > deadline {
+                    log::error!("Failed to submit zkSync transaction. Retry deadline reached. details={:?} error={}", payment, e);
+                    self.dao.payment_failed(&payment.order_id).await;
+                } else {
+                    log::warn!(
+                        "Failed to submit zkSync transaction. Payment will be retried until {}. details={:?} error={}",
+                        deadline, payment, e
+                    );
+                };
             }
         };
     }
@@ -332,7 +343,7 @@ impl PaymentDriverCron for ZksyncDriver {
             log::trace!("checking tx {:?}", &tx);
             let tx_hash = match &tx.tx_hash {
                 None => continue,
-                Some(a) => a,
+                Some(tx_hash) => tx_hash,
             };
             // Check payments before to fetch network
             let first_payment: PaymentEntity = match self.dao.get_first_payment(&tx_hash).await {
@@ -340,47 +351,56 @@ impl PaymentDriverCron for ZksyncDriver {
                 None => continue,
             };
 
-            // Check_tx returns None when the result is unknown
-            if let Some(result) = wallet::check_tx(&tx_hash, first_payment.network).await {
-                let payments = self.dao.transaction_confirmed(&tx.tx_id, result).await;
-                if !result {
-                    log::warn!("Payment failed, will be re-tried.");
-                    continue;
+            let tx_success = match wallet::check_tx(&tx_hash, first_payment.network).await {
+                None => continue, // Check_tx returns None when the result is unknown
+                Some(tx_success) => tx_success,
+            };
+
+            let payments = self.dao.transaction_confirmed(&tx.tx_id).await;
+            let order_ids: Vec<String> = payments
+                .iter()
+                .map(|payment| payment.order_id.clone())
+                .collect();
+
+            if let Err(err) = tx_success {
+                log::error!(
+                    "ZkSync transaction verification failed. tx_details={:?} error={}",
+                    tx,
+                    err
+                );
+                self.dao.transaction_failed(&tx.tx_id).await;
+                for order_id in order_ids.iter() {
+                    self.dao.payment_failed(order_id).await;
                 }
-                let order_ids = payments
-                    .iter()
-                    .map(|payment| payment.order_id.clone())
-                    .collect();
-
-                // TODO: Add token support
-                let platform =
-                    network_token_to_platform(Some(first_payment.network), None).unwrap(); // TODO: Catch error?
-                let details = match wallet::verify_tx(&tx_hash, first_payment.network).await {
-                    Ok(a) => a,
-                    Err(e) => {
-                        log::warn!("Failed to get transaction details from zksync, creating bespoke details. Error={}", e);
-
-                        // Create bespoke payment details:
-                        // - Sender + receiver are the same
-                        // - Date is always now
-                        // - Amount needs to be updated to total of all PaymentEntity's
-
-                        let mut details = utils::db_to_payment_details(&first_payment);
-                        details.amount = payments
-                            .into_iter()
-                            .map(|payment| utils::db_amount_to_big_dec(payment.amount.clone()))
-                            .sum::<BigDecimal>();
-                        details
-                    }
-                };
-                let tx_hash = hex::decode(&tx_hash).unwrap();
-                if let Err(e) =
-                    bus::notify_payment(&self.get_name(), &platform, order_ids, &details, tx_hash)
-                        .await
-                {
-                    log::error!("{}", e)
-                };
+                return;
             }
+
+            // TODO: Add token support
+            let platform = network_token_to_platform(Some(first_payment.network), None).unwrap(); // TODO: Catch error?
+            let details = match wallet::verify_tx(&tx_hash, first_payment.network).await {
+                Ok(a) => a,
+                Err(e) => {
+                    log::warn!("Failed to get transaction details from zksync, creating bespoke details. Error={}", e);
+
+                    //Create bespoke payment details:
+                    // - Sender + receiver are the same
+                    // - Date is always now
+                    // - Amount needs to be updated to total of all PaymentEntity's
+                    let mut details = utils::db_to_payment_details(&first_payment);
+                    details.amount = payments
+                        .into_iter()
+                        .map(|payment| utils::db_amount_to_big_dec(payment.amount.clone()))
+                        .sum::<BigDecimal>();
+                    details
+                }
+            };
+            let tx_hash = hex::decode(&tx_hash).unwrap();
+
+            if let Err(e) =
+                bus::notify_payment(&self.get_name(), &platform, order_ids, &details, tx_hash).await
+            {
+                log::error!("{}", e)
+            };
         }
     }
 


### PR DESCRIPTION
If submitting transaction fails (e.g. due to operator downtime), retry for some time (hard-coded 15 minutes).

Retrying transactions that failed verification is **not included** because it is a much more complicated matter and cannot be easily solved without major rework of the driver. Transactions that failed verification will in general *fail it again* if re-submitted (by definition of stupidity: "Doing the same thing and expecting different results"). Possible scenario when it would make sense to retry a transaction that failed to verify is "not enough funds" but it requires detecting that account was topped up before re-sending the transaction -- and that's a non-trivial task. Therefore I decide to leave it out of the scope since we have more important issues to solve at this moment.

---
##### Testing instructions

###### Regression test
Just run `payment_api --driver=zksync` and `invoice_flow` to check if transactions work.

###### Functionality test
Modify `core/payment-driver/zksync/src/zksync/wallet.rs` and put this code at the first line of `make_transfer`:
```rust
pub async fn make_transfer(details: &PaymentDetails, nonce: u32) -> Result<String, GenericError> {
    return Err(GenericError::new("This is a test".to_string()));
```
I know it's kinda lame but that's the fastest way to simulate operator error. You can also lower the hard-coded timeout to make the test faster. Then run `payment_api --driver=zksync` and `invoice_flow`. The server (`payment_api`) should output warnings like this until deadline is reached:
```
[2021-01-14T21:01:02Z WARN  ya_zksync_driver::driver] Failed to submit zkSync transaction. Payment will be retried until 2021-01-14 21:01:14.138368546 UTC. details=PaymentEntity { ... } error=This is a test
```
Finally, it should display an error:
```
[2021-01-14T21:01:32Z ERROR ya_zksync_driver::driver] Failed to submit zkSync transaction. Retry deadline reached. details=PaymentEntity { ... } error=This is a test
```