### PR TITLE
Implement exit command for zksync driver

### DIFF
--- a/core/model/src/driver.rs
+++ b/core/model/src/driver.rs
@@ -298,6 +298,13 @@ impl Exit {
             token,
         }
     }
+
+    pub fn amount(&self) -> Option<BigDecimal> {
+        match &self.amount {
+            Some(a) => Some(a.clone()),
+            None => None,
+        }
+    }
 }
 
 impl RpcMessage for Exit {

--- a/core/model/src/driver.rs
+++ b/core/model/src/driver.rs
@@ -278,6 +278,7 @@ impl RpcMessage for Enter {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Exit {
+    sender: String,
     to: Option<String>,
     amount: Option<BigDecimal>,
     network: Option<String>,
@@ -286,12 +287,14 @@ pub struct Exit {
 
 impl Exit {
     pub fn new(
+        sender: String,
         to: Option<String>,
         amount: Option<BigDecimal>,
         network: Option<String>,
         token: Option<String>,
     ) -> Exit {
         Exit {
+            sender,
             to,
             amount,
             network,
@@ -299,12 +302,9 @@ impl Exit {
         }
     }
 
-    pub fn amount(&self) -> Option<BigDecimal> {
-        match &self.amount {
-            Some(a) => Some(a.clone()),
-            None => None,
-        }
-    }
+    pub fn amount(&self) -> Option<BigDecimal> { self.amount.clone() }
+    pub fn sender(&self) -> String { self.sender.clone() }
+    pub fn to(&self) -> Option<String> { self.to.clone() }
 }
 
 impl RpcMessage for Exit {

--- a/core/model/src/driver.rs
+++ b/core/model/src/driver.rs
@@ -302,9 +302,15 @@ impl Exit {
         }
     }
 
-    pub fn amount(&self) -> Option<BigDecimal> { self.amount.clone() }
-    pub fn sender(&self) -> String { self.sender.clone() }
-    pub fn to(&self) -> Option<String> { self.to.clone() }
+    pub fn amount(&self) -> Option<BigDecimal> {
+        self.amount.clone()
+    }
+    pub fn sender(&self) -> String {
+        self.sender.clone()
+    }
+    pub fn to(&self) -> Option<String> {
+        self.to.clone()
+    }
 }
 
 impl RpcMessage for Exit {

--- a/core/payment-driver/zksync/examples/withdrawal.rs
+++ b/core/payment-driver/zksync/examples/withdrawal.rs
@@ -67,16 +67,14 @@ async fn main() -> anyhow::Result<()> {
         .parse()
         .expect("Cannot parse 'amount' parameter to BigDecimal");
 
-    let withdraw_handle = driver_wallet::withdraw(wallet, Some(amount)).await?;
-
-    info!("Waiting for receipt - this takes LOOONG to complete...");
-    info!(
-        "Check it here: https://rinkeby.zkscan.io/explorer/accounts/{}",
-        addr_hex
-    );
+    let withdraw_handle = driver_wallet::withdraw(wallet, Some(amount), None).await?;
 
     let tx_info = withdraw_handle.wait_for_commit().await?;
     if tx_info.success.unwrap_or(false) {
+        let tx_hash = withdraw_handle.hash();
+        let hash_hex = hex::encode(tx_hash.as_ref());
+        info!("Transaction committed, track it here https://rinkeby.zkscan.io/explorer/transactions/{}", hash_hex);
+        info!("Waiting for verification - this takes LOOONG to complete...");
         withdraw_handle.wait_for_verify().await?;
         info!("Withdrawal succeeded!");
     } else {

--- a/core/payment-driver/zksync/src/driver.rs
+++ b/core/payment-driver/zksync/src/driver.rs
@@ -128,8 +128,9 @@ impl PaymentDriver for ZksyncDriver {
         _caller: String,
         msg: Exit,
     ) -> Result<String, GenericError> {
-        log::info!("EXIT = Not Implemented: {:?}", msg);
-        Ok("NOT_IMPLEMENTED".to_string())
+        wallet::exit(_caller, &msg)
+            .await
+            .and(Ok("Success!".to_string()))
     }
 
     async fn get_account_balance(

--- a/core/payment-driver/zksync/src/driver.rs
+++ b/core/payment-driver/zksync/src/driver.rs
@@ -128,9 +128,19 @@ impl PaymentDriver for ZksyncDriver {
         _caller: String,
         msg: Exit,
     ) -> Result<String, GenericError> {
-        wallet::exit(_caller, &msg)
-            .await
-            .and(Ok("Success!".to_string()))
+        if !self.is_account_active(&msg.sender()) {
+            return Err(GenericError::new(
+                "Cannot start withdrawal, account is not active",
+            ));
+        }
+
+        let tx_hash = wallet::exit(&msg).await?;
+        Ok(format!(
+            "Withdrawal has been accepted by the zkSync operator. \
+        It may take some time until the funds are available on Ethereum blockchain. \
+        Tracking link: https://rinkeby.zkscan.io/explorer/transactions/{}",
+            tx_hash
+        ))
     }
 
     async fn get_account_balance(

--- a/core/payment/src/cli.rs
+++ b/core/payment/src/cli.rs
@@ -27,6 +27,7 @@ pub enum PaymentCli {
         token: Option<String>,
     },
     Exit {
+        address: Option<String>,
         #[structopt(help = "Optional address to exit to. [default: <DEFAULT_IDENTIDITY>]")]
         to: Option<String>,
         #[structopt(long, short, help = "Optional amount to exit. [default: <ALL_FUNDS>]")]
@@ -164,17 +165,21 @@ impl PaymentCli {
                 CommandOutput::object(wallet::enter(amount, driver, network, token).await?)
             }
             PaymentCli::Exit {
+                address,
                 to,
                 amount,
                 driver,
                 network,
                 token,
             } => {
+                let address = resolve_address(address).await?;
                 let amount = match amount {
                     None => None,
                     Some(a) => Some(BigDecimal::from_str(&a)?),
                 };
-                CommandOutput::object(wallet::exit(to, amount, driver, network, token).await?)
+                CommandOutput::object(
+                    wallet::exit(address, to, amount, driver, network, token).await?,
+                )
             }
             PaymentCli::Transfer {
                 to,

--- a/core/payment/src/wallet.rs
+++ b/core/payment/src/wallet.rs
@@ -18,6 +18,7 @@ pub async fn enter(
 }
 
 pub async fn exit(
+    sender: String,
     to: Option<String>,
     amount: Option<BigDecimal>,
     driver: String,
@@ -25,7 +26,7 @@ pub async fn exit(
     token: Option<String>,
 ) -> anyhow::Result<String> {
     let driver_id = driver_bus_id(driver);
-    let message = Exit::new(to, amount, network, token);
+    let message = Exit::new(sender, to, amount, network, token);
     let tx_id = bus::service(driver_id).call(message).await??;
     Ok(tx_id)
 }


### PR DESCRIPTION
Implements `exit` command based on already added `wallet::withdraw`.

**Changes:**

- extend `Exit` (message) structure of `sender` and accessor methods,
- retrieve confirmed transaction's hash,
- improve messages returned from command to the caller
- improve an example (tracking url to the zk-sync transaction)

**Tests:**

- :heavy_check_mark: Exiting with just amount 
```
#> cargo run payment exit --amount=10
Withdrawal has been accepted by the zkSync operator. It may take some time until the funds are available on Ethereum blockchain. 
Tracking link: https://rinkeby.zkscan.io/explorer/transactions/c0dedebfedb6825c17b548769792b120498f50722f4c6e48c02f9058f7c6d310
```

- :heavy_check_mark: Exiting to different address
- :heavy_check_mark: Cleaning account without parameters

Check it here: [[zk-scan @ 0x5943...9d15](https://rinkeby.zkscan.io/explorer/accounts/0x59432583686171d091c0c058f187d34b93339d15)]
