### PR TITLE
Key backup command for Identity

### DIFF
--- a/core/identity/src/cli/identity.rs
+++ b/core/identity/src/cli/identity.rs
@@ -132,9 +132,9 @@ pub enum IdentityCommand {
         node_or_alias: NodeOrAlias,
     },
 
-    /// Backup given identity to a file
-    Backup {
-        /// Identity alias to backup
+    /// Exports given identity to a file | stdout
+    Export {
+        /// Identity alias to export
         node_or_alias: Option<NodeOrAlias>,
 
         /// File path where identity will be written. Defaults to `stdout`
@@ -273,7 +273,7 @@ impl IdentityCommand {
                         .map_err(|e| anyhow::Error::msg(e))?,
                 )
             }
-            IdentityCommand::Backup {
+            IdentityCommand::Export {
                 node_or_alias,
                 file_path,
             } => {

--- a/core/identity/src/cli/identity.rs
+++ b/core/identity/src/cli/identity.rs
@@ -119,6 +119,7 @@ pub enum IdentityCommand {
     /// Update given identity
     Update {
         /// Identity to update
+        #[structopt(default_value = "")]
         alias_or_id: NodeOrAlias,
         #[structopt(long)]
         alias: Option<String>,

--- a/core/identity/src/cli/identity.rs
+++ b/core/identity/src/cli/identity.rs
@@ -286,18 +286,12 @@ impl IdentityCommand {
 
                 match file_path {
                     Some(file) => {
-                        if file.parent().map_or(false, |parent| !parent.is_dir()) {
-                            anyhow::bail!(
-                                "Directory '{:?}' does not exists or is write protected",
-                                file.parent()
-                            )
-                        }
                         if file.is_file() {
                             anyhow::bail!("File already exists")
                         }
 
-                        std::fs::write(file, key_file).map_err(|e| anyhow::Error::msg(e))?;
-                        CommandOutput::object(format!("Written to {:?}", file))
+                        std::fs::write(file, key_file)?;
+                        CommandOutput::object(format!("Written to '{}'", file.display()))
                     }
                     None => CommandOutput::object(key_file),
                 }

--- a/core/identity/src/service/identity.rs
+++ b/core/identity/src/service/identity.rs
@@ -334,6 +334,14 @@ impl IdentityService {
         Ok(model::Ack {})
     }
 
+    pub async fn get_key_file(
+        &mut self,
+        key_id: model::GetKeyFile,
+    ) -> Result<String, model::Error> {
+        let key = self.get_key_by_id(&key_id.node_id)?;
+        key.to_key_file().map_err(|e| model::Error::new_err_msg(e))
+    }
+
     pub fn bind_service(me: Arc<Mutex<Self>>) {
         let this = me.clone();
         let _ = bus::bind(model::BUS_ID, move |_list: model::List| {
@@ -432,6 +440,11 @@ impl IdentityService {
         let _ = bus::bind(model::BUS_ID, move |subscribe: model::Subscribe| {
             let this = this.clone();
             async move { this.lock().await.subscribe(subscribe).await }
+        });
+        let this = me.clone();
+        let _ = bus::bind(model::BUS_ID, move |node_id: model::GetKeyFile| {
+            let this = this.clone();
+            async move { this.lock().await.get_key_file(node_id).await }
         });
     }
 }

--- a/core/identity/src/service/identity.rs
+++ b/core/identity/src/service/identity.rs
@@ -338,7 +338,7 @@ impl IdentityService {
         &mut self,
         key_id: model::GetKeyFile,
     ) -> Result<String, model::Error> {
-        let key = self.get_key_by_id(&key_id.node_id)?;
+        let key = self.get_key_by_id(&key_id.0)?;
         key.to_key_file().map_err(|e| model::Error::new_err_msg(e))
     }
 

--- a/core/model/src/identity.rs
+++ b/core/model/src/identity.rs
@@ -213,20 +213,19 @@ impl RpcMessage for Subscribe {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BackupId {
+pub struct GetKeyFile {
     pub node_id: NodeId,
-    pub file_path: Option<String>,
 }
 
-impl BackupId {
-    pub fn new(node_id: NodeId, file_path: Option<String>) -> Self {
-        Self { node_id, file_path }
+impl GetKeyFile {
+    pub fn new(node_id: NodeId) -> Self {
+        Self { node_id }
     }
 }
 
-impl RpcMessage for BackupId {
-    const ID: &'static str = "BackupId";
-    type Item = Option<IdentityInfo>;
+impl RpcMessage for GetKeyFile {
+    const ID: &'static str = "GetKeyFile";
+    type Item = String;
     type Error = Error;
 }
 

--- a/core/model/src/identity.rs
+++ b/core/model/src/identity.rs
@@ -211,6 +211,25 @@ impl RpcMessage for Subscribe {
     type Error = Error;
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackupId {
+    pub node_id: NodeId,
+    pub file_path: Option<String>,
+}
+
+impl BackupId {
+    pub fn new(node_id: NodeId, file_path: Option<String>) -> Self {
+        Self { node_id, file_path }
+    }
+}
+
+impl RpcMessage for BackupId {
+    const ID: &'static str = "BackupId";
+    type Item = Option<IdentityInfo>;
+    type Error = Error;
+}
+
 pub mod event {
     use super::Error;
     use serde::{Deserialize, Serialize};

--- a/core/model/src/identity.rs
+++ b/core/model/src/identity.rs
@@ -213,15 +213,7 @@ impl RpcMessage for Subscribe {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct GetKeyFile {
-    pub node_id: NodeId,
-}
-
-impl GetKeyFile {
-    pub fn new(node_id: NodeId) -> Self {
-        Self { node_id }
-    }
-}
+pub struct GetKeyFile(pub NodeId);
 
 impl RpcMessage for GetKeyFile {
     const ID: &'static str = "GetKeyFile";


### PR DESCRIPTION
```
  pnowosie/pay-146-key-backup-command ?  cargo run id export --help          ✔  9710  14:14:32
yagna-id-export 0.2.0
Exports given identity to a file | stdout

USAGE:
    yagna id export [FLAGS] [OPTIONS] [node-or-alias]

FLAGS:
        --json       Return results in JSON format
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
        --file-path <file-path>    File path where identity will be written. Defaults to `stdout`
    -d, --datadir <data-dir>       Service data dir [env: YAGNA_DATADIR]  [default:
                                   /home/pnowosie/.local/share/yagna]
    -g, --gsb-url <gsb-url>        Service Bus (aka GSB) URL [env: GSB_URL]  [default: tcp://127.0.0.1:7464]

ARGS:
    <node-or-alias>    Identity alias to export

```

### Tests

Here are identities
```
┌───────────┬──────────┬─────────┬──────────────────────────────────────────────┐
│  default  │  locked  │  alias  │  address                                     │
├───────────┼──────────┼─────────┼──────────────────────────────────────────────┤
│  X        │          │         │  0x94e1a08cee33f97374bd5dfff8ad972be70d7d31  │
│           │  X       │  bob    │  0xfdea04bd56a8813a623d31c8d7ec100677879e85  │
│           │  X       │  alice  │  0xe3d15125f931495493894e02411be28cc7c43a92  │
└───────────┴──────────┴─────────┴──────────────────────────────────────────────┘
```


- :x: writing to non-existing directory
- :heavy_check_mark: export default to stdout
- :heavy_check_mark: export default to file
- :heavy_check_mark: export bob to file
- :heavy_check_mark: export default to file
- :heavy_check_mark: export alice to stdout
- :x: export alice to already existing file
- :x: try to export non-existing alias (celine)
- :heavy_check_mark: export / restart service / import / unlock

- Diff-ed stdout and file export
```
 cargo run id export bob | diff test/bob.key -
20c20
< }
\ No newline at end of file
---
> }
```

- Retrived bob's data from `yagna.db/identity` table `key_file_json` field and compared with file. Equal but a new line char at EOF.
 