### PR TITLE
[ya-activity] Increase GSB call timeout where remote logic handles timeouts by itself

### DIFF
--- a/core/activity/src/api.rs
+++ b/core/activity/src/api.rs
@@ -20,11 +20,7 @@ mod common {
     use ya_service_api_web::middleware::Identity;
     use ya_service_bus::{timeout::IntoTimeoutFuture, RpcEndpoint};
 
-    use crate::common::{
-        agreement_provider_service, authorize_activity_executor, authorize_activity_initiator,
-        get_activity_agreement, get_persisted_state, get_persisted_usage, set_persisted_state,
-        set_persisted_usage, PathActivity, QueryTimeout,
-    };
+    use crate::common::*;
 
     pub fn extend_web_scope(scope: actix_web::Scope) -> actix_web::Scope {
         scope
@@ -81,7 +77,7 @@ mod common {
                 activity_id: path.activity_id.to_string(),
                 timeout: query.timeout.clone(),
             })
-            .timeout(query.timeout)
+            .timeout(timeout_margin(query.timeout))
             .await???;
 
         set_persisted_state(&db, &path.activity_id, state)
@@ -124,7 +120,7 @@ mod common {
                 activity_id: path.activity_id.to_string(),
                 timeout: query.timeout.clone(),
             })
-            .timeout(query.timeout)
+            .timeout(timeout_margin(query.timeout))
             .await???;
 
         set_persisted_usage(&db, &path.activity_id, usage)

--- a/core/activity/src/requestor/control.rs
+++ b/core/activity/src/requestor/control.rs
@@ -96,7 +96,7 @@ async fn create_activity(
         .to(provider_id)
         .service(activity::BUS_ID)
         .send(msg)
-        .timeout(query.timeout)
+        .timeout(timeout_margin(query.timeout))
         .await???;
 
     log::debug!("activity created: {}, inserting", create_resp.activity_id());
@@ -134,7 +134,7 @@ async fn destroy_activity(
     };
     agreement_provider_service(&id, &agreement)?
         .send(msg)
-        .timeout(query.timeout)
+        .timeout(timeout_margin(query.timeout))
         .await???;
 
     set_persisted_state(
@@ -179,7 +179,7 @@ async fn exec(
         .to(agreement.provider_id().clone())
         .service(&activity::exeunit::bus_id(&path.activity_id))
         .send(msg)
-        .timeout(query.timeout)
+        .timeout(timeout_margin(query.timeout))
         .await???;
 
     counter!("activity.requestor.run-exescript", 1);
@@ -224,7 +224,7 @@ async fn await_results(
         .to(agreement.provider_id().clone())
         .service(&activity::exeunit::bus_id(&path.activity_id))
         .send(msg)
-        .timeout(query.timeout)
+        .timeout(timeout_margin(query.timeout))
         .await???;
 
     Ok::<_, Error>(web::Json(results))

--- a/core/activity/src/requestor/state.rs
+++ b/core/activity/src/requestor/state.rs
@@ -5,10 +5,7 @@ use ya_persistence::executor::DbExecutor;
 use ya_service_api_web::middleware::Identity;
 use ya_service_bus::{timeout::IntoTimeoutFuture, RpcEndpoint};
 
-use crate::common::{
-    agreement_provider_service, authorize_activity_initiator, get_activity_agreement, PathActivity,
-    QueryTimeout,
-};
+use crate::common::*;
 use crate::error::Error;
 
 pub fn extend_web_scope(scope: actix_web::Scope) -> actix_web::Scope {
@@ -33,7 +30,7 @@ async fn get_running_command(
 
     let cmd = agreement_provider_service(&id, &agreement)?
         .send(msg)
-        .timeout(query.timeout)
+        .timeout(timeout_margin(query.timeout))
         .await???;
 
     Ok::<_, Error>(web::Json(cmd))


### PR DESCRIPTION
In cases where a GSB call timeout was set and the remote logic times out, it was impossible for the remote side to reply with a timeout response.
This issue was prevalent while developing `yajsapi`.