### PR TITLE
Fallback for failing DNS resolution

### DIFF
--- a/core/payment-driver/glmsync/src/zksync/faucet.rs
+++ b/core/payment-driver/glmsync/src/zksync/faucet.rs
@@ -86,9 +86,7 @@ async fn faucet_donate(address: &str, _network: Network) -> Result<(), GenericEr
         .finish();
     let faucet_url = resolve_faucet_url().await?;
     let request_url = format!("{}/{}", faucet_url, address);
-    let request_url = resolver::resolve_dns_record(&request_url)
-        .await
-        .map_err(GenericError::new)?;
+    let request_url = resolver::try_resolve_dns_record(&request_url).await;
     debug!("Faucet request url: {}", request_url);
     let response = client
         .get(request_url)

--- a/core/payment-driver/gnt/src/gnt/faucet.rs
+++ b/core/payment-driver/gnt/src/gnt/faucet.rs
@@ -30,11 +30,7 @@ impl EthFaucetConfig {
         let faucet_address_str = env::var(ETH_FAUCET_ADDRESS_ENV_VAR)
             .ok()
             .unwrap_or_else(|| DEFAULT_ETH_FAUCET_ADDRESS.to_string());
-        let faucet_address_str = resolver::resolve_dns_record(&faucet_address_str)
-            .await
-            .map_err(|e| {
-                GNTDriverError::DatabaseError(format!("Error resolving tGLM faucet address: {}", e))
-            })?;
+        let faucet_address_str = resolver::try_resolve_dns_record(&faucet_address_str).await;
         let faucet_address = faucet_address_str
             .parse()
             .map_err(|e| GNTDriverError::LibraryError(format!("invalid faucet address: {}", e)))?;

--- a/core/payment-driver/zksync/src/zksync/faucet.rs
+++ b/core/payment-driver/zksync/src/zksync/faucet.rs
@@ -86,9 +86,7 @@ async fn faucet_donate(address: &str, _network: Network) -> Result<(), GenericEr
         .finish();
     let faucet_url = resolve_faucet_url().await?;
     let request_url = format!("{}/{}", faucet_url, address);
-    let request_url = resolver::resolve_dns_record(&request_url)
-        .await
-        .map_err(GenericError::new)?;
+    let request_url = resolver::try_resolve_dns_record(&request_url).await;
     debug!("Faucet request url: {}", request_url);
     let response = client
         .get(request_url)

--- a/utils/networking/src/resolver.rs
+++ b/utils/networking/src/resolver.rs
@@ -59,3 +59,14 @@ pub async fn resolve_dns_record(request_url: &str) -> anyhow::Result<String> {
 
     Ok(request_url.replace(&request_host, &address))
 }
+
+/// Try resolving hostname with `resolve_dns_record`. Return the original URL if it fails
+pub async fn try_resolve_dns_record(request_url: &str) -> String {
+    match resolve_dns_record(request_url).await {
+        Ok(url) => url,
+        Err(e) => {
+            log::warn!("Error resolving hostname: {} url={}", e, request_url);
+            request_url.to_owned()
+        }
+    }
+}


### PR DESCRIPTION
In some setups (e.g. CI tests running on Docker network) Google DNS servers are unavailable and the resolution fails. As a fallback the default DNS resolver could be used by simply passing the original URL into the request.