### PR TITLE
ZkSync: Fixed token name in withdraw

### DIFF
--- a/core/payment-driver/zksync/examples/withdrawal.rs
+++ b/core/payment-driver/zksync/examples/withdrawal.rs
@@ -68,7 +68,8 @@ async fn main() -> anyhow::Result<()> {
         .parse()
         .expect("Cannot parse 'amount' parameter to BigDecimal");
 
-    let withdraw_handle = driver_wallet::withdraw(wallet, Some(amount), None).await?;
+    let withdraw_handle =
+        driver_wallet::withdraw(wallet, DbNetwork::Rinkeby, Some(amount), None).await?;
 
     let tx_info = withdraw_handle.wait_for_commit().await?;
     if tx_info.success.unwrap_or(false) {

--- a/core/payment-driver/zksync/src/zksync/wallet.rs
+++ b/core/payment-driver/zksync/src/zksync/wallet.rs
@@ -91,7 +91,7 @@ pub async fn exit(msg: &Exit) -> Result<String, GenericError> {
     let network = Network::from_str(&network).map_err(|e| GenericError::new(e))?;
     let wallet = get_wallet(&msg.sender(), network).await?;
     unlock_wallet(&wallet, network).await?;
-    let tx_handle = withdraw(wallet, msg.amount(), msg.to()).await?;
+    let tx_handle = withdraw(wallet, network, msg.amount(), msg.to()).await?;
     let tx_info = tx_handle
         .wait_for_commit()
         .await
@@ -310,29 +310,33 @@ async fn unlock_wallet<S: EthereumSigner + Clone, P: Provider + Clone>(
 
 pub async fn withdraw<S: EthereumSigner + Clone, P: Provider + Clone>(
     wallet: Wallet<S, P>,
+    network: Network,
     amount: Option<BigDecimal>,
     recipient: Option<String>,
 ) -> Result<SyncTransactionHandle<P>, GenericError> {
+    let token = get_network_token(network, None);
     let balance = wallet
-        .get_balance(BlockStatus::Committed, ZKSYNC_TOKEN_NAME)
+        .get_balance(BlockStatus::Committed, token.as_str())
         .await
         .map_err(GenericError::new)?;
     info!(
-        "Wallet funded with {} tGLM available for withdrawal",
-        utils::big_uint_to_big_dec(balance.clone())
+        "Wallet funded with {} {} available for withdrawal",
+        utils::big_uint_to_big_dec(balance.clone()),
+        token
     );
 
     info!("Obtaining withdrawal fee");
     let address = wallet.address();
     let withdraw_fee = wallet
         .provider
-        .get_tx_fee(TxFeeTypes::Withdraw, address, ZKSYNC_TOKEN_NAME)
+        .get_tx_fee(TxFeeTypes::Withdraw, address, token.as_str())
         .await
         .map_err(GenericError::new)?
         .total_fee;
     info!(
-        "Withdrawal transaction fee {:.5}",
-        utils::big_uint_to_big_dec(withdraw_fee.clone())
+        "Withdrawal transaction fee {:.5} {}",
+        utils::big_uint_to_big_dec(withdraw_fee.clone()),
+        token
     );
 
     let amount = match amount {
@@ -341,8 +345,9 @@ pub async fn withdraw<S: EthereumSigner + Clone, P: Provider + Clone>(
     };
     let withdraw_amount = std::cmp::min(balance - withdraw_fee, amount);
     info!(
-        "Withdrawal of {:.5} tGLM started",
-        utils::big_uint_to_big_dec(withdraw_amount.clone())
+        "Withdrawal of {:.5} {} started",
+        utils::big_uint_to_big_dec(withdraw_amount.clone()),
+        token
     );
 
     let recipient_address = match recipient {
@@ -352,13 +357,13 @@ pub async fn withdraw<S: EthereumSigner + Clone, P: Provider + Clone>(
 
     let withdraw_builder = wallet
         .start_withdraw()
-        .token(ZKSYNC_TOKEN_NAME)
+        .token(token.as_str())
         .map_err(GenericError::new)?
         .amount(withdraw_amount.clone())
         .to(recipient_address);
     log::debug!(
         "Withdrawal raw data. token={}, amount={}, to={}",
-        ZKSYNC_TOKEN_NAME,
+        token,
         withdraw_amount,
         recipient_address
     );


### PR DESCRIPTION
Withdrawal function used hard-coded `GNT` token which was Rinkeby-specific legacy solution. Because of this withdrawals have not been working on mainnet. Usage of constant has been replaced by a call to `get_network_token` in order to use token ticker appropriate for the given network.

**GlmSync purposely omitted.**

---
**Testing instructions**

Rinkeby -> see instructions in #1072 

Mainnet -> have faith that it works (it would cost ~$30 to test it now)
