### PR TITLE
enclose version functionality in ya-compile-time-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7006,6 +7006,7 @@ name = "ya-compile-time-utils"
 version = "0.1.0"
 dependencies = [
  "git-version",
+ "metrics",
  "semver 0.11.0",
  "vergen",
 ]
@@ -7794,7 +7795,6 @@ dependencies = [
  "gftp",
  "lazy_static",
  "log",
- "metrics",
  "openssl",
  "structopt",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ dotenv = "0.15.0"
 futures = "0.3"
 lazy_static = "1.4"
 log = "0.4"
-metrics = "0.12"
 openssl = "0.10"
 structopt = "0.3"
 tokio = {version = "0.2.22", features=["uds"]}

--- a/golem_cli/src/main.rs
+++ b/golem_cli/src/main.rs
@@ -86,7 +86,7 @@ pub fn banner() {
         include_str!("banner.txt"),
         version = ya_compile_time_utils::semver_str(),
         git_commit = ya_compile_time_utils::git_rev(),
-        build = ya_compile_time_utils::build_number_str().unwrap_or("-"),
+        build = ya_compile_time_utils::build_number().unwrap_or("-"),
         date = ya_compile_time_utils::build_date()
     ))
     .unwrap();

--- a/utils/compile-time-utils/Cargo.toml
+++ b/utils/compile-time-utils/Cargo.toml
@@ -7,6 +7,7 @@ description = "Compile-time utilities"
 
 [dependencies]
 git-version = "0.3.4"
+metrics = "0.12"
 semver = "0.11.0"
 
 [build-dependencies]

--- a/utils/compile-time-utils/src/lib.rs
+++ b/utils/compile-time-utils/src/lib.rs
@@ -1,7 +1,8 @@
 use git_version::git_version;
+use metrics::value;
 use semver::Version;
 
-/// Returns latest tag or version from Cargo.toml`.
+/// Returns latest tag (via `git describe --tag --abbrev=0`) or version from Cargo.toml`.
 pub fn git_tag() -> &'static str {
     git_version!(
         args = ["--tag", "--abbrev=0"],
@@ -20,31 +21,43 @@ pub fn build_date() -> &'static str {
 }
 
 /// Returns Github Actions build number if available or None.
-pub fn build_number_str() -> Option<&'static str> {
+pub fn build_number() -> Option<&'static str> {
     option_env!("GITHUB_RUN_NUMBER")
 }
 
-pub fn build_number() -> Option<u64> {
-    build_number_str().map(|i| {
-        // should not panic
-        i.parse().unwrap()
-    })
-}
-
 /// convert tag to a semantic version
-pub fn semver_str() -> &'static str {
+pub fn semver_str() -> String {
     let mut version = git_tag();
     for prefix in ["pre-rel-", "v"].iter() {
         if version.starts_with(prefix) {
             version = &version[prefix.len()..];
         }
     }
-    version
+    if let Some(bn) = build_number() {
+        [version, bn].join("+")
+    } else {
+        version.to_string()
+    }
 }
 
 pub fn semver() -> Version {
-    // It must parse correctly and if it passes test it won't change later.
-    Version::parse(semver_str()).unwrap()
+    Version::parse(&semver_str()).unwrap()
+}
+
+pub fn report_version_to_metrics() {
+    let version = semver();
+    value!("yagna.version.major", version.major);
+    value!("yagna.version.minor", version.minor);
+    value!("yagna.version.patch", version.patch);
+    value!(
+        "yagna.version.is_prerelease",
+        (!version.pre.is_empty()) as u64
+    );
+    if !version.build.is_empty() {
+        if let semver::Identifier::Numeric(build_number) = version.build[0] {
+            value!("yagna.version.build_number", build_number);
+        }
+    }
 }
 
 #[macro_export]
@@ -52,7 +65,7 @@ macro_rules! version_describe {
     () => {
         Box::leak(
             [
-                $crate::semver_str(),
+                &$crate::semver_str(),
                 " (",
                 $crate::git_rev(),
                 " ",
@@ -73,14 +86,19 @@ mod test {
     use super::*;
 
     #[test]
+    fn test_git_rev() {
+        println!("git rev: {:?}", git_rev());
+    }
+
+    #[test]
     fn test_semver() {
         // should not panic
-        semver();
+        println!("semver: {:?}", semver());
     }
 
     #[test]
     fn test_build_number() {
         // should not panic
-        build_number();
+        println!("build: {:?}", build_number());
     }
 }


### PR DESCRIPTION
It encloses version reporting in ya-compile-time-utils
made on top of #933 