### PR TITLE
Provider - fix debit notes property

### DIFF
--- a/agent/provider/src/payments/model.rs
+++ b/agent/provider/src/payments/model.rs
@@ -35,10 +35,10 @@ impl<'a> PaymentDescription<'a> {
     }
 
     pub fn get_debit_note_deadline(&self) -> Result<Option<chrono::Duration>> {
-        match self
-            .agreement
-            .pointer_typed::<i64>(DEBIT_NOTE_ACCEPT_TIMEOUT_PROPERTY)
-        {
+        match self.agreement.pointer_typed::<i64>(&format!(
+            "/offer/properties{}",
+            DEBIT_NOTE_ACCEPT_TIMEOUT_PROPERTY
+        )) {
             Ok(deadline) => Ok(Some(chrono::Duration::seconds(deadline))),
             Err(Error::NoKey(_)) => Ok(None),
             Err(e) => Err(e.into()),


### PR DESCRIPTION
resolves: https://github.com/golemfactory/yagna/issues/1100

Property name in Agreement differs from property name in Offer since it must be prefixed with "/offer/properties".