### PR TITLE
Rename query's "pollTimeout" to "timeout"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7373,7 +7373,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.5.0"
-source = "git+https://github.com/golemfactory/ya-client.git?branch=release/v0.6#0fcd83c1b034284ecdb0341242ac19c57245b777"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=6916938177b860eb646b082f0784370863802231#6916938177b860eb646b082f0784370863802231"
 dependencies = [
  "awc 1.0.1",
  "bytes 0.5.6",
@@ -7398,7 +7398,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-client.git?branch=release/v0.6#0fcd83c1b034284ecdb0341242ac19c57245b777"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=6916938177b860eb646b082f0784370863802231#6916938177b860eb646b082f0784370863802231"
 dependencies = [
  "bigdecimal 0.2.0",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,8 +178,8 @@ ya-service-api-web = { path = "core/serv-api/web" }
 #ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "6b494e17d7a662e0b710af8c5a2e99ab4007fdb9"}
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", branch = "release/v0.6"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", branch = "release/v0.6"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "6916938177b860eb646b082f0784370863802231" }
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "6916938177b860eb646b082f0784370863802231" }
 
 # ya-client = { path = "../ya-client" }
 # ya-client-model = { path = "../ya-client/model" }

--- a/core/activity/src/common.rs
+++ b/core/activity/src/common.rs
@@ -46,8 +46,8 @@ pub struct QueryEvents {
     #[serde(rename = "appSessionId")]
     pub app_session_id: Option<String>,
     /// number of milliseconds to wait
-    #[serde(rename = "pollTimeout", default = "default_query_timeout")]
-    pub poll_timeout: Option<f32>,
+    #[serde(rename = "timeout", default = "default_query_timeout")]
+    pub timeout: Option<f32>,
     /// select events past the specified point in time
     #[serde(rename = "afterTimestamp")]
     pub after_timestamp: DateTime<Utc>,

--- a/core/activity/src/provider/mod.rs
+++ b/core/activity/src/provider/mod.rs
@@ -48,7 +48,7 @@ async fn get_events(
             query.after_timestamp,
             query.max_events,
         )
-        .timeout(query.poll_timeout)
+        .timeout(query.timeout)
         .await??
         .into_iter()
         .collect::<Vec<ProviderEvent>>();

--- a/core/payment/src/api/debit_notes.rs
+++ b/core/payment/src/api/debit_notes.rs
@@ -100,7 +100,7 @@ async fn get_debit_note_events(
     id: Identity,
 ) -> HttpResponse {
     let node_id = id.identity;
-    let timeout_secs = query.poll_timeout.unwrap_or(params::DEFAULT_EVENT_TIMEOUT);
+    let timeout_secs = query.timeout.unwrap_or(params::DEFAULT_EVENT_TIMEOUT);
     let after_timestamp = query.after_timestamp.map(|d| d.naive_utc());
     let max_events = query.max_events;
     let app_session_id = &query.app_session_id;

--- a/core/payment/src/api/invoices.rs
+++ b/core/payment/src/api/invoices.rs
@@ -86,7 +86,7 @@ async fn get_invoice_events(
     id: Identity,
 ) -> HttpResponse {
     let node_id = id.identity;
-    let timeout_secs = query.poll_timeout.unwrap_or(params::DEFAULT_EVENT_TIMEOUT);
+    let timeout_secs = query.timeout.unwrap_or(params::DEFAULT_EVENT_TIMEOUT);
     let after_timestamp = query.after_timestamp.map(|d| d.naive_utc());
     let max_events = query.max_events;
     let app_session_id = &query.app_session_id;

--- a/core/payment/src/api/payments.rs
+++ b/core/payment/src/api/payments.rs
@@ -23,7 +23,7 @@ async fn get_payments(
     id: Identity,
 ) -> HttpResponse {
     let node_id = id.identity;
-    let timeout_secs = query.poll_timeout.unwrap_or(params::DEFAULT_EVENT_TIMEOUT);
+    let timeout_secs = query.timeout.unwrap_or(params::DEFAULT_EVENT_TIMEOUT);
     let after_timestamp = query.after_timestamp.map(|d| d.naive_utc());
     let max_events = query.max_events;
     let app_session_id = &query.app_session_id;


### PR DESCRIPTION
"pollTimeout" does not conform to the spec which makes SDKs unable to properly set a request timeout