### PR TITLE
Fix for CLI's "activity status" and flexbuffers

### DIFF
--- a/core/activity/src/provider/service.rs
+++ b/core/activity/src/provider/service.rs
@@ -386,9 +386,10 @@ mod local {
             .await
             .map_err(Error::from)?;
 
+        let map_entry = |(k, v): (State, _)| (format!("{:?}", k), v);
         Ok(StatsResult {
-            total,
-            last_1h,
+            total: total.into_iter().map(map_entry).collect(),
+            last_1h: last_1h.into_iter().map(map_entry).collect(),
             last_activity_ts: None,
         })
     }

--- a/core/model/src/activity.rs
+++ b/core/model/src/activity.rs
@@ -227,7 +227,6 @@ pub mod local {
     use super::*;
     use chrono::{DateTime, Utc};
     use std::collections::BTreeMap;
-    use ya_client_model::activity::State;
 
     /// Local activity bus address.
     pub const BUS_ID: &str = "/local/activity";
@@ -242,8 +241,8 @@ pub mod local {
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct StatsResult {
-        pub total: BTreeMap<State, u64>,
-        pub last_1h: BTreeMap<State, u64>,
+        pub total: BTreeMap<String, u64>,
+        pub last_1h: BTreeMap<String, u64>,
         pub last_activity_ts: Option<DateTime<Utc>>,
     }
 


### PR DESCRIPTION
`flexbuffers` is unable to properly de/serialize maps with `enum`s as keys. This PR changes the key type from `State` to `String` since "activity status" gsb endpoint is used for presentational purposes only.

Note:
- changing the intermediary serialized type (e.g. with `serde_as(as = "Vec<(_, _)>")`) affects output formatting which in turn breaks `golemsp` and produces cluttered console output
- defining a separate display struct for `StatsResult` leads to additional upkeep to keep identical properties in sync between the structs