### PR TITLE
Safely decode received payment details

### DIFF
--- a/core/payment/src/dao/payment.rs
+++ b/core/payment/src/dao/payment.rs
@@ -142,7 +142,7 @@ impl<'c> PaymentDao<'c> {
     pub async fn insert_received(&self, payment: Payment, payee_id: NodeId) -> DbResult<()> {
         let activity_payments = payment.activity_payments.clone();
         let agreement_payments = payment.agreement_payments.clone();
-        let payment = WriteObj::new_received(payment);
+        let payment = WriteObj::new_received(payment)?;
         self.insert(payment, activity_payments, agreement_payments)
             .await
     }


### PR DESCRIPTION
Proper error handling instead of `unwrap()`.