### PR TITLE
Enforce developers to update lock file, otherwise test will fail

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,18 +50,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-index-
 
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        if: matrix.os != 'macos-latest'
+      - name: cargo tree - to check lockfile validity
+        uses: actions-rs/cargo@v1
         with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target1-${{ hashFiles('**/Cargo.lock') }}
+          command: tree
+          args: --locked
 
       - name: cargo fmt
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        if: matrix.os != 'macos-latest'
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target1-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Cache vcpkg's artifacts
         uses: actions/cache@v1
@@ -83,7 +89,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace
+          args: --workspace --locked
 
       - name: cargo test sgx
         if: matrix.os == 'ubuntu-latest'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
  "parking_lot 0.11.1",
  "pin-project 0.4.27",
  "smallvec 1.6.1",
- "tokio",
+ "tokio 0.2.24",
  "tokio-util 0.3.1",
 ]
 


### PR DESCRIPTION
First commit will test if it actually breaks, will update lock file in the second.

Also moved `tree` and `fmt` to run before the long cache task, fail fast!