### PR TITLE
ZkSync: Unlock wallet before withdrawal

### DIFF
--- a/core/payment-driver/glmsync/src/driver.rs
+++ b/core/payment-driver/glmsync/src/driver.rs
@@ -159,7 +159,7 @@ impl PaymentDriver for ZksyncDriver {
         Ok(format!(
             "Withdrawal has been accepted by the zkSync operator. \
         It may take some time until the funds are available on Ethereum blockchain. \
-        Tracking link: https://rinkeby.zkscan.io/explorer/transactions/{}",
+        Tracking link: http://rinkeby.zksync.imapp.pl/explorer/transactions/{}",
             tx_hash
         ))
     }

--- a/core/payment-driver/glmsync/src/zksync/wallet.rs
+++ b/core/payment-driver/glmsync/src/zksync/wallet.rs
@@ -62,7 +62,7 @@ pub async fn init_wallet(msg: &Init) -> Result<(), GenericError> {
 
     if mode.contains(AccountMode::SEND) {
         let wallet = get_wallet(&address, network).await?;
-        unlock_wallet(wallet, network).await?;
+        unlock_wallet(&wallet, network).await?;
     }
     Ok(())
 }
@@ -79,6 +79,7 @@ pub async fn exit(msg: &Exit) -> Result<String, GenericError> {
     let network = msg.network().unwrap_or(DEFAULT_NETWORK.to_string());
     let network = Network::from_str(&network).map_err(|e| GenericError::new(e))?;
     let wallet = get_wallet(&msg.sender(), network).await?;
+    unlock_wallet(&wallet, network).await?;
     let tx_handle = withdraw(wallet, msg.amount(), msg.to()).await?;
     let tx_info = tx_handle
         .wait_for_commit()
@@ -261,7 +262,7 @@ fn get_zk_network(network: Network) -> ZkNetwork {
 }
 
 async fn unlock_wallet<S: EthereumSigner + Clone, P: Provider + Clone>(
-    wallet: Wallet<S, P>,
+    wallet: &Wallet<S, P>,
     _network: Network,
 ) -> Result<(), GenericError> {
     log::debug!("unlock_wallet");

--- a/core/payment-driver/zksync/src/zksync/wallet.rs
+++ b/core/payment-driver/zksync/src/zksync/wallet.rs
@@ -73,7 +73,7 @@ pub async fn init_wallet(msg: &Init) -> Result<(), GenericError> {
 
     if mode.contains(AccountMode::SEND) {
         let wallet = get_wallet(&address, network).await?;
-        unlock_wallet(wallet, network).await?;
+        unlock_wallet(&wallet, network).await?;
     }
     Ok(())
 }
@@ -90,6 +90,7 @@ pub async fn exit(msg: &Exit) -> Result<String, GenericError> {
     let network = msg.network().unwrap_or(DEFAULT_NETWORK.to_string());
     let network = Network::from_str(&network).map_err(|e| GenericError::new(e))?;
     let wallet = get_wallet(&msg.sender(), network).await?;
+    unlock_wallet(&wallet, network).await?;
     let tx_handle = withdraw(wallet, msg.amount(), msg.to()).await?;
     let tx_info = tx_handle
         .wait_for_commit()
@@ -275,7 +276,7 @@ fn get_zk_network(network: Network) -> ZkNetwork {
 }
 
 async fn unlock_wallet<S: EthereumSigner + Clone, P: Provider + Clone>(
-    wallet: Wallet<S, P>,
+    wallet: &Wallet<S, P>,
     network: Network,
 ) -> Result<(), GenericError> {
     log::debug!("unlock_wallet");


### PR DESCRIPTION
Provider's wallet might not be unlocked when `payment exit` is being run. That would cause the command to fail. A call to `unlock_wallet` has been added to fix this.

Bonus: fixed glmSync transaction tracking link.

---
### Testing instructions

#### ZkSync
1. Run the service
```shell
$ cargo run service run
```

2. Get some funds
```shell
$ cargo run payment fund
Received funds from the faucet. address=0x1264aee4168286ddf962c172a53e0e89a1562e44
```

3. Withdraw
```shell
$ cargo run payment exit
Withdrawal has been accepted by the zkSync operator. It may take some time until the funds are available on Ethereum blockchain. Tracking link: https://rinkeby.zkscan.io/explorer/transactions/ebb12605a72ff4e080b8375e6b9cb77e18548bbbc1882cdb870d65c319907221
```

4. Follow the link to check if withdrawal was successful.


#### GlmSync
1. Run the service
```shell
$ export GLMSYNC_FAUCET_ADDR=http://yacn.dev.golem.network:5777/zk/donate
$ cargo run service run
```

2. Get some funds
```shell
$ cargo run payment fund --driver=glmsync
Received funds from the faucet. address=0x1264aee4168286ddf962c172a53e0e89a1562e44
```

3. Withdraw
```shell
$ cargo run payment exit --driver=glmsync
Withdrawal has been accepted by the zkSync operator. It may take some time until the funds are available on Ethereum blockchain. Tracking link: http://rinkeby.zksync.imapp.pl/explorer/transactions/f8c3d60f10dc6b1715104e28fb1f2445cfecb5617860fa34dc5cf36e95192758
```

4. Follow the link to check if withdrawal was successful.