### PR TITLE
Payment status/yagna with header

### DIFF
--- a/core/payment-driver/base/src/driver.rs
+++ b/core/payment-driver/base/src/driver.rs
@@ -16,7 +16,7 @@ pub use bigdecimal::BigDecimal;
 use std::collections::HashMap;
 pub use ya_client_model::NodeId;
 pub use ya_core_model::identity::{event::Event as IdentityEvent, Error as IdentityError};
-pub use ya_core_model::payment::local::Network;
+pub use ya_core_model::payment::local::{Network, Platform};
 
 #[async_trait(?Send)]
 pub trait PaymentDriver {

--- a/core/payment-driver/dummy/src/lib.rs
+++ b/core/payment-driver/dummy/src/lib.rs
@@ -3,7 +3,7 @@ mod service;
 pub const DRIVER_NAME: &'static str = "dummy";
 pub const NETWORK_NAME: &'static str = "dummy";
 pub const TOKEN_NAME: &'static str = "GLM";
-pub const PLATFORM_NAME: &'static str = "dummy-glm";
+pub const PLATFORM_NAME: &'static str = "dummy-dummy-glm"; // TODO: remove
 
 pub struct PaymentDriverService;
 

--- a/core/payment-driver/dummy/src/service.rs
+++ b/core/payment-driver/dummy/src/service.rs
@@ -6,7 +6,7 @@ use maplit::hashmap;
 use std::str::FromStr;
 use uuid::Uuid;
 use ya_core_model::driver::*;
-use ya_core_model::payment::local as payment_srv;
+use ya_core_model::payment::local::{self as payment_srv, Platform};
 use ya_service_bus::typed::service;
 use ya_service_bus::{typed as bus, RpcEndpoint};
 
@@ -26,13 +26,19 @@ pub fn bind_service() {
 
 pub async fn register_in_payment_service() -> anyhow::Result<()> {
     log::debug!("Registering driver in payment service...");
+    let default_platform = Platform {
+        driver: DRIVER_NAME.to_string(),
+        network: NETWORK_NAME.to_string(),
+        token: TOKEN_NAME.to_string(),
+    };
     let details = payment_srv::DriverDetails {
         default_network: NETWORK_NAME.to_string(),
         networks: hashmap! {
             NETWORK_NAME.to_string() => payment_srv::Network {
+                name: NETWORK_NAME.to_string(),
                 default_token: TOKEN_NAME.to_string(),
                 tokens: hashmap! {
-                    TOKEN_NAME.to_string() => PLATFORM_NAME.to_string()
+                    TOKEN_NAME.to_string().to_lowercase() => default_platform
                 }
             }
         },

--- a/core/payment-driver/gnt/src/lib.rs
+++ b/core/payment-driver/gnt/src/lib.rs
@@ -56,7 +56,7 @@ pub const DRIVER_NAME: &'static str = "erc20";
 
 pub const DEFAULT_NETWORK: &'static str = "rinkeby";
 pub const DEFAULT_TOKEN: &'static str = "tGLM";
-pub const DEFAULT_PLATFORM: &'static str = "erc20-rinkeby-tglm";
+pub const DEFAULT_PLATFORM: &'static str = "erc20-rinkeby-tglm"; // TODO: remove
 
 const ETH_FAUCET_MAX_WAIT: time::Duration = time::Duration::from_secs(180);
 

--- a/core/payment-driver/gnt/src/service.rs
+++ b/core/payment-driver/gnt/src/service.rs
@@ -1,9 +1,9 @@
 use crate::processor::GNTDriverProcessor;
-use crate::{DEFAULT_NETWORK, DEFAULT_PLATFORM, DEFAULT_TOKEN, DRIVER_NAME};
+use crate::{DEFAULT_NETWORK, DEFAULT_TOKEN, DRIVER_NAME};
 use bigdecimal::BigDecimal;
 use maplit::hashmap;
 use ya_core_model::driver::*;
-use ya_core_model::payment::local as payment_srv;
+use ya_core_model::payment::local::{self as payment_srv, Platform};
 use ya_persistence::executor::DbExecutor;
 use ya_service_bus::typed::service;
 use ya_service_bus::{typed as bus, RpcEndpoint};
@@ -34,11 +34,17 @@ pub async fn subscribe_to_identity_events() -> anyhow::Result<()> {
 
 pub async fn register_in_payment_service() -> anyhow::Result<()> {
     log::debug!("Registering driver in payment service...");
+    let default_platform = Platform {
+        driver: DRIVER_NAME.to_string(),
+        network: DEFAULT_NETWORK.to_string(),
+        token: DEFAULT_TOKEN.to_string(),
+    };
     let networks = hashmap! {  // TODO: Implement multi-network support
         DEFAULT_NETWORK.to_string() => payment_srv::Network {
+            name: DEFAULT_NETWORK.to_string(),
             default_token: DEFAULT_TOKEN.to_string(),
             tokens: hashmap! {
-                DEFAULT_TOKEN.to_string() => DEFAULT_PLATFORM.to_string()
+                DEFAULT_TOKEN.to_string().to_lowercase() => default_platform
             }
         }
     };

--- a/core/payment-driver/zksync/src/driver.rs
+++ b/core/payment-driver/zksync/src/driver.rs
@@ -17,7 +17,9 @@ use ya_payment_driver::{
     cron::PaymentDriverCron,
     dao::DbExecutor,
     db::models::PaymentEntity,
-    driver::{async_trait, BigDecimal, IdentityError, IdentityEvent, Network, PaymentDriver},
+    driver::{
+        async_trait, BigDecimal, IdentityError, IdentityEvent, Network, PaymentDriver, Platform,
+    },
     model::*,
     utils,
 };
@@ -136,12 +138,18 @@ impl PaymentDriver for ZksyncDriver {
 
     fn get_networks(&self) -> HashMap<String, Network> {
         // TODO: Implement multi-network support
+        let default_platform = Platform {
+            driver: DRIVER_NAME.to_string(),
+            network: DEFAULT_NETWORK.to_string(),
+            token: DEFAULT_TOKEN.to_string(),
+        };
 
         hashmap! {
             DEFAULT_NETWORK.to_string() => Network {
+                name: DEFAULT_NETWORK.to_string(),
                 default_token: DEFAULT_TOKEN.to_string(),
                 tokens: hashmap! {
-                    DEFAULT_TOKEN.to_string() => DEFAULT_PLATFORM.to_string()
+                    DEFAULT_TOKEN.to_string().to_lowercase() => default_platform
                 }
             }
         }

--- a/core/payment-driver/zksync/src/lib.rs
+++ b/core/payment-driver/zksync/src/lib.rs
@@ -10,7 +10,7 @@ pub const ZKSYNC_TOKEN_NAME: &'static str = "GNT";
 
 pub const DEFAULT_NETWORK: &'static str = "rinkeby";
 pub const DEFAULT_TOKEN: &'static str = "tGLM";
-pub const DEFAULT_PLATFORM: &'static str = "zksync-rinkeby-tglm";
+pub const DEFAULT_PLATFORM: &'static str = "zksync-rinkeby-tglm"; // TODO: remove
 
 pub use service::ZksyncService as PaymentDriverService;
 

--- a/core/payment/examples/account_balance.rs
+++ b/core/payment/examples/account_balance.rs
@@ -15,8 +15,11 @@ async fn main() -> anyhow::Result<()> {
     for account in account_list.into_iter() {
         let payer_status = bus::service(pay::BUS_ID)
             .call(pay::GetStatus {
-                platform: account.platform.to_string(),
                 address: account.address.to_string(),
+                platform: Some(account.platform.to_string()),
+                driver: None,
+                network: None,
+                token: None,
             })
             .await??;
 

--- a/core/payment/examples/cancel_invoice.rs
+++ b/core/payment/examples/cancel_invoice.rs
@@ -24,16 +24,22 @@ async fn assert_requested_amount(
 ) -> anyhow::Result<()> {
     let payer_status = bus::service(pay::BUS_ID)
         .call(pay::GetStatus {
-            platform: payment_platform.to_string(),
             address: payer_addr.to_string(),
+            platform: Some(payment_platform.to_string()),
+            driver: None,
+            network: None,
+            token: None,
         })
         .await??;
     assert_eq!(&payer_status.outgoing.requested.total_amount, amount);
 
     let payee_status = bus::service(pay::BUS_ID)
         .call(pay::GetStatus {
-            platform: payment_platform.to_string(),
             address: payee_addr.to_string(),
+            platform: Some(payment_platform.to_string()),
+            driver: None,
+            network: None,
+            token: None,
         })
         .await??;
     assert_eq!(&payee_status.incoming.requested.total_amount, amount);

--- a/core/payment/examples/validate_allocation.rs
+++ b/core/payment/examples/validate_allocation.rs
@@ -14,8 +14,11 @@ async fn get_requestor_balance_and_platform() -> anyhow::Result<(BigDecimal, Str
         if account.send {
             let status = bus::service(pay::BUS_ID)
                 .call(pay::GetStatus {
-                    platform: account.platform.clone(),
                     address: account.address.clone(),
+                    platform: Some(account.platform.clone()),
+                    driver: None,
+                    network: None,
+                    token: None,
                 })
                 .await??;
             return Ok((status.amount, account.platform));

--- a/core/payment/src/cli.rs
+++ b/core/payment/src/cli.rs
@@ -27,6 +27,8 @@ pub enum PaymentCli {
         driver: String,
         #[structopt(long)]
         network: Option<String>,
+        #[structopt(long)]
+        platform: Option<String>,
     },
     Accounts,
     Invoice {
@@ -71,12 +73,14 @@ impl PaymentCli {
                 account,
                 driver,
                 network,
+                platform,
             } => {
                 let address = resolve_address(account).await?;
                 let status = bus::service(pay::BUS_ID)
                     .call(pay::GetStatus {
                         address,
-                        driver,
+                        platform,
+                        driver: Some(driver),
                         network,
                         token: None,
                     })

--- a/core/payment/src/cli.rs
+++ b/core/payment/src/cli.rs
@@ -85,7 +85,47 @@ impl PaymentCli {
                         token: None,
                     })
                     .await??;
-                CommandOutput::object(status) // TODO: render as table
+                if ctx.json_output {
+                    CommandOutput::object(status)
+                } else {
+                    Ok(ResponseTable {
+                        columns: vec![
+                            "platform".to_owned(),
+                            "total amount".to_owned(),
+                            "reserved".to_owned(),
+                            "amount".to_owned(),
+                            "incoming".to_owned(),
+                            "outgoing".to_owned(),
+                        ],
+                        values: vec![
+                            serde_json::json! {[
+                            format!("driver: {}", status.platform.driver),
+                            format!("{} {}", status.amount, status.platform.token),
+                            format!("{} {}", status.reserved, status.platform.token),
+                            "accepted",
+                            status.incoming.accepted.total_amount,
+                            status.outgoing.accepted.total_amount,
+                            ]},
+                            serde_json::json! {[
+                            format!("network: {}", status.platform.network),
+                            "",
+                            "",
+                            "confirmed",
+                            status.incoming.confirmed.total_amount,
+                            status.outgoing.confirmed.total_amount,
+                            ]},
+                            serde_json::json! {[
+                            format!("token: {}", status.platform.token),
+                            "",
+                            "",
+                            "requested",
+                            status.incoming.requested.total_amount,
+                            status.outgoing.requested.total_amount,
+                            ]},
+                        ],
+                    }
+                    .into())
+                }
             }
             PaymentCli::Accounts => {
                 let accounts = bus::service(pay::BUS_ID)

--- a/golem_cli/src/command/yagna.rs
+++ b/golem_cli/src/command/yagna.rs
@@ -17,9 +17,8 @@ pub static DEFAULT_NETWORK: &'static str = "mainnet";
 
 pub struct PaymentType {
     pub platform: &'static str,
-    pub token: &'static str,
     pub driver: &'static str,
-    pub token_display_name: &'static str,
+    pub token: &'static str,
 }
 
 pub struct DriverDescriptor(pub HashMap<&'static str, PaymentType>);
@@ -31,18 +30,16 @@ lazy_static! {
             "mainnet",
             PaymentType {
                 platform: "zksync-mainnet-glm",
-                token: "glm",
                 driver: "zksync",
-                token_display_name: "GLM",
+                token: "GLM",
             },
         );
         zksync.insert(
             "rinkeby",
             PaymentType {
                 platform: "zksync-rinkeby-tglm",
-                token: "tglm",
                 driver: "zksync",
-                token_display_name: "tGLM",
+                token: "tGLM",
             },
         );
         DriverDescriptor(zksync)
@@ -53,18 +50,16 @@ lazy_static! {
             "mainnet",
             PaymentType {
                 platform: "erc20-mainnet-glm",
-                token: "glm",
                 driver: "erc20",
-                token_display_name: "GLM",
+                token: "GLM",
             },
         );
         erc20.insert(
             "rinkeby",
             PaymentType {
                 platform: "erc20-rinkeby-tglm",
-                token: "tglm",
                 driver: "erc20",
-                token_display_name: "tGLM",
+                token: "tGLM",
             },
         );
         DriverDescriptor(erc20)
@@ -83,7 +78,7 @@ impl DriverDescriptor {
     }
 
     pub fn token_name(&self, network: Option<&str>) -> anyhow::Result<&str> {
-        Ok(self.payment_type(network)?.token_display_name)
+        Ok(self.payment_type(network)?.token)
     }
 }
 

--- a/golem_cli/src/setup.rs
+++ b/golem_cli/src/setup.rs
@@ -1,4 +1,4 @@
-use crate::command::{RecvAccount, UsageDef, DEFAULT_NETWORK, ERC20_DRIVER};
+use crate::command::{RecvAccount, UsageDef, DEFAULT_NETWORK};
 use crate::terminal::clear_stdin;
 use anyhow::Result;
 use directories::ProjectDirs;
@@ -152,13 +152,12 @@ pub async fn setup(run_config: &mut RunConfig, force: bool) -> Result<i32> {
             .map(|p| p.name)
             .collect();
 
-        // We expect, that token name will be the same for zksync driver within specified network.
-        let token = (*ERC20_DRIVER).token_name(Some(&run_config.network))?;
-        let ngnt_per_h = promptly::prompt_default(format!("Price {} per hour", token), 5.0)?;
+        let default_glm_per_h = 1.0;
+        let glm_per_h = promptly::prompt_default("Price GLM per hour", default_glm_per_h)?;
 
         let usage = UsageDef {
-            cpu: ngnt_per_h / 3600.0,
-            duration: ngnt_per_h / 3600.0 / 5.0,
+            cpu: glm_per_h / 3600.0,
+            duration: glm_per_h / 3600.0 / default_glm_per_h,
             initial: 0.0,
         };
 

--- a/golem_cli/src/status.rs
+++ b/golem_cli/src/status.rs
@@ -134,8 +134,10 @@ pub async fn run(args: StatusCommand) -> Result</*exit code*/ i32> {
             let (zk_payment_status, erc20_payment_status) =
                 payment_status(&cmd, &args.network, &config.account).await?;
 
-            // We expect, that token name will be the same for zksync driver within specified network.
-            let token = (*ERC20_DRIVER).token_name(Some(&args.network))?;
+            let token = match zk_payment_status.platform.token.len() {
+                0 => erc20_payment_status.platform.token,
+                _ => zk_payment_status.platform.token,
+            };
 
             let mut table = Table::new();
             let format = format::FormatBuilder::new().padding(1, 1).build();

--- a/golem_cli/src/status.rs
+++ b/golem_cli/src/status.rs
@@ -24,7 +24,7 @@ async fn payment_status(
 ) -> anyhow::Result<(StatusResult, StatusResult)> {
     if let Some(account) = account {
         let address = account.address.to_lowercase();
-        let (status_zk, status) = future::join(
+        let (status_zk, status_erc20) = future::join(
             cmd.yagna()?
                 .payment_status(Some(&address), network, &ZKSYNC_DRIVER),
             cmd.yagna()?
@@ -54,7 +54,7 @@ async fn payment_status(
             })
             .flatten()
             .unwrap_or(true);
-        match (status_zk, status) {
+        match (status_zk, status_erc20) {
             (Ok(zk), Ok(eth)) => Ok((zk, eth)),
             (Err(e), _) if is_zk => Err(e),
             (_, Err(e)) if is_erc20 => Err(e),
@@ -63,12 +63,12 @@ async fn payment_status(
             (Err(e), _) => Err(e),
         }
     } else {
-        let (status_zk, status) = future::join(
+        let (status_zk, status_erc20) = future::join(
             cmd.yagna()?.payment_status(None, network, &ZKSYNC_DRIVER),
             cmd.yagna()?.payment_status(None, network, &ERC20_DRIVER),
         )
         .await;
-        match (status_zk, status) {
+        match (status_zk, status_erc20) {
             (Ok(zk), Ok(eth)) => Ok((zk, eth)),
             (Err(e), _) => Err(e),
             (Ok(zk), Err(_)) => Ok((zk, StatusResult::default())),
@@ -150,6 +150,10 @@ pub async fn run(args: StatusCommand) -> Result</*exit code*/ i32> {
             } else {
                 table.add_row(row!["address", &id.node_id]);
             }
+            table.add_row(row![
+                "network",
+                Style::new().fg(Colour::Purple).paint(&args.network)
+            ]);
             let total_amount = &zk_payment_status.amount + &erc20_payment_status.amount;
             table.add_row(row![
                 "amount (total)",


### PR DESCRIPTION
I've added header info to `yagna payment status` and formatted it as a table (`--json` is backward compatible`)
Now it is possible for `golemsp` to use token name from above output, so I've removed internal cfg.