### PR TITLE
Get faucet url from envvar or resolve srv record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7494,13 +7494,13 @@ dependencies = [
  "structopt",
  "thiserror",
  "tokio 0.2.24",
- "trust-dns-resolver 0.19.6",
  "ya-core-model",
  "ya-sb-proto",
  "ya-sb-router",
  "ya-service-api",
  "ya-service-api-interfaces",
  "ya-service-bus",
+ "ya-utils-networking",
 ]
 
 [[package]]
@@ -7890,6 +7890,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ya-utils-networking"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "trust-dns-resolver 0.19.6",
+]
+
+[[package]]
 name = "ya-utils-path"
 version = "0.1.0"
 dependencies = [
@@ -7976,6 +7984,7 @@ dependencies = [
  "ya-payment-driver",
  "ya-service-api-interfaces",
  "ya-utils-futures",
+ "ya-utils-networking",
  "zksync",
  "zksync_eth_signer",
 ]
@@ -8021,6 +8030,7 @@ dependencies = [
  "ya-service-bus",
  "ya-sgx",
  "ya-utils-futures",
+ "ya-utils-networking",
  "ya-utils-path",
  "ya-utils-process",
  "ya-version",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ ya-sgx = "0.1"
 ya-utils-path = "0.1"
 ya-utils-futures = "0.1"
 ya-utils-process = { version = "0.1", features = ["lock"] }
+ya-utils-networking = "0.1"
 ya-version = "0.1"
 
 gftp = { version = "0.1", optional = true } # just to enable gftp build for cargo-deb
@@ -132,6 +133,7 @@ members = [
     "utils/agreement-utils",
     "utils/compile-time-utils",
     "utils/futures",
+    "utils/networking",
     "utils/path",
     "utils/process",
     "utils/std-utils",
@@ -188,8 +190,9 @@ ya-exe-unit = { path = "exe-unit" }
 ya-file-logging = { path = "utils/file-logging" }
 ya-transfer = { path = "utils/transfer" }
 ya-utils-actix = { path = "utils/actix_utils"}
-ya-utils-futures = { path = "utils/futures"}
-ya-utils-path = { path = "utils/path"}
+ya-utils-futures = { path = "utils/futures" }
+ya-utils-networking = { path = "utils/networking" }
+ya-utils-path = { path = "utils/path" }
 ya-utils-process = { path = "utils/process"}
 ya-diesel-utils = { path = "utils/diesel-utils"}
 ya-metrics = { path = "core/metrics" }

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -13,6 +13,7 @@ ya-core-model = { path = "../model", features=["net", "identity"] }
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.3"
+ya-utils-networking = "0.1"
 
 actix-rt = "1.0"
 anyhow = "1.0"
@@ -22,7 +23,6 @@ log = "0.4"
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["time"] }
-trust-dns-resolver = { version = "0.19", features = ["mdns"] }
 
 [dev-dependencies]
 ya-sb-proto = "0.1"

--- a/core/net/src/service.rs
+++ b/core/net/src/service.rs
@@ -2,11 +2,8 @@ use actix_rt::Arbiter;
 use anyhow::anyhow;
 use futures::channel::oneshot;
 use futures::prelude::*;
-use std::io::{Error as IoError, ErrorKind as IoErrorKind};
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::rc::Rc;
-use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-use trust_dns_resolver::TokioAsyncResolver;
 
 use ya_core_model::identity::{self, IdentityInfo};
 use ya_core_model::net;
@@ -16,41 +13,21 @@ use ya_service_bus::connection::ClientInfo;
 use ya_service_bus::{
     connection, serialization, typed as bus, untyped as local_bus, Error, RpcEndpoint, RpcMessage,
 };
+use ya_utils_networking::srv_resolver;
 
 use crate::api::{net_service, parse_from_addr};
 use crate::handler::{auto_rebind, CentralBusHandler};
 
 pub const CENTRAL_ADDR_ENV_VAR: &str = "CENTRAL_NET_HOST";
-const DEFAULT_LOOKUP_DOMAIN: &'static str = "dev.golem.network";
 
 async fn central_net_addr() -> std::io::Result<SocketAddr> {
     Ok(match std::env::var(CENTRAL_ADDR_ENV_VAR) {
         Ok(v) => v,
-        Err(_) => resolve_net_addr().await?,
+        Err(_) => srv_resolver::resolve_record("_net._tcp.").await?,
     }
     .to_socket_addrs()?
     .next()
     .expect("central net hub addr needed"))
-}
-
-async fn resolve_net_addr() -> std::io::Result<String> {
-    let resolver: TokioAsyncResolver =
-        TokioAsyncResolver::tokio(ResolverConfig::google(), ResolverOpts::default()).await?;
-    let lookup = resolver
-        .srv_lookup(format!("_net._tcp.{}", DEFAULT_LOOKUP_DOMAIN))
-        .await?;
-    let srv = lookup
-        .iter()
-        .next()
-        .ok_or_else(|| IoError::from(IoErrorKind::NotFound))?;
-    let addr = format!(
-        "{}:{}",
-        srv.target().to_string().trim_end_matches('.'),
-        srv.port()
-    );
-
-    log::debug!("Central net address: {}", addr);
-    Ok(addr)
 }
 
 /// Initialize net module on a hub.

--- a/core/net/src/service.rs
+++ b/core/net/src/service.rs
@@ -23,7 +23,7 @@ pub const CENTRAL_ADDR_ENV_VAR: &str = "CENTRAL_NET_HOST";
 async fn central_net_addr() -> std::io::Result<SocketAddr> {
     Ok(match std::env::var(CENTRAL_ADDR_ENV_VAR) {
         Ok(v) => v,
-        Err(_) => srv_resolver::resolve_record("_net._tcp.").await?,
+        Err(_) => srv_resolver::resolve_yagna_record("_net._tcp.").await?,
     }
     .to_socket_addrs()?
     .next()

--- a/core/net/src/service.rs
+++ b/core/net/src/service.rs
@@ -23,7 +23,7 @@ pub const CENTRAL_ADDR_ENV_VAR: &str = "CENTRAL_NET_HOST";
 async fn central_net_addr() -> std::io::Result<SocketAddr> {
     Ok(match std::env::var(CENTRAL_ADDR_ENV_VAR) {
         Ok(v) => v,
-        Err(_) => srv_resolver::resolve_yagna_record("_net._tcp.").await?,
+        Err(_) => srv_resolver::resolve_yagna_record("_net._tcp").await?,
     }
     .to_socket_addrs()?
     .next()

--- a/core/payment-driver/zksync/Cargo.toml
+++ b/core/payment-driver/zksync/Cargo.toml
@@ -32,6 +32,7 @@ ya-payment-driver = "0.1.0"
 ya-client-model = "0.2.0"
 ya-service-api-interfaces = "0.1"
 ya-utils-futures = "0.1"
+ya-utils-networking = "0.1"
 
 [dev-dependencies]
 actix-rt = "1.0"

--- a/core/payment-driver/zksync/src/zksync/faucet.rs
+++ b/core/payment-driver/zksync/src/zksync/faucet.rs
@@ -11,16 +11,16 @@ use tokio::time::delay_for;
 
 // Workspace uses
 use ya_payment_driver::{db::models::Network, model::GenericError};
+use ya_utils_networking::srv_resolver;
 
 // Local uses
 use crate::zksync::wallet::account_balance;
 
-const DEFAULT_FAUCET_ADDR: &str = "http://3.249.139.167:5778/zk/donatex";
+const DEFAULT_FAUCET_SRV_PREFIX: &str = "_zk-faucet._tcp.";
+const FAUCET_ADDR_ENVAR: &str = "ZKSYNC_FAUCET_ADDR";
 const MAX_FAUCET_REQUESTS: u32 = 6;
 
 lazy_static! {
-    static ref FAUCET_ADDR: String =
-        env::var("ZKSYNC_FAUCET_ADDR").unwrap_or(DEFAULT_FAUCET_ADDR.to_string());
     static ref MIN_BALANCE: BigDecimal = BigDecimal::from(50);
     static ref MAX_WAIT: Duration = Duration::minutes(1);
 }
@@ -81,8 +81,9 @@ async fn wait_for_ngnt(address: &str, network: Network) -> Result<(), GenericErr
 
 async fn faucet_donate(address: &str, _network: Network) -> Result<(), GenericError> {
     let client = awc::Client::new();
+    let faucet_url = resolve_faucet_url().await?;
     let response = client
-        .get(format!("{}/{}", *FAUCET_ADDR, address))
+        .get(format!("{}/{}", faucet_url, address))
         .send()
         .await
         .map_err(GenericError::new)?
@@ -93,4 +94,13 @@ async fn faucet_donate(address: &str, _network: Network) -> Result<(), GenericEr
     log::debug!("Funds requested. Response = {}", response);
     // TODO: Verify tx hash
     Ok(())
+}
+
+async fn resolve_faucet_url() -> Result<String, GenericError> {
+    match env::var(FAUCET_ADDR_ENVAR) {
+        Ok(addr) => Ok(addr),
+        _ => srv_resolver::resolve_record(DEFAULT_FAUCET_SRV_PREFIX)
+            .await
+            .map_err(|_| GenericError::new("Faucet SRV record cannot be resolved")),
+    }
 }

--- a/core/payment-driver/zksync/src/zksync/faucet.rs
+++ b/core/payment-driver/zksync/src/zksync/faucet.rs
@@ -16,7 +16,7 @@ use ya_utils_networking::srv_resolver;
 // Local uses
 use crate::zksync::wallet::account_balance;
 
-const DEFAULT_FAUCET_SRV_PREFIX: &str = "_zk-faucet._tcp.";
+const DEFAULT_FAUCET_SRV_PREFIX: &str = "_zk-faucet._tcp";
 const FAUCET_ADDR_ENVAR: &str = "ZKSYNC_FAUCET_ADDR";
 const MAX_FAUCET_REQUESTS: u32 = 6;
 

--- a/utils/networking/Cargo.toml
+++ b/utils/networking/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ya-utils-networking"
+version = "0.1.0"
+authors = ["Golem Factory <contact@golem.network>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+log = "0.4"
+trust-dns-resolver = { version = "0.19", features = ["mdns"] }
+

--- a/utils/networking/src/lib.rs
+++ b/utils/networking/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod srv_resolver;

--- a/utils/networking/src/srv_resolver.rs
+++ b/utils/networking/src/srv_resolver.rs
@@ -1,0 +1,29 @@
+use std::io::{Error as IoError, ErrorKind as IoErrorKind};
+use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
+use trust_dns_resolver::TokioAsyncResolver;
+
+const DEFAULT_LOOKUP_DOMAIN: &'static str = "dev.golem.network";
+
+pub async fn resolve_record(record: &str) -> std::io::Result<String> {
+    let resolver: TokioAsyncResolver =
+        TokioAsyncResolver::tokio(ResolverConfig::google(), ResolverOpts::default()).await?;
+    let lookup = resolver
+        .srv_lookup(format!(
+            "{}.{}",
+            record.trim_end_matches('.'),
+            DEFAULT_LOOKUP_DOMAIN
+        ))
+        .await?;
+    let srv = lookup
+        .iter()
+        .next()
+        .ok_or_else(|| IoError::from(IoErrorKind::NotFound))?;
+    let addr = format!(
+        "{}:{}",
+        srv.target().to_string().trim_end_matches('.'),
+        srv.port()
+    );
+
+    log::debug!("Central net address: {}", addr);
+    Ok(addr)
+}


### PR DESCRIPTION
SRV record is set (thanks to @Wiezzel who figured it out).
```
 nslookup -type=SRV _zk-faucet._tcp.dev.golem.network
Server:		127.0.0.53
Address:	127.0.0.53#53

Non-authoritative answer:
_zk-faucet._tcp.dev.golem.network	service = 10 10 5778 yacn.dev.golem.network.

Authoritative answers can be found from:

```

Testing shows that SRV record is resolved only to hostname & port
`2021-02-03T07:29:38Z INFO  faucet_srv] Resolved faucet host: "yacn.dev.golem.network:5778"`

### Assumptions

For now I'm taking the following assumptions (tech debt)
* all other zk-sync faucets we provide via SRV would end with `zk/donatex`
* environment variable `ZKSYNC_FAUCET_ADDR` value is taken as is without any changes

### Tests
Run withdrawal example with log level `debug`. Example of [[successful withdrawal](https://rinkeby.zkscan.io/explorer/transactions/42e17ba7092e914c65b725e69bd01208b589fdcadb920ecd0f4d20ce8b07f81d)].

```
[2021-02-03T08:11:17Z DEBUG ya_utils_networking::srv_resolver] Resolved address: yacn.dev.golem.network:5778
[2021-02-03T08:11:17Z DEBUG ya_zksync_driver::zksync::faucet] Faucet url: http://yacn.dev.golem.network:5778/zk/donatex/0x19a2...6df3
```