### PR TITLE
fix exposing version as a metric

### DIFF
--- a/utils/compile-time-utils/src/lib.rs
+++ b/utils/compile-time-utils/src/lib.rs
@@ -1,5 +1,5 @@
 use git_version::git_version;
-use metrics::value;
+use metrics::gauge;
 use semver::Version;
 
 /// Returns latest tag (via `git describe --tag --abbrev=0`) or version from Cargo.toml`.
@@ -25,7 +25,7 @@ pub fn build_number_str() -> Option<&'static str> {
     option_env!("GITHUB_RUN_NUMBER")
 }
 
-pub fn build_number() -> Option<u64> {
+pub fn build_number() -> Option<i64> {
     build_number_str().map(|s| s.parse().ok()).flatten()
 }
 
@@ -50,15 +50,15 @@ pub fn semver() -> std::result::Result<Version, semver::SemVerError> {
 
 pub fn report_version_to_metrics() {
     if let Ok(version) = semver() {
-        value!("yagna.version.major", version.major);
-        value!("yagna.version.minor", version.minor);
-        value!("yagna.version.patch", version.patch);
-        value!(
+        gauge!("yagna.version.major", version.major as i64);
+        gauge!("yagna.version.minor", version.minor as i64);
+        gauge!("yagna.version.patch", version.patch as i64);
+        gauge!(
             "yagna.version.is_prerelease",
-            (!version.pre.is_empty()) as u64
+            (!version.pre.is_empty()) as i64
         );
         if let Some(build_number) = build_number() {
-            value!("yagna.version.build_number", build_number);
+            gauge!("yagna.version.build_number", build_number);
         }
     }
 }


### PR DESCRIPTION
`value!` is treated as a histogram and kept only for 10 seconds.