### PR TITLE
[tomls] bump subcrates minor version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7203,7 +7203,7 @@ dependencies = [
 
 [[package]]
 name = "ya-compile-time-utils"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "git-version",
  "metrics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7531,7 +7531,7 @@ dependencies = [
 
 [[package]]
 name = "ya-payment"
-version = "0.3.0"
+version = "0.2.0"
 dependencies = [
  "actix-rt",
  "actix-web 3.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "gftp"
-version = "0.2.0"
+version = "0.1.2"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7105,7 +7105,7 @@ dependencies = [
 
 [[package]]
 name = "ya-activity"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "actix-rt",
  "actix-web 3.3.2",
@@ -7415,7 +7415,7 @@ dependencies = [
 
 [[package]]
 name = "ya-market"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "actix-http 2.2.0",
  "actix-rt",
@@ -7531,7 +7531,7 @@ dependencies = [
 
 [[package]]
 name = "ya-payment"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix-rt",
  "actix-web 3.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7213,7 +7213,7 @@ dependencies = [
 
 [[package]]
 name = "ya-core-model"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bigdecimal 0.1.2",
  "bitflags 1.2.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7156,8 +7156,8 @@ dependencies = [
 
 [[package]]
 name = "ya-client"
-version = "0.4.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=4099adb99dadbc8929caba33538806f5e10d5920#4099adb99dadbc8929caba33538806f5e10d5920"
+version = "0.5.0"
+source = "git+https://github.com/golemfactory/ya-client.git?branch=release/v0.5#62e4757d5e1748e6606c3d7992a1a7956e52d8b8"
 dependencies = [
  "awc 1.0.1",
  "bytes 0.5.6",
@@ -7181,8 +7181,8 @@ dependencies = [
 
 [[package]]
 name = "ya-client-model"
-version = "0.2.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=4099adb99dadbc8929caba33538806f5e10d5920#4099adb99dadbc8929caba33538806f5e10d5920"
+version = "0.3.0"
+source = "git+https://github.com/golemfactory/ya-client.git?branch=release/v0.5#62e4757d5e1748e6606c3d7992a1a7956e52d8b8"
 dependencies = [
  "bigdecimal 0.1.2",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "ya-agreement-utils"
-version = "0.2.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7213,7 +7213,7 @@ dependencies = [
 
 [[package]]
 name = "ya-core-model"
-version = "0.3.0"
+version = "0.2.0"
 dependencies = [
  "bigdecimal 0.1.2",
  "bitflags 1.2.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,7 +2778,7 @@ dependencies = [
 
 [[package]]
 name = "golemsp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix-rt",
  "ansi_term 0.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7211,7 +7211,7 @@ dependencies = [
 
 [[package]]
 name = "ya-core-model"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "bigdecimal 0.1.2",
  "bitflags 1.2.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7696,8 +7696,9 @@ dependencies = [
 
 [[package]]
 name = "ya-sb-proto"
-version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=6b494e17d7a662e0b710af8c5a2e99ab4007fdb9#6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba491b25b0ca2d03f697c7a734f79f7bb9550e570132bd95af53f62d52668424"
 dependencies = [
  "bytes 0.5.6",
  "prost",
@@ -7710,8 +7711,9 @@ dependencies = [
 
 [[package]]
 name = "ya-sb-router"
-version = "0.3.1"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=6b494e17d7a662e0b710af8c5a2e99ab4007fdb9#6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d10e05cad4f3d9eb46c48e5ae6a6ecfe49c1373707b886a167e2dac130b86075"
 dependencies = [
  "anyhow",
  "bytes 0.4.12",
@@ -7732,7 +7734,8 @@ dependencies = [
 [[package]]
 name = "ya-sb-util"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=6b494e17d7a662e0b710af8c5a2e99ab4007fdb9#6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20b2e7cfeacabb607fe1fd1dc8e653c3ee853f2e127cb1ed72955ea4cb84f951"
 dependencies = [
  "futures 0.3.12",
  "pin-project 0.4.27",
@@ -7819,8 +7822,9 @@ dependencies = [
 
 [[package]]
 name = "ya-service-bus"
-version = "0.3.1"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=6b494e17d7a662e0b710af8c5a2e99ab4007fdb9#6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7650b19a2f73f5d6cded3045756fc35048abc094781154d3145ca21dd68ce8c6"
 dependencies = [
  "actix 0.9.0",
  "flexbuffers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7157,7 +7157,8 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.5.0"
-source = "git+https://github.com/golemfactory/ya-client.git?branch=release/v0.5#62e4757d5e1748e6606c3d7992a1a7956e52d8b8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cf68fa232c9de768f3a8041d7725b6817e7561fdab22d462d485da37c65f4a"
 dependencies = [
  "awc 1.0.1",
  "bytes 0.5.6",
@@ -7182,7 +7183,8 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-client.git?branch=release/v0.5#62e4757d5e1748e6606c3d7992a1a7956e52d8b8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d166700c6215a0a80f6e75bd33d74a5a4adb3715114bb3d47e4f9a33bb2a2fa2"
 dependencies = [
  "bigdecimal 0.1.2",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2693,7 +2693,7 @@ dependencies = [
 
 [[package]]
 name = "gftp"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7143,7 +7143,7 @@ dependencies = [
 
 [[package]]
 name = "ya-agreement-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7242,7 +7242,7 @@ dependencies = [
 
 [[package]]
 name = "ya-dummy-driver"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix 0.9.0",
  "anyhow",
@@ -7325,7 +7325,7 @@ dependencies = [
 
 [[package]]
 name = "ya-gnt-driver"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix 0.9.0",
  "actix-connect 1.0.2",
@@ -7531,7 +7531,7 @@ dependencies = [
 
 [[package]]
 name = "ya-payment"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "actix-rt",
  "actix-web 3.3.2",
@@ -7580,7 +7580,7 @@ dependencies = [
 
 [[package]]
 name = "ya-payment-driver"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix 0.9.0",
  "anyhow",
@@ -7977,7 +7977,7 @@ dependencies = [
 
 [[package]]
 name = "ya-zksync-driver"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7507,7 +7507,7 @@ dependencies = [
 
 [[package]]
 name = "ya-net"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "actix-rt",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,8 +172,8 @@ ya-service-api-web = { path = "core/serv-api/web" }
 #ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", branch = "release/v0.5"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", branch = "release/v0.5"}
+#ya-client = { git = "https://github.com/golemfactory/ya-client.git", branch = "release/v0.5"}
+#ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", branch = "release/v0.5"}
 
 #ya-client = { path = "../ya-client" }
 #ya-client-model = { path = "../ya-client/model" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ ya-utils-futures = "0.1"
 ya-utils-process = { version = "0.1", features = ["lock"] }
 ya-version = "0.1"
 
-gftp = { version = "^0.2", optional = true } # just to enable gftp build for cargo-deb
+gftp = { version = "0.1", optional = true } # just to enable gftp build for cargo-deb
 ya-provider = { version = "0.2", optional = true } # just to enable conditionally running some tests
 
 actix-rt = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ ya-zksync-driver = { version = "0.1", optional = true }
 ya-identity = "0.2"
 ya-market = "0.2"
 ya-metrics = "0.1"
-ya-net = { version = "0.1", features = ["service"] }
+ya-net = { version = "0.2", features = ["service"] }
 ya-payment = "0.1"
 ya-persistence = "0.2"
 ya-sb-proto = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,15 +24,15 @@ path = "core/serv/src/main.rs"
 [dependencies]
 ya-activity = "0.3"
 ya-compile-time-utils = "0.1"
-ya-dummy-driver = { version = "0.1", optional = true }
+ya-dummy-driver = { version = "0.2", optional = true }
 ya-file-logging = "0.1"
-ya-gnt-driver = { version = "0.1", optional = true }
-ya-zksync-driver = { version = "0.1", optional = true }
+ya-gnt-driver = { version = "0.2", optional = true }
+ya-zksync-driver = { version = "0.2", optional = true }
 ya-identity = "0.2"
 ya-market = "0.3"
 ya-metrics = "0.1"
 ya-net = { version = "0.2", features = ["service"] }
-ya-payment = "0.2"
+ya-payment = "0.3"
 ya-persistence = "0.2"
 ya-sb-proto = "0.1"
 ya-sb-router = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,8 +172,8 @@ ya-sb-router = { git = "https://github.com/golemfactory/ya-service-bus.git", rev
 ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "4099adb99dadbc8929caba33538806f5e10d5920"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "4099adb99dadbc8929caba33538806f5e10d5920"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", branch = "release/v0.5"}
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", branch = "release/v0.5"}
 
 #ya-client = { path = "../ya-client" }
 #ya-client-model = { path = "../ya-client/model" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ ya-utils-futures = "0.1"
 ya-utils-process = { version = "0.1", features = ["lock"] }
 ya-version = "0.1"
 
-gftp = { version = "0.2", optional = true } # just to enable gftp build for cargo-deb
+gftp = { version = "0.1", optional = true } # just to enable gftp build for cargo-deb
 ya-provider = { version = "0.2", optional = true } # just to enable conditionally running some tests
 
 actix-rt = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,17 +22,17 @@ name = "yagna"
 path = "core/serv/src/main.rs"
 
 [dependencies]
-ya-activity = "0.2"
+ya-activity = "0.3"
 ya-compile-time-utils = "0.1"
 ya-dummy-driver = { version = "0.1", optional = true }
 ya-file-logging = "0.1"
 ya-gnt-driver = { version = "0.1", optional = true }
 ya-zksync-driver = { version = "0.1", optional = true }
 ya-identity = "0.2"
-ya-market = "0.2"
+ya-market = "0.3"
 ya-metrics = "0.1"
 ya-net = { version = "0.2", features = ["service"] }
-ya-payment = "0.1"
+ya-payment = "0.2"
 ya-persistence = "0.2"
 ya-sb-proto = "0.1"
 ya-sb-router = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,13 +34,13 @@ ya-metrics = "0.1"
 ya-net = { version = "0.2", features = ["service"] }
 ya-payment = "0.2"
 ya-persistence = "0.2"
-ya-sb-proto = "0.1"
-ya-sb-router = "0.3"
+ya-sb-proto = "0.2"
+ya-sb-router = "0.4"
 ya-service-api = "0.1"
 ya-service-api-derive = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-api-web = "0.1"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 ya-sgx = "0.1"
 ya-utils-path = "0.1"
 ya-utils-futures = "0.1"
@@ -166,10 +166,10 @@ ya-service-api-interfaces = { path = "core/serv-api/interfaces" }
 ya-service-api-web = { path = "core/serv-api/web" }
 
 ## SERVICE BUS
-ya-service-bus = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
-ya-sb-proto = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
-ya-sb-router = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
-ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
+#ya-service-bus = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
+#ya-sb-proto = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
+#ya-sb-router = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
+#ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
 
 ## CLIENT
 ya-client = { git = "https://github.com/golemfactory/ya-client.git", branch = "release/v0.5"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ ya-identity = "0.2"
 ya-market = "0.3"
 ya-metrics = "0.1"
 ya-net = { version = "0.2", features = ["service"] }
-ya-payment = "0.3"
+ya-payment = "0.2"
 ya-persistence = "0.2"
 ya-sb-proto = "0.1"
 ya-sb-router = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ ya-utils-futures = "0.1"
 ya-utils-process = { version = "0.1", features = ["lock"] }
 ya-version = "0.1"
 
-gftp = { version = "0.1", optional = true } # just to enable gftp build for cargo-deb
+gftp = { version = "0.2", optional = true } # just to enable gftp build for cargo-deb
 ya-provider = { version = "0.2", optional = true } # just to enable conditionally running some tests
 
 actix-rt = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ ya-utils-futures = "0.1"
 ya-utils-process = { version = "0.1", features = ["lock"] }
 ya-version = "0.1"
 
-gftp = { version = "0.1", optional = true } # just to enable gftp build for cargo-deb
+gftp = { version = "^0.2", optional = true } # just to enable gftp build for cargo-deb
 ya-provider = { version = "0.2", optional = true } # just to enable conditionally running some tests
 
 actix-rt = "1.0"

--- a/agent/provider/Cargo.toml
+++ b/agent/provider/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 time-dependent-tests = []
 
 [dependencies]
-ya-agreement-utils = { version = "0.1" }
+ya-agreement-utils = { version = "^0.2"}
 ya-client = { version = "0.5", features = ['cli'] }
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"

--- a/agent/provider/Cargo.toml
+++ b/agent/provider/Cargo.toml
@@ -17,8 +17,8 @@ time-dependent-tests = []
 
 [dependencies]
 ya-agreement-utils = "0.2"
-ya-client = { version = "0.4", features = ['cli'] }
-ya-client-model = "0.2"
+ya-client = { version = "0.5", features = ['cli'] }
+ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.2", features = ['activity', 'payment'] }
 ya-file-logging = "0.1"

--- a/agent/provider/Cargo.toml
+++ b/agent/provider/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 time-dependent-tests = []
 
 [dependencies]
-ya-agreement-utils = "0.2"
+ya-agreement-utils = "0.1"
 ya-client = { version = "0.5", features = ['cli'] }
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"

--- a/agent/provider/Cargo.toml
+++ b/agent/provider/Cargo.toml
@@ -20,7 +20,7 @@ ya-agreement-utils = { version = "^0.2"}
 ya-client = { version = "0.5", features = ['cli'] }
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.2", features = ['activity', 'payment'] }
+ya-core-model = { version = "^0.3", features = ['activity', 'payment'] }
 ya-file-logging = "0.1"
 ya-utils-actix = "0.1"
 ya-utils-path = "0.1"

--- a/agent/provider/Cargo.toml
+++ b/agent/provider/Cargo.toml
@@ -20,7 +20,7 @@ ya-agreement-utils = "0.2"
 ya-client = { version = "0.5", features = ['cli'] }
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.2", features = ['activity', 'payment'] }
+ya-core-model = { version = "0.3", features = ['activity', 'payment'] }
 ya-file-logging = "0.1"
 ya-utils-actix = "0.1"
 ya-utils-path = "0.1"

--- a/agent/provider/Cargo.toml
+++ b/agent/provider/Cargo.toml
@@ -20,7 +20,7 @@ ya-agreement-utils = { version = "^0.2"}
 ya-client = { version = "0.5", features = ['cli'] }
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.3", features = ['activity', 'payment'] }
+ya-core-model = { version = "0.2", features = ['activity', 'payment'] }
 ya-file-logging = "0.1"
 ya-utils-actix = "0.1"
 ya-utils-path = "0.1"

--- a/agent/provider/Cargo.toml
+++ b/agent/provider/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 time-dependent-tests = []
 
 [dependencies]
-ya-agreement-utils = "0.1"
+ya-agreement-utils = { version = "0.1" }
 ya-client = { version = "0.5", features = ['cli'] }
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"

--- a/agent/provider/src/provider_agent.rs
+++ b/agent/provider/src/provider_agent.rs
@@ -2,7 +2,7 @@ use actix::prelude::*;
 use actix::utils::IntervalFunc;
 use anyhow::{anyhow, Error};
 use futures::{future, FutureExt, StreamExt, TryFutureExt};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::convert::TryFrom;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -75,7 +75,7 @@ impl GlobalsManager {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, derive_more::Display)]
+#[derive(Clone, Debug, Default, Serialize, derive_more::Display)]
 #[display(
     fmt = "{}{}{}",
     "node_name.as_ref().map(|nn| format!(\"Node name: {}\", nn)).unwrap_or(\"\".into())",
@@ -86,6 +86,45 @@ pub struct GlobalsState {
     pub node_name: Option<String>,
     pub subnet: Option<String>,
     pub account: Option<NodeId>,
+}
+
+impl<'de> Deserialize<'de> for GlobalsState {
+    fn deserialize<D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, <D as Deserializer<'de>>::Error> {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        pub enum Account {
+            NodeId(NodeId),
+            Deprecated {
+                platform: Option<String>,
+                address: NodeId,
+            },
+        }
+
+        impl Account {
+            pub fn address(self) -> NodeId {
+                match self {
+                    Account::NodeId(address) => address,
+                    Account::Deprecated { address, .. } => address,
+                }
+            }
+        }
+
+        #[derive(Deserialize)]
+        pub struct GenericGlobalsState {
+            pub node_name: Option<String>,
+            pub subnet: Option<String>,
+            pub account: Option<Account>,
+        }
+
+        let s = GenericGlobalsState::deserialize(deserializer)?;
+        Ok(GlobalsState {
+            node_name: s.node_name,
+            subnet: s.subnet,
+            account: s.account.map(|a| a.address()),
+        })
+    }
 }
 
 impl GlobalsState {
@@ -535,3 +574,81 @@ pub struct Shutdown;
 #[derive(Message)]
 #[rtype(result = "Result<(), Error>")]
 struct CreateOffers(pub OfferKind);
+
+#[cfg(test)]
+mod test {
+    use crate::GlobalsState;
+
+    const GLOBALS_JSON_ALPHA_3: &str = r#"
+{
+  "node_name": "amusing-crate",
+  "subnet": "community.3",
+  "account": {
+    "platform": null,
+    "address": "0x979db95461652299c34e15df09441b8dfc4edf7a"
+  }
+}
+"#;
+
+    const GLOBALS_JSON_ALPHA_4: &str = r#"
+{
+  "node_name": "amusing-crate",
+  "subnet": "community.4",
+  "account": "0x979db95461652299c34e15df09441b8dfc4edf7a"
+}
+"#;
+
+    #[test]
+    fn deserialize_globals() {
+        let mut g3: GlobalsState = serde_json::from_str(GLOBALS_JSON_ALPHA_3).unwrap();
+        let g4: GlobalsState = serde_json::from_str(GLOBALS_JSON_ALPHA_4).unwrap();
+        assert_eq!(g3.node_name, Some("amusing-crate".into()));
+        assert_eq!(g3.node_name, g4.node_name);
+        assert_eq!(g3.subnet, Some("community.3".into()));
+        assert_eq!(g4.subnet, Some("community.4".into()));
+        g3.subnet = Some("community.4".into());
+        assert_eq!(
+            serde_json::to_string(&g3).unwrap(),
+            serde_json::to_string(&g4).unwrap()
+        );
+        assert_eq!(
+            g3.account.unwrap().to_string(),
+            g4.account.unwrap().to_string()
+        );
+    }
+
+    #[test]
+    fn deserialize_no_account() {
+        let g: GlobalsState = serde_json::from_str(
+            r#"
+    {
+      "node_name": "amusing-crate",
+      "subnet": "community.3"
+    }
+    "#,
+        )
+        .unwrap();
+
+        assert_eq!(g.node_name, Some("amusing-crate".into()));
+        assert_eq!(g.subnet, Some("community.3".into()));
+        assert!(g.account.is_none())
+    }
+
+    #[test]
+    fn deserialize_null_account() {
+        let g: GlobalsState = serde_json::from_str(
+            r#"
+    {
+      "node_name": "amusing-crate",
+      "subnet": "community.4",
+      "account": null
+    }
+    "#,
+        )
+        .unwrap();
+
+        assert_eq!(g.node_name, Some("amusing-crate".into()));
+        assert_eq!(g.subnet, Some("community.4".into()));
+        assert!(g.account.is_none())
+    }
+}

--- a/core/activity/Cargo.toml
+++ b/core/activity/Cargo.toml
@@ -12,7 +12,7 @@ ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-api-web = "0.1"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 actix-rt = "1.0"
 actix-web = "3.2"
@@ -39,6 +39,6 @@ uuid = { version = "0.8", features = ["serde", "v4"] }
 structopt = "0.3.7"
 
 [dev-dependencies]
-ya-sb-router = "0.3"
+ya-sb-router = "0.4"
 
 

--- a/core/activity/Cargo.toml
+++ b/core/activity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-activity"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/core/activity/Cargo.toml
+++ b/core/activity/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 ya-core-model = { version = "0.2", features = ["activity", "market"], path="../model" }
-ya-client-model = { version = "0.2", features = ["sgx"] }
+ya-client-model = { version = "0.3", features = ["sgx"] }
 ya-net = "0.1"
 ya-persistence = "0.2"
 ya-service-api = "0.1"

--- a/core/activity/Cargo.toml
+++ b/core/activity/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-ya-core-model = { version = "0.2", features = ["activity", "market"] }
+ya-core-model = { version = "^0.3", features = ["activity", "market"] }
 ya-client-model = { version = "0.3", features = ["sgx"] }
 ya-net = "0.2"
 ya-persistence = "0.2"

--- a/core/activity/Cargo.toml
+++ b/core/activity/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-ya-core-model = { version = "0.2", features = ["activity", "market"], path="../model" }
+ya-core-model = { version = "0.3", features = ["activity", "market"] }
 ya-client-model = { version = "0.3", features = ["sgx"] }
 ya-net = "0.1"
 ya-persistence = "0.2"

--- a/core/activity/Cargo.toml
+++ b/core/activity/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-ya-core-model = { version = "0.3", features = ["activity", "market"] }
+ya-core-model = { version = "0.2", features = ["activity", "market"] }
 ya-client-model = { version = "0.3", features = ["sgx"] }
 ya-net = "0.2"
 ya-persistence = "0.2"

--- a/core/activity/Cargo.toml
+++ b/core/activity/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 ya-core-model = { version = "0.3", features = ["activity", "market"] }
 ya-client-model = { version = "0.3", features = ["sgx"] }
-ya-net = "0.1"
+ya-net = "0.2"
 ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"

--- a/core/gftp/Cargo.toml
+++ b/core/gftp/Cargo.toml
@@ -20,7 +20,7 @@ required-features=['bin']
 [dependencies]
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.3", features = ["gftp", "identity", "net"] }
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 actix-rt = "1.0"
 anyhow = "1.0"

--- a/core/gftp/Cargo.toml
+++ b/core/gftp/Cargo.toml
@@ -19,7 +19,7 @@ required-features=['bin']
 
 [dependencies]
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.2", features = ["gftp", "identity", "net"], path="../model" }
+ya-core-model = { version = "0.3", features = ["gftp", "identity", "net"] }
 ya-service-bus = "0.3"
 
 actix-rt = "1.0"

--- a/core/gftp/Cargo.toml
+++ b/core/gftp/Cargo.toml
@@ -19,7 +19,7 @@ required-features=['bin']
 
 [dependencies]
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.2", features = ["gftp", "identity", "net"] }
+ya-core-model = { version = "^0.3", features = ["gftp", "identity", "net"] }
 ya-service-bus = "0.4"
 
 actix-rt = "1.0"

--- a/core/gftp/Cargo.toml
+++ b/core/gftp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gftp"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/yagna"

--- a/core/gftp/Cargo.toml
+++ b/core/gftp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gftp"
-version = "0.2.0"
+version = "0.1.2"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/yagna"

--- a/core/gftp/Cargo.toml
+++ b/core/gftp/Cargo.toml
@@ -19,7 +19,7 @@ required-features=['bin']
 
 [dependencies]
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.3", features = ["gftp", "identity", "net"] }
+ya-core-model = { version = "0.2", features = ["gftp", "identity", "net"] }
 ya-service-bus = "0.4"
 
 actix-rt = "1.0"

--- a/core/identity/Cargo.toml
+++ b/core/identity/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
-ya-core-model = { version = "0.2", features = ["identity", "appkey"] }
+ya-core-model = { version = "^0.3", features = ["identity", "appkey"] }
 ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"

--- a/core/identity/Cargo.toml
+++ b/core/identity/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
-ya-core-model = { version = "0.3", features = ["identity", "appkey"] }
+ya-core-model = { version = "0.2", features = ["identity", "appkey"] }
 ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"

--- a/core/identity/Cargo.toml
+++ b/core/identity/Cargo.toml
@@ -11,7 +11,7 @@ ya-core-model = { version = "0.3", features = ["identity", "appkey"] }
 ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 actix-rt = "1.0"
 anyhow = "1.0"
@@ -34,7 +34,7 @@ uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 ya-service-api-derive = "0.1"
-ya-sb-router = "0.3"
+ya-sb-router = "0.4"
 
 actix-service = "1.0.5"
 actix-web = "3.2"

--- a/core/identity/Cargo.toml
+++ b/core/identity/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
-ya-core-model = { features = ["identity", "appkey"], path="../model" }
+ya-core-model = { version = "0.3", features = ["identity", "appkey"] }
 ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"

--- a/core/identity/Cargo.toml
+++ b/core/identity/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-ya-client-model = { version = "0.2", features = ["with-diesel"] }
+ya-client-model = { version = "0.3", features = ["with-diesel"] }
 ya-core-model = { features = ["identity", "appkey"], path="../model" }
 ya-persistence = "0.2"
 ya-service-api = "0.1"

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -22,7 +22,7 @@ ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-api-web = "0.1"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 actix-web = "3.2"
 async-trait = { version = "0.1.33" }

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -15,7 +15,7 @@ ya-agreement-utils = { version = "^0.2"}
 ya-diesel-utils = { version = "0.1" }
 ya-std-utils = "0.1"
 ya-client = "0.5"
-ya-core-model = { version = "0.2", features = ["market", "net"] }
+ya-core-model = { version = "^0.3", features = ["market", "net"] }
 ya-market-resolver = "0.2"
 ya-net = "0.2"
 ya-persistence = "0.2"

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-market"
-version = "0.2.0"
+version = "0.3.0"
 description = "The Distributed Marketplace implementation for Yagna."
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -14,7 +14,7 @@ testing = ["actix-http", "actix-rt", "actix-service", "env_logger"]
 ya-agreement-utils = "0.2"
 ya-diesel-utils = { version = "0.1" }
 ya-std-utils = "0.1"
-ya-client = "0.4"
+ya-client = "0.5"
 ya-core-model = { version = "0.2", features = ["market", "net"] }
 ya-market-resolver = "0.2"
 ya-net = "0.1"

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -11,7 +11,7 @@ bcast-singleton = []
 testing = ["actix-http", "actix-rt", "actix-service", "env_logger"]
 
 [dependencies]
-ya-agreement-utils = { version = "0.1" }
+ya-agreement-utils = { version = "^0.2"}
 ya-diesel-utils = { version = "0.1" }
 ya-std-utils = "0.1"
 ya-client = "0.5"

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -15,7 +15,7 @@ ya-agreement-utils = { version = "^0.2"}
 ya-diesel-utils = { version = "0.1" }
 ya-std-utils = "0.1"
 ya-client = "0.5"
-ya-core-model = { version = "0.3", features = ["market", "net"] }
+ya-core-model = { version = "0.2", features = ["market", "net"] }
 ya-market-resolver = "0.2"
 ya-net = "0.2"
 ya-persistence = "0.2"

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -17,7 +17,7 @@ ya-std-utils = "0.1"
 ya-client = "0.5"
 ya-core-model = { version = "0.3", features = ["market", "net"] }
 ya-market-resolver = "0.2"
-ya-net = "0.1"
+ya-net = "0.2"
 ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -11,7 +11,7 @@ bcast-singleton = []
 testing = ["actix-http", "actix-rt", "actix-service", "env_logger"]
 
 [dependencies]
-ya-agreement-utils = "0.1"
+ya-agreement-utils = { version = "0.1" }
 ya-diesel-utils = { version = "0.1" }
 ya-std-utils = "0.1"
 ya-client = "0.5"

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -11,7 +11,7 @@ bcast-singleton = []
 testing = ["actix-http", "actix-rt", "actix-service", "env_logger"]
 
 [dependencies]
-ya-agreement-utils = "0.2"
+ya-agreement-utils = "0.1"
 ya-diesel-utils = { version = "0.1" }
 ya-std-utils = "0.1"
 ya-client = "0.5"

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -15,7 +15,7 @@ ya-agreement-utils = "0.2"
 ya-diesel-utils = { version = "0.1" }
 ya-std-utils = "0.1"
 ya-client = "0.5"
-ya-core-model = { version = "0.2", features = ["market", "net"] }
+ya-core-model = { version = "0.3", features = ["market", "net"] }
 ya-market-resolver = "0.2"
 ya-net = "0.1"
 ya-persistence = "0.2"

--- a/core/metrics/Cargo.toml
+++ b/core/metrics/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/golemfactory/yagna"
 license = "LGPL-3.0"
 
 [dependencies]
-ya-core-model = { version = "0.2", features = ["identity"] }
+ya-core-model = { version = "0.3", features = ["identity"] }
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.3"

--- a/core/metrics/Cargo.toml
+++ b/core/metrics/Cargo.toml
@@ -13,7 +13,7 @@ license = "LGPL-3.0"
 ya-core-model = { version = "0.3", features = ["identity"] }
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 actix-web = { version = "3", features = ["openssl"] }
 anyhow = "1.0.32"

--- a/core/metrics/Cargo.toml
+++ b/core/metrics/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/golemfactory/yagna"
 license = "LGPL-3.0"
 
 [dependencies]
-ya-core-model = { version = "0.3", features = ["identity"] }
+ya-core-model = { version = "0.2", features = ["identity"] }
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.4"

--- a/core/metrics/Cargo.toml
+++ b/core/metrics/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/golemfactory/yagna"
 license = "LGPL-3.0"
 
 [dependencies]
-ya-core-model = { version = "0.2", features = ["identity"] }
+ya-core-model = { version = "^0.3", features = ["identity"] }
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.4"

--- a/core/model/Cargo.toml
+++ b/core/model/Cargo.toml
@@ -36,7 +36,7 @@ version = []
 
 [dependencies]
 ya-client-model = "0.3"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 bigdecimal = { version = "0.1.0", optional = true }
 bitflags = { version = "1.2", optional = true }

--- a/core/model/Cargo.toml
+++ b/core/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-core-model"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/yagna"

--- a/core/model/Cargo.toml
+++ b/core/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-core-model"
-version = "0.3.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/yagna"

--- a/core/model/Cargo.toml
+++ b/core/model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-core-model"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/yagna"

--- a/core/model/Cargo.toml
+++ b/core/model/Cargo.toml
@@ -35,7 +35,7 @@ sgx = ['graphene-sgx']
 version = []
 
 [dependencies]
-ya-client-model = "0.2"
+ya-client-model = "0.3"
 ya-service-bus = "0.3"
 
 bigdecimal = { version = "0.1.0", optional = true }

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -12,7 +12,7 @@ service = []
 ya-core-model = { version = "0.3", features=["net", "identity"] }
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 actix-rt = "1.0"
 anyhow = "1.0"
@@ -25,8 +25,8 @@ tokio = { version = "0.2", features = ["time"] }
 trust-dns-resolver = { version = "0.19", features = ["mdns"] }
 
 [dev-dependencies]
-ya-sb-proto = "0.1"
-ya-sb-router = "0.3"
+ya-sb-proto = "0.2"
+ya-sb-router = "0.4"
 
 env_logger = "0.7"
 serde = "1.0"

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 service = []
 
 [dependencies]
-ya-core-model = { path = "../model", features=["net", "identity"] }
+ya-core-model = { version = "0.3", features=["net", "identity"] }
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.3"

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 service = []
 
 [dependencies]
-ya-core-model = { version = "0.3", features=["net", "identity"] }
+ya-core-model = { version = "0.2", features=["net", "identity"] }
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.4"

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-net"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 service = []
 
 [dependencies]
-ya-core-model = { version = "0.2", features=["net", "identity"] }
+ya-core-model = { version = "^0.3", features=["net", "identity"] }
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.4"

--- a/core/payment-driver/base/Cargo.toml
+++ b/core/payment-driver/base/Cargo.toml
@@ -28,6 +28,6 @@ tokio = { version = "0.2", features = ["macros"] }
 ya-client-model = "0.3"
 ya-core-model = { version = "0.3", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 [dev-dependencies]

--- a/core/payment-driver/base/Cargo.toml
+++ b/core/payment-driver/base/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1.0"
 tokio = { version = "0.2", features = ["macros"] }
 
 ## yagna dependencies
-ya-client-model = "0.2.0"
+ya-client-model = "0.3"
 ya-core-model = { version = "0.2.1", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-bus = "0.3"

--- a/core/payment-driver/base/Cargo.toml
+++ b/core/payment-driver/base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-payment-driver"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/core/payment-driver/base/Cargo.toml
+++ b/core/payment-driver/base/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "0.2", features = ["macros"] }
 
 ## yagna dependencies
 ya-client-model = "0.3"
-ya-core-model = { version = "0.2.1", features = ["driver", "identity", "payment"] }
+ya-core-model = { version = "0.3", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-bus = "0.3"
 

--- a/core/payment-driver/base/Cargo.toml
+++ b/core/payment-driver/base/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "0.2", features = ["macros"] }
 
 ## yagna dependencies
 ya-client-model = "0.3"
-ya-core-model = { version = "0.3", features = ["driver", "identity", "payment"] }
+ya-core-model = { version = "0.2", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-bus = "0.4"
 

--- a/core/payment-driver/base/Cargo.toml
+++ b/core/payment-driver/base/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "0.2", features = ["macros"] }
 
 ## yagna dependencies
 ya-client-model = "0.3"
-ya-core-model = { version = "0.2", features = ["driver", "identity", "payment"] }
+ya-core-model = { version = "^0.3", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-bus = "0.4"
 

--- a/core/payment-driver/dummy/Cargo.toml
+++ b/core/payment-driver/dummy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-dummy-driver"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/core/payment-driver/dummy/Cargo.toml
+++ b/core/payment-driver/dummy/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 ya-core-model = { version = "0.3", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-api-interfaces = "0.1"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 actix = { version = "0.9", default-features = false }
 anyhow = "1.0"

--- a/core/payment-driver/dummy/Cargo.toml
+++ b/core/payment-driver/dummy/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 default = []
 
 [dependencies]
-ya-core-model = { version = "0.3", features = ["driver", "identity", "payment"] }
+ya-core-model = { version = "0.2", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.4"

--- a/core/payment-driver/dummy/Cargo.toml
+++ b/core/payment-driver/dummy/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 default = []
 
 [dependencies]
-ya-core-model = { version = "0.2", features = ["driver", "identity", "payment"] }
+ya-core-model = { version = "0.3", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.3"

--- a/core/payment-driver/dummy/Cargo.toml
+++ b/core/payment-driver/dummy/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 default = []
 
 [dependencies]
-ya-core-model = { version = "0.2", features = ["driver", "identity", "payment"] }
+ya-core-model = { version = "^0.3", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.4"

--- a/core/payment-driver/gnt/Cargo.toml
+++ b/core/payment-driver/gnt/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
-ya-core-model = { version = "0.3", features = ["driver", "identity", "payment"] }
+ya-core-model = { version = "0.2", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.4"

--- a/core/payment-driver/gnt/Cargo.toml
+++ b/core/payment-driver/gnt/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-ya-client-model = { version = "0.2", features = ["with-diesel"] }
+ya-client-model = { version = "0.3", features = ["with-diesel"] }
 ya-core-model = { version = "0.2", features = ["driver", "identity", "payment"], path="../../model" }
 ya-persistence = "0.2"
 ya-service-api-interfaces = "0.1"

--- a/core/payment-driver/gnt/Cargo.toml
+++ b/core/payment-driver/gnt/Cargo.toml
@@ -9,7 +9,7 @@ ya-client-model = { version = "0.3", features = ["with-diesel"] }
 ya-core-model = { version = "0.3", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-api-interfaces = "0.1"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 actix = { version = "0.9", default-features = false }
 actix-connect="1.0"

--- a/core/payment-driver/gnt/Cargo.toml
+++ b/core/payment-driver/gnt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-gnt-driver"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/core/payment-driver/gnt/Cargo.toml
+++ b/core/payment-driver/gnt/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
-ya-core-model = { version = "0.2", features = ["driver", "identity", "payment"], path="../../model" }
+ya-core-model = { version = "0.3", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.3"

--- a/core/payment-driver/gnt/Cargo.toml
+++ b/core/payment-driver/gnt/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
-ya-core-model = { version = "0.2", features = ["driver", "identity", "payment"] }
+ya-core-model = { version = "^0.3", features = ["driver", "identity", "payment"] }
 ya-persistence = "0.2"
 ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.4"

--- a/core/payment-driver/zksync/Cargo.toml
+++ b/core/payment-driver/zksync/Cargo.toml
@@ -29,7 +29,7 @@ zksync_eth_signer = { git = "https://github.com/matter-labs/zksync", rev = "9b42
 
 ## yagna dependencies
 ya-payment-driver = "0.1.0"
-ya-client-model = "0.2.0"
+ya-client-model = "0.3"
 ya-service-api-interfaces = "0.1"
 ya-utils-futures = "0.1"
 

--- a/core/payment-driver/zksync/Cargo.toml
+++ b/core/payment-driver/zksync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-zksync-driver"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
@@ -28,7 +28,7 @@ zksync = { git = "https://github.com/matter-labs/zksync", rev = "9b4263c883c0f57
 zksync_eth_signer = { git = "https://github.com/matter-labs/zksync", rev = "9b4263c883c0f57c75068a0cc6339d051157a306"}
 
 ## yagna dependencies
-ya-payment-driver = "0.1.0"
+ya-payment-driver = "0.2"
 ya-client-model = "0.3"
 ya-service-api-interfaces = "0.1"
 ya-utils-futures = "0.1"

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -10,7 +10,7 @@ default = []
 [dependencies]
 ya-agreement-utils = { version = "^0.2"}
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
-ya-core-model = { version = "0.2", features = [ "activity", "driver", "identity", "market", "payment" ] }
+ya-core-model = { version = "^0.3", features = [ "activity", "driver", "identity", "market", "payment" ] }
 ya-net = "0.2"
 ya-metrics = "0.1.0"
 ya-persistence = "0.2"

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -17,7 +17,7 @@ ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-api-web = "0.1"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 actix-web = "3.2"
 anyhow = "1.0.26"
@@ -53,6 +53,6 @@ ya-dummy-driver = "0.2"
 ya-gnt-driver = "0.2"
 ya-zksync-driver = "0.2"
 ya-net = { version = "0.2", features = ["service"] }
-ya-sb-router = "0.3"
+ya-sb-router = "0.4"
 
 actix-rt = "1.0"

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-payment"
-version = "0.3.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 
 [dependencies]
 ya-agreement-utils = "0.2"
-ya-client-model = { version = "0.2", features = ["with-diesel"] }
+ya-client-model = { version = "0.3", features = ["with-diesel"] }
 ya-core-model = { version = "0.2.1", path="../model", features = [ "activity", "driver", "identity", "market", "payment" ] }
 ya-net = "0.1"
 ya-metrics = "0.1.0"
@@ -48,7 +48,7 @@ uuid = { version = "0.8", features = ["v4"] }
 humantime="2.0.1"
 
 [dev-dependencies]
-ya-client = "0.4"
+ya-client = "0.5"
 ya-dummy-driver = "0.1"
 ya-gnt-driver = "0.1"
 ya-zksync-driver = "0.1"

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 default = []
 
 [dependencies]
-ya-agreement-utils = "0.2"
+ya-agreement-utils = "0.1"
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
 ya-core-model = { version = "0.3", features = [ "activity", "driver", "identity", "market", "payment" ] }
 ya-net = "0.2"

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-payment"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 default = []
 
 [dependencies]
-ya-agreement-utils = { version = "0.1" }
+ya-agreement-utils = { version = "^0.2"}
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
 ya-core-model = { version = "0.3", features = [ "activity", "driver", "identity", "market", "payment" ] }
 ya-net = "0.2"

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -11,7 +11,7 @@ default = []
 ya-agreement-utils = "0.2"
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
 ya-core-model = { version = "0.3", features = [ "activity", "driver", "identity", "market", "payment" ] }
-ya-net = "0.1"
+ya-net = "0.2"
 ya-metrics = "0.1.0"
 ya-persistence = "0.2"
 ya-service-api = "0.1"
@@ -52,7 +52,7 @@ ya-client = "0.5"
 ya-dummy-driver = "0.1"
 ya-gnt-driver = "0.1"
 ya-zksync-driver = "0.1"
-ya-net = { version = "0.1", features = ["service"] }
+ya-net = { version = "0.2", features = ["service"] }
 ya-sb-router = "0.3"
 
 actix-rt = "1.0"

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -10,7 +10,7 @@ default = []
 [dependencies]
 ya-agreement-utils = { version = "^0.2"}
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
-ya-core-model = { version = "0.3", features = [ "activity", "driver", "identity", "market", "payment" ] }
+ya-core-model = { version = "0.2", features = [ "activity", "driver", "identity", "market", "payment" ] }
 ya-net = "0.2"
 ya-metrics = "0.1.0"
 ya-persistence = "0.2"

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-payment"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
@@ -49,9 +49,9 @@ humantime="2.0.1"
 
 [dev-dependencies]
 ya-client = "0.5"
-ya-dummy-driver = "0.1"
-ya-gnt-driver = "0.1"
-ya-zksync-driver = "0.1"
+ya-dummy-driver = "0.2"
+ya-gnt-driver = "0.2"
+ya-zksync-driver = "0.2"
 ya-net = { version = "0.2", features = ["service"] }
 ya-sb-router = "0.3"
 

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 default = []
 
 [dependencies]
-ya-agreement-utils = "0.1"
+ya-agreement-utils = { version = "0.1" }
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
 ya-core-model = { version = "0.3", features = [ "activity", "driver", "identity", "market", "payment" ] }
 ya-net = "0.2"

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -10,7 +10,7 @@ default = []
 [dependencies]
 ya-agreement-utils = "0.2"
 ya-client-model = { version = "0.3", features = ["with-diesel"] }
-ya-core-model = { version = "0.2.1", path="../model", features = [ "activity", "driver", "identity", "market", "payment" ] }
+ya-core-model = { version = "0.3", features = [ "activity", "driver", "identity", "market", "payment" ] }
 ya-net = "0.1"
 ya-metrics = "0.1.0"
 ya-persistence = "0.2"

--- a/core/persistence/Cargo.toml
+++ b/core/persistence/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = { version = "0.3", features = [ "with-diesel" ] }
-ya-core-model = { path="../model" }
+ya-core-model = { version = "0.3" }
 
 anyhow = "1.0.26"
 bigdecimal = "0.1.0"

--- a/core/persistence/Cargo.toml
+++ b/core/persistence/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = { version = "0.3", features = [ "with-diesel" ] }
-ya-core-model = { version = "0.2" }
+ya-core-model = { version = "^0.3"}
 
 anyhow = "1.0.26"
 bigdecimal = "0.1.0"

--- a/core/persistence/Cargo.toml
+++ b/core/persistence/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 
 [dependencies]
-ya-client-model = { version = "0.2", features = [ "with-diesel" ] }
+ya-client-model = { version = "0.3", features = [ "with-diesel" ] }
 ya-core-model = { path="../model" }
 
 anyhow = "1.0.26"

--- a/core/persistence/Cargo.toml
+++ b/core/persistence/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = { version = "0.3", features = [ "with-diesel" ] }
-ya-core-model = { version = "0.3" }
+ya-core-model = { version = "0.2" }
 
 anyhow = "1.0.26"
 bigdecimal = "0.1.0"

--- a/core/serv-api/web/Cargo.toml
+++ b/core/serv-api/web/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client = "0.5"
-ya-core-model = { version = "0.3", features = ["appkey"] }
+ya-core-model = { version = "0.2", features = ["appkey"] }
 ya-service-api = "0.1"
 ya-service-api-cache = "0.1"
 ya-service-bus = "0.4"

--- a/core/serv-api/web/Cargo.toml
+++ b/core/serv-api/web/Cargo.toml
@@ -10,7 +10,7 @@ ya-client = "0.5"
 ya-core-model = { version = "0.3", features = ["appkey"] }
 ya-service-api = "0.1"
 ya-service-api-cache = "0.1"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 actix-service = "1.0.0"
 actix-web = "3.2"
@@ -23,7 +23,7 @@ url = "2.1.1"
 [dev-dependencies]
 ya-identity = "0.2"
 ya-persistence = "0.2"
-ya-sb-router = "0.3"
+ya-sb-router = "0.4"
 ya-service-api-derive = "0.1"
 ya-service-api-interfaces = "0.1"
 

--- a/core/serv-api/web/Cargo.toml
+++ b/core/serv-api/web/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client = "0.5"
-ya-core-model = { version = "0.2", features = ["appkey"] }
+ya-core-model = { version = "^0.3", features = ["appkey"] }
 ya-service-api = "0.1"
 ya-service-api-cache = "0.1"
 ya-service-bus = "0.4"

--- a/core/serv-api/web/Cargo.toml
+++ b/core/serv-api/web/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client = "0.5"
-ya-core-model = { path = "../../model", features = ["appkey"] }
+ya-core-model = { version = "0.3", features = ["appkey"] }
 ya-service-api = "0.1"
 ya-service-api-cache = "0.1"
 ya-service-bus = "0.3"

--- a/core/serv-api/web/Cargo.toml
+++ b/core/serv-api/web/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-ya-client = "0.4"
+ya-client = "0.5"
 ya-core-model = { path = "../../model", features = ["appkey"] }
 ya-service-api = "0.1"
 ya-service-api-cache = "0.1"

--- a/core/sgx/Cargo.toml
+++ b/core/sgx/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 anyhow = "1.0"
 graphene-sgx = { version = "0.3", features = [ "ias" ] }
 ya-client-model = "0.3"
-ya-core-model = { version = "0.2", features = ["sgx"] }
+ya-core-model = { version = "0.3", features = ["sgx"] }
 ya-service-bus = "0.3"

--- a/core/sgx/Cargo.toml
+++ b/core/sgx/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 anyhow = "1.0"
 graphene-sgx = { version = "0.3", features = [ "ias" ] }
 ya-client-model = "0.3"
-ya-core-model = { version = "0.3", features = ["sgx"] }
+ya-core-model = { version = "0.2", features = ["sgx"] }
 ya-service-bus = "0.4"

--- a/core/sgx/Cargo.toml
+++ b/core/sgx/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0"
 graphene-sgx = { version = "0.3", features = [ "ias" ] }
-ya-client-model = "0.2"
+ya-client-model = "0.3"
 ya-core-model = { version = "0.2", features = ["sgx"] }
 ya-service-bus = "0.3"

--- a/core/sgx/Cargo.toml
+++ b/core/sgx/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 anyhow = "1.0"
 graphene-sgx = { version = "0.3", features = [ "ias" ] }
 ya-client-model = "0.3"
-ya-core-model = { version = "0.2", features = ["sgx"] }
+ya-core-model = { version = "^0.3", features = ["sgx"] }
 ya-service-bus = "0.4"

--- a/core/sgx/Cargo.toml
+++ b/core/sgx/Cargo.toml
@@ -9,4 +9,4 @@ anyhow = "1.0"
 graphene-sgx = { version = "0.3", features = [ "ias" ] }
 ya-client-model = "0.3"
 ya-core-model = { version = "0.3", features = ["sgx"] }
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"

--- a/core/version/Cargo.toml
+++ b/core/version/Cargo.toml
@@ -12,7 +12,7 @@ ya-core-model = { version = "0.3", features = ["version"] }
 ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 
 actix-web = "3.2"
 anyhow = "1.0"

--- a/core/version/Cargo.toml
+++ b/core/version/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 ya-client = "0.5"
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.2.0", features = ["version"] }
+ya-core-model = { version = "0.3", features = ["version"] }
 ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"

--- a/core/version/Cargo.toml
+++ b/core/version/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 ya-client = "0.5"
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.3", features = ["version"] }
+ya-core-model = { version = "0.2", features = ["version"] }
 ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"

--- a/core/version/Cargo.toml
+++ b/core/version/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-ya-client = "0.4"
+ya-client = "0.5"
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.2.0", features = ["version"] }
 ya-persistence = "0.2"

--- a/core/version/Cargo.toml
+++ b/core/version/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 ya-client = "0.5"
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.2", features = ["version"] }
+ya-core-model = { version = "^0.3", features = ["version"] }
 ya-persistence = "0.2"
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -27,7 +27,7 @@ libproc = "0.7"
 winapi = { version = "0.3.8", features = ["jobapi2", "processthreadsapi"] }
 
 [dependencies]
-ya-agreement-utils = "0.2"
+ya-agreement-utils = "0.1"
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.3", features = ["activity", "appkey"] }

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -28,7 +28,7 @@ winapi = { version = "0.3.8", features = ["jobapi2", "processthreadsapi"] }
 
 [dependencies]
 ya-agreement-utils = "0.2"
-ya-client-model = "0.2"
+ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.2", features = ["activity", "appkey"], path="../core/model" }
 ya-runtime-api = { version = "0.1", path = "runtime-api", features = ["server"] }

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -30,7 +30,7 @@ winapi = { version = "0.3.8", features = ["jobapi2", "processthreadsapi"] }
 ya-agreement-utils = { version = "^0.2"}
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.2", features = ["activity", "appkey"] }
+ya-core-model = { version = "^0.3", features = ["activity", "appkey"] }
 ya-runtime-api = { version = "0.1", path = "runtime-api", features = ["server"] }
 ya-service-bus = "0.4"
 ya-transfer = "0.1"

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -30,7 +30,7 @@ winapi = { version = "0.3.8", features = ["jobapi2", "processthreadsapi"] }
 ya-agreement-utils = { version = "^0.2"}
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.3", features = ["activity", "appkey"] }
+ya-core-model = { version = "0.2", features = ["activity", "appkey"] }
 ya-runtime-api = { version = "0.1", path = "runtime-api", features = ["server"] }
 ya-service-bus = "0.4"
 ya-transfer = "0.1"

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -32,7 +32,7 @@ ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.3", features = ["activity", "appkey"] }
 ya-runtime-api = { version = "0.1", path = "runtime-api", features = ["server"] }
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 ya-transfer = "0.1"
 ya-utils-path = "0.1"
 
@@ -67,7 +67,7 @@ yansi = "0.5.0"
 
 [dev-dependencies]
 ya-runtime-api = { version = "0.1", path = "runtime-api", features = ["codec", "server"] }
-ya-sb-router = "0.3"
+ya-sb-router = "0.4"
 
 actix-files = "0.4"
 actix-rt = "1.0.1"

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -30,7 +30,7 @@ winapi = { version = "0.3.8", features = ["jobapi2", "processthreadsapi"] }
 ya-agreement-utils = "0.2"
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.2", features = ["activity", "appkey"], path="../core/model" }
+ya-core-model = { version = "0.3", features = ["activity", "appkey"] }
 ya-runtime-api = { version = "0.1", path = "runtime-api", features = ["server"] }
 ya-service-bus = "0.3"
 ya-transfer = "0.1"

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -27,7 +27,7 @@ libproc = "0.7"
 winapi = { version = "0.3.8", features = ["jobapi2", "processthreadsapi"] }
 
 [dependencies]
-ya-agreement-utils = { version = "0.1" }
+ya-agreement-utils = { version = "^0.2"}
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.3", features = ["activity", "appkey"] }

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -27,7 +27,7 @@ libproc = "0.7"
 winapi = { version = "0.3.8", features = ["jobapi2", "processthreadsapi"] }
 
 [dependencies]
-ya-agreement-utils = "0.1"
+ya-agreement-utils = { version = "0.1" }
 ya-client-model = "0.3"
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.3", features = ["activity", "appkey"] }

--- a/golem_cli/Cargo.toml
+++ b/golem_cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "golemsp"
 description = "User friedly CLI for running Golem Provider"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/golem_cli/Cargo.toml
+++ b/golem_cli/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-ya-client = { version = "0.4", features = ['cli'] }
+ya-client = { version = "0.5", features = ['cli'] }
 ya-compile-time-utils = "0.1"
 ya-core-model = { version = "0.2", features=["payment", "version"] }
 ya-provider = "0.2"

--- a/golem_cli/Cargo.toml
+++ b/golem_cli/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 ya-client = { version = "0.5", features = ['cli'] }
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.2", features=["payment", "version"] }
+ya-core-model = { version = "^0.3", features=["payment", "version"] }
 ya-provider = "0.2"
 ya-utils-path = "0.1.0"
 ya-utils-process = { version = "0.1.0", features = ["lock"] }

--- a/golem_cli/Cargo.toml
+++ b/golem_cli/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 ya-client = { version = "0.5", features = ['cli'] }
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.2", features=["payment", "version"] }
+ya-core-model = { version = "0.3", features=["payment", "version"] }
 ya-provider = "0.2"
 ya-utils-path = "0.1.0"
 ya-utils-process = { version = "0.1.0", features = ["lock"] }

--- a/golem_cli/Cargo.toml
+++ b/golem_cli/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 ya-client = { version = "0.5", features = ['cli'] }
 ya-compile-time-utils = "0.1"
-ya-core-model = { version = "0.3", features=["payment", "version"] }
+ya-core-model = { version = "0.2", features=["payment", "version"] }
 ya-provider = "0.2"
 ya-utils-path = "0.1.0"
 ya-utils-process = { version = "0.1.0", features = ["lock"] }

--- a/utils/agreement-utils/Cargo.toml
+++ b/utils/agreement-utils/Cargo.toml
@@ -10,7 +10,7 @@ description="Yagna agreement utils"
 keywords=["golem", "yagna"]
 
 [dependencies]
-ya-client-model = "0.2"
+ya-client-model = "0.3"
 
 serde = "1.0"
 serde_json = "1.0"

--- a/utils/agreement-utils/Cargo.toml
+++ b/utils/agreement-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-agreement-utils"
-version = "0.2.0"
+version = "0.1.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/yagna"

--- a/utils/agreement-utils/Cargo.toml
+++ b/utils/agreement-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-agreement-utils"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/yagna"

--- a/utils/compile-time-utils/Cargo.toml
+++ b/utils/compile-time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-compile-time-utils"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/yagna/utils/compile-time-utils"

--- a/utils/compile-time-utils/Cargo.toml
+++ b/utils/compile-time-utils/Cargo.toml
@@ -3,7 +3,11 @@ name = "ya-compile-time-utils"
 version = "0.1.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
-description = "Compile-time utilities"
+homepage = "https://github.com/golemfactory/yagna/utils/compile-time-utils"
+repository = "https://github.com/golemfactory/yagna"
+license = "LGPL-3.0"
+description = "Yagna Compile-time utilities"
+keywords=["golem", "yagna", "compile", "compile-time"]
 
 [dependencies]
 git-version = "0.3.4"

--- a/utils/compile-time-utils/src/lib.rs
+++ b/utils/compile-time-utils/src/lib.rs
@@ -4,7 +4,7 @@ use semver::Version;
 
 /// Returns latest tag (via `git describe --tag --abbrev=0`).
 pub fn git_tag() -> &'static str {
-    git_version!(args = ["--tag", "--abbrev=0"])
+    git_version!(args = ["--tag", "--abbrev=0"], cargo_prefix = "")
 }
 
 /// Returns latest commit short hash.

--- a/utils/compile-time-utils/src/lib.rs
+++ b/utils/compile-time-utils/src/lib.rs
@@ -2,12 +2,9 @@ use git_version::git_version;
 use metrics::gauge;
 use semver::Version;
 
-/// Returns latest tag (via `git describe --tag --abbrev=0`) or version from Cargo.toml`.
+/// Returns latest tag (via `git describe --tag --abbrev=0`).
 pub fn git_tag() -> &'static str {
-    git_version!(
-        args = ["--tag", "--abbrev=0"],
-        fallback = env!("CARGO_PKG_VERSION")
-    )
+    git_version!(args = ["--tag", "--abbrev=0"])
 }
 
 /// Returns latest commit short hash.
@@ -87,6 +84,11 @@ macro_rules! version_describe {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_git_tag() {
+        println!("git tag: {:?}", git_tag());
+    }
 
     #[test]
     fn test_git_rev() {

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = "0.3"
-ya-core-model = { version = "0.2" }
+ya-core-model = { version = "^0.3"}
 ya-net = "0.2"
 ya-service-bus = "0.4"
 ya-utils-path = "0.1"

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -11,7 +11,7 @@ ya-core-model = "0.3"
 ya-net = "0.2"
 ya-service-bus = "0.4"
 ya-utils-path = "0.1"
-gftp = "0.2"
+gftp = { version = "0.1" }
 
 actix-http = "1.0.1"
 actix-rt = "1.0.0"

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -11,7 +11,7 @@ ya-core-model = "0.3"
 ya-net = "0.2"
 ya-service-bus = "0.3"
 ya-utils-path = "0.1"
-gftp = "0.1"
+gftp = "0.2"
 
 actix-http = "1.0.1"
 actix-rt = "1.0.0"

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 ya-client-model = "0.3"
 ya-core-model = "0.3"
-ya-net = "0.1"
+ya-net = "0.2"
 ya-service-bus = "0.3"
 ya-utils-path = "0.1"
 gftp = "0.1"

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = "0.3"
-ya-core-model = "0.2"
+ya-core-model = "0.3"
 ya-net = "0.1"
 ya-service-bus = "0.3"
 ya-utils-path = "0.1"

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-ya-client-model = "0.2"
+ya-client-model = "0.3"
 ya-core-model = "0.2"
 ya-net = "0.1"
 ya-service-bus = "0.3"

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 ya-client-model = "0.3"
 ya-core-model = "0.3"
 ya-net = "0.2"
-ya-service-bus = "0.3"
+ya-service-bus = "0.4"
 ya-utils-path = "0.1"
 gftp = "0.2"
 

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -11,7 +11,7 @@ ya-core-model = { version = "0.2" }
 ya-net = "0.2"
 ya-service-bus = "0.4"
 ya-utils-path = "0.1"
-gftp = { version = "^0.2"}
+gftp = { version = "0.1" }
 
 actix-http = "1.0.1"
 actix-rt = "1.0.0"

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client-model = "0.3"
-ya-core-model = "0.3"
+ya-core-model = { version = "0.2" }
 ya-net = "0.2"
 ya-service-bus = "0.4"
 ya-utils-path = "0.1"

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -11,7 +11,7 @@ ya-core-model = { version = "^0.3"}
 ya-net = "0.2"
 ya-service-bus = "0.4"
 ya-utils-path = "0.1"
-gftp = { version = "0.1" }
+gftp = { version = "^0.2"}
 
 actix-http = "1.0.1"
 actix-rt = "1.0.0"

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -11,7 +11,7 @@ ya-core-model = "0.3"
 ya-net = "0.2"
 ya-service-bus = "0.4"
 ya-utils-path = "0.1"
-gftp = { version = "0.1" }
+gftp = { version = "^0.2"}
 
 actix-http = "1.0.1"
 actix-rt = "1.0.0"


### PR DESCRIPTION
## Bump
Bump all main subcrates and those which we should update on crates.io along with Alpha.4 release

## Payment driver - not sure
I'm not sure about payment driver crates. @Wiezzel @maaktweluit pls decide if their versions should also need to be updated.

## Before
Do not merge it before publish on crates.io is done

Before merging this we should also 
- remove patches from the main `Cargo.toml` after all is published on crates.io.
- merge https://github.com/golemfactory/ya-client/pull/100 and push to the crates.io
- merge https://github.com/golemfactory/ya-service-bus/pull/5 and  push to crates.io

There is related https://github.com/golemfactory/yarapi/pull/8