### PR TITLE
Use self-hosted runners for goth integration tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -145,7 +145,7 @@ jobs:
 
   integration-test:
     name: Run integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: build
     steps:
       - name: Checkout

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -145,7 +145,7 @@ jobs:
 
   integration-test:
     name: Run integration tests
-    runs-on: ubuntu-18.04
+    runs-on: goth
     needs: build
     steps:
       - name: Checkout
@@ -180,7 +180,7 @@ jobs:
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # --assets-path: https://github.com/golemfactory/goth/issues/336
-        run: poetry run poe ci_test
+        run: poetry run poe ci_test_self_hosted
 
       - name: Upload test logs
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
GitHub Actions now uses Ubuntu version 20.04 by default when `ubuntu-latest` is specified as the runner for a job. This change resulted in integration tests failing (example here: https://github.com/golemfactory/yagna/actions/runs/569398098) due to [`trust-dns`](https://github.com/bluejekyll/trust-dns) not being able to parse the `resolv.conf` file:
```
TRust-DNS can not load system config: Error parsing resolv.conf: InvalidOption(2)
```
It's not yet clear which option is causing the parser to fail. To get the tests running again this PR changes the runner version back to 18.04.