### PR TITLE
Changed default GSB endpoint to UNIX socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7786,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "ya-sb-proto"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=6b494e17d7a662e0b710af8c5a2e99ab4007fdb9#6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"
+source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=707e4f9a64c8ede5b371d10dd8d564dba64bfa4c#707e4f9a64c8ede5b371d10dd8d564dba64bfa4c"
 dependencies = [
  "bytes 0.5.6",
  "prost",
@@ -7800,7 +7800,7 @@ dependencies = [
 [[package]]
 name = "ya-sb-router"
 version = "0.3.1"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=6b494e17d7a662e0b710af8c5a2e99ab4007fdb9#6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"
+source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=707e4f9a64c8ede5b371d10dd8d564dba64bfa4c#707e4f9a64c8ede5b371d10dd8d564dba64bfa4c"
 dependencies = [
  "anyhow",
  "bytes 0.4.12",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "ya-sb-util"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=6b494e17d7a662e0b710af8c5a2e99ab4007fdb9#6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"
+source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=707e4f9a64c8ede5b371d10dd8d564dba64bfa4c#707e4f9a64c8ede5b371d10dd8d564dba64bfa4c"
 dependencies = [
  "futures 0.3.12",
  "pin-project 0.4.27",
@@ -7909,7 +7909,7 @@ dependencies = [
 [[package]]
 name = "ya-service-bus"
 version = "0.3.1"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=6b494e17d7a662e0b710af8c5a2e99ab4007fdb9#6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"
+source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=707e4f9a64c8ede5b371d10dd8d564dba64bfa4c#707e4f9a64c8ede5b371d10dd8d564dba64bfa4c"
 dependencies = [
  "actix 0.9.0",
  "flexbuffers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,10 +168,10 @@ ya-service-api-interfaces = { path = "core/serv-api/interfaces" }
 ya-service-api-web = { path = "core/serv-api/web" }
 
 ## SERVICE BUS
-ya-service-bus = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
-ya-sb-proto = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
-ya-sb-router = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
-ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
+ya-service-bus = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "707e4f9a64c8ede5b371d10dd8d564dba64bfa4c" }
+ya-sb-proto = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "707e4f9a64c8ede5b371d10dd8d564dba64bfa4c" }
+ya-sb-router = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "707e4f9a64c8ede5b371d10dd8d564dba64bfa4c" }
+ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "707e4f9a64c8ede5b371d10dd8d564dba64bfa4c" }
 
 ## CLIENT
 ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "c3f3419e48eade7f4d491c71948a1a50446d87d5"}

--- a/core/payment/examples/payment_api.rs
+++ b/core/payment/examples/payment_api.rs
@@ -11,7 +11,7 @@ use structopt::StructOpt;
 use ya_client_model::market;
 use ya_client_model::payment::PAYMENT_API_PATH;
 use ya_client_model::NodeId;
-use ya_core_model::driver::{driver_bus_id, AccountMode, Init, Fund};
+use ya_core_model::driver::{driver_bus_id, AccountMode, Fund, Init};
 use ya_core_model::identity;
 use ya_dummy_driver as dummy;
 use ya_gnt_driver as gnt;
@@ -240,7 +240,7 @@ async fn main() -> anyhow::Result<()> {
         .call(Fund::new(
             requestor_addr.clone(),
             args.network.clone(),
-            None
+            None,
         ))
         .await??;
     bus::service(driver_bus_id(driver_name))

--- a/core/payment/src/service.rs
+++ b/core/payment/src/service.rs
@@ -55,13 +55,13 @@ mod local {
 
         counter!("payment.amount.received", 0, "platform" => "erc20-rinkeby-tglm");
         counter!("payment.amount.received", 0, "platform" => "erc20-mainnet-glm");
-        counter!("payment.amount.received", 0, "platform" => "zksync-rinkeby-tglm"); 
-        counter!("payment.amount.received", 0, "platform" => "zksync-mainnet-glm"); 
+        counter!("payment.amount.received", 0, "platform" => "zksync-rinkeby-tglm");
+        counter!("payment.amount.received", 0, "platform" => "zksync-mainnet-glm");
 
         counter!("payment.amount.sent", 0, "platform" => "erc20-rinkeby-tglm");
         counter!("payment.amount.sent", 0, "platform" => "erc20-mainnet-glm");
-        counter!("payment.amount.sent", 0, "platform" => "zksync-rinkeby-tglm"); 
-        counter!("payment.amount.sent", 0, "platform" => "zksync-mainnet-glm"); 
+        counter!("payment.amount.sent", 0, "platform" => "zksync-rinkeby-tglm");
+        counter!("payment.amount.sent", 0, "platform" => "zksync-mainnet-glm");
 
         log::debug!("Successfully bound payment local service to service bus");
     }


### PR DESCRIPTION
Testing instructions:
1. Run yagna and look for message about GSB listening on UNIX socket.
```
$ cargo run service run
[2021-02-09T16:08:51Z INFO  yagna] Starting yagna service! Version: 0.6.0-rc6 (4e6629dc 2021-02-08).
Log is written to /home/adam/yagna/test/yagna_rCURRENT.log
[2021-02-09T16:08:51Z INFO  yagna] Data directory: /home/adam/yagna/test
[2021-02-09T16:08:51Z INFO  ya_sb_router] Router listening on: "/tmp/yagna.sock"
```
2. Check file permissions (should be 700 – only owner allowed to connect).
```
$ stat /tmp/yagna.sock
  File: yagna.sock
  Size: 0               Blocks: 0          IO Block: 4096   socket
Device: 804h/2052d      Inode: 4332642     Links: 1
Access: (0700/srwx------)  Uid: ( 1001/    adam)   Gid: ( 1001/    adam)
Access: 2021-02-09 17:58:24.924073454 +0100
Modify: 2021-02-09 17:58:24.556082429 +0100
Change: 2021-02-09 17:58:24.556082429 +0100
 Birth: -
```
3. Run some CLI commands and check if they work.
