### PR TITLE
ZkSync driver: cron job mutexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7563,6 +7563,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "ethereum-types 0.6.0",
+ "futures 0.3.12",
  "hex",
  "log",
  "num",

--- a/core/payment-driver/base/Cargo.toml
+++ b/core/payment-driver/base/Cargo.toml
@@ -16,6 +16,7 @@ chrono = { version = "0.4", features = ["serde"] }
 diesel = { version = "1.4", features = ["sqlite", "r2d2", "chrono"] }
 diesel_migrations = "1.4"
 ethereum-types = "0.6.0"
+futures = "0.3"
 hex = "0.4"
 log = "0.4.8"
 num = { version = "0.2", features = ["serde"] }

--- a/core/payment-driver/base/src/cron.rs
+++ b/core/payment-driver/base/src/cron.rs
@@ -9,6 +9,7 @@ use actix::{
     prelude::{Addr, Context},
     Actor,
 };
+use futures::lock::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -21,34 +22,52 @@ pub trait PaymentDriverCron {
 }
 
 pub struct Cron<D: PaymentDriverCron> {
-    driver: Arc<D>,
+    payment_job_handle: Arc<Mutex<Arc<D>>>,
+    confirmation_job_handle: Arc<Mutex<Arc<D>>>,
 }
 
 impl<D: PaymentDriverCron + 'static> Cron<D> {
     pub fn new(driver: Arc<D>) -> Addr<Self> {
         log::trace!("Creating Cron for PaymentDriver.");
-        let me = Self { driver };
+        let me = Self {
+            payment_job_handle: Arc::new(Mutex::new(driver.clone())),
+            confirmation_job_handle: Arc::new(Mutex::new(driver.clone())),
+        };
         me.start()
     }
 
     fn start_confirmation_job(&mut self, ctx: &mut Context<Self>) {
         let _ = ctx.run_interval(Duration::from_secs(5), |act, _ctx| {
-            log::trace!("Spawning confirmation job.");
-            let driver = act.driver.clone();
+            let driver = act.confirmation_job_handle.clone();
             Arbiter::spawn(async move {
-                driver.confirm_payments().await;
-                log::trace!("Confirmation job finished.");
+                match driver.try_lock() {
+                    Some(driver) => {
+                        log::trace!("Running payment confirmation job...");
+                        driver.confirm_payments().await;
+                        log::trace!("Confirmation job finished.");
+                    }
+                    None => {
+                        log::trace!("Confirmation job in progress.");
+                    }
+                }
             });
         });
     }
 
     fn start_payment_job(&mut self, ctx: &mut Context<Self>) {
         let _ = ctx.run_interval(Duration::from_secs(10), |act, _ctx| {
-            log::trace!("Spawning payment job.");
-            let driver = act.driver.clone();
+            let driver = act.payment_job_handle.clone();
             Arbiter::spawn(async move {
-                driver.process_payments().await;
-                log::trace!("Payment job finished.");
+                match driver.try_lock() {
+                    Some(driver) => {
+                        log::trace!("Running payment job...");
+                        driver.process_payments().await;
+                        log::trace!("Payment job finished.");
+                    }
+                    None => {
+                        log::trace!("Payment job in progress.");
+                    }
+                }
             });
         });
     }


### PR DESCRIPTION
If a new payment scheduling job started while a previous one had been already in progress, it would lead to database errors due to single transaction being processed twice. Introduced mutexes for payment scheduling job and payment confirmation job to avoid it.