### PR TITLE
Review payment example regards to dummy driver

### DIFF
--- a/core/payment/examples/README.md
+++ b/core/payment/examples/README.md
@@ -10,6 +10,26 @@ cp ../../.env-template .env
 ```
 To use ZkSync instead of Dummy driver use `cargo run --example payment_api -- --driver=zksync --platform=zksync-rinkeby-tglm` instead.
 
+
+### Examples
+
+To make sense of the included examples it is important to understand what parameters the example accepts and how they 
+can be used to change payment platform (driver, network, token). We list examples along with their parameters starting 
+from `payment_api` with is required to run any other example with payment platform that matches the `payment_api`'s platform.
+
+| Example             | Parameters                                     | Defaults                                                                                       |
+|---------------------|------------------------------------------------|------------------------------------------------------------------------------------------------|
+| payment_api         | driver, platform                               | driver=`dummy`, platform=`dummy-glm`                                                           |
+| account_ballance    |                                                | Same as `payment_api`                                                                          |
+| cancel_invoice      | driver, network                                | driver=`dummy`, network=None                                                                   |
+| debit_note_flow     | platform                                       | platform=`dummy-glm`                                                                           |
+| get_accounts        | <`provider_addr`><br/>  <`requestor_addr`><br/> platform | `provider_addr` and `requestor_addr` are required  positional parameters. Platform=`dummy-glm` |
+| invoice_flow        | platform                                       | platform=`dummy-glm`                                                                           |
+| market_decoration   |                                                | Same as `payment_api`                                                                          |
+| release_allocation  |                                                | Same as `payment_api`                                                                          |
+| validate_allocation |                                                | Same as `payment_api`                                                                          |
+<!-- Generated with https://www.tablesgenerator.com/markdown_tables -->
+
 ### Debit note flow
 
 To test the whole flow start the API server (see above) and run the debit_note_flow

--- a/core/payment/examples/README.md
+++ b/core/payment/examples/README.md
@@ -6,9 +6,9 @@ To start the API server (both provider & requestor) run the following commands:
 ```shell script
 cd core/payment
 cp ../../.env-template .env
-cargo run --example payment_api
+(rm payment.db* || true) && cargo run --example payment_api
 ```
-To use Erc-20 instead of ZkSync driver us `cargo run --example payment_api -- --driver=erc20 --platform=erc20-rinkeby-tglm` instead.
+To use ZkSync instead of Dummy driver use `cargo run --example payment_api -- --driver=zksync --platform=zksync-rinkeby-tglm` instead.
 
 ### Debit note flow
 

--- a/core/payment/examples/README.md
+++ b/core/payment/examples/README.md
@@ -23,7 +23,7 @@ from `payment_api` with is required to run any other example with payment platfo
 | account_ballance    |                                                | Same as `payment_api`                                                                          |
 | cancel_invoice      | driver, network                                | driver=`dummy`, network=None                                                                   |
 | debit_note_flow     | platform                                       | platform=`dummy-glm`                                                                           |
-| get_accounts        | <`provider_addr`><br/>  <`requestor_addr`><br/> platform | `provider_addr` and `requestor_addr` are required  positional parameters. Platform=`dummy-glm` |
+| get_accounts        | <`provider_addr`><br/>  <`requestor_addr`><br/> platform | `provider_addr` and `requestor_addr` are required,  positional, `0x`-hex-encoded parameters. Platform=`dummy-glm` |
 | invoice_flow        | platform                                       | platform=`dummy-glm`                                                                           |
 | market_decoration   |                                                | Same as `payment_api`                                                                          |
 | release_allocation  |                                                | Same as `payment_api`                                                                          |

--- a/core/payment/examples/account_balance.rs
+++ b/core/payment/examples/account_balance.rs
@@ -26,5 +26,6 @@ async fn main() -> anyhow::Result<()> {
         log::info!("Balance: {:?}", payer_status.amount);
         log::debug!("payer_status: {:?}", payer_status);
     }
+    log::info!(" 👍🏻 Example completed successfully ❤️");
     Ok(())
 }

--- a/core/payment/examples/cancel_invoice.rs
+++ b/core/payment/examples/cancel_invoice.rs
@@ -179,10 +179,12 @@ async fn main() -> anyhow::Result<()> {
     .await?;
 
     log::info!("Creating allocation...");
+    let accounts = requestor.get_requestor_accounts().await?;
+    let account = accounts.first().expect("No account available");
     let allocation = requestor
         .create_allocation(&NewAllocation {
-            address: None,          // Use default address (i.e. identity)
-            payment_platform: None, // Use default payment platform
+            address: Some(account.address.clone()),
+            payment_platform: Some(account.platform.clone()),
             total_amount: BigDecimal::from(10u64),
             timeout: None,
             make_deposit: false,
@@ -226,5 +228,6 @@ async fn main() -> anyhow::Result<()> {
     cancel_result.unwrap_err();
     log::info!("Failed to cancel accepted invoice.");
 
+    log::info!(" 👍🏻 Example completed successfully ❤️");
     Ok(())
 }

--- a/core/payment/examples/debit_note_flow.rs
+++ b/core/payment/examples/debit_note_flow.rs
@@ -189,5 +189,6 @@ async fn main() -> anyhow::Result<()> {
     //     requestor.get_payments_for_debit_note::<Utc>(&debit_note2.debit_note_id, Some(Utc::now()), None).await
     // );
 
+    log::info!(" 👍🏻 Example completed successfully ❤️");
     Ok(())
 }

--- a/core/payment/examples/get_accounts.rs
+++ b/core/payment/examples/get_accounts.rs
@@ -4,7 +4,7 @@ use ya_client::web::{rest_api_url, WebClient};
 
 #[derive(Clone, Debug, StructOpt)]
 struct Args {
-    #[structopt(short, long, default_value = "zksync-rinkeby-tglm")]
+    #[structopt(short, long, default_value = "dummy-glm")]
     platform: String,
     #[structopt()]
     provider_addr: String,

--- a/core/payment/examples/get_accounts.rs
+++ b/core/payment/examples/get_accounts.rs
@@ -49,5 +49,6 @@ async fn main() -> anyhow::Result<()> {
     );
     log::info!("OK.");
 
+    log::info!(" 👍🏻 Example completed successfully ❤️");
     Ok(())
 }

--- a/core/payment/examples/invoice_flow.rs
+++ b/core/payment/examples/invoice_flow.rs
@@ -146,5 +146,6 @@ async fn main() -> anyhow::Result<()> {
         .unwrap();
     log::debug!("events 3: {:?}", &invoice_events_settled);
 
+    log::info!(" 👍🏻 Example completed successfully ❤️");
     Ok(())
 }

--- a/core/payment/examples/market_decoration.rs
+++ b/core/payment/examples/market_decoration.rs
@@ -50,5 +50,6 @@ async fn main() -> anyhow::Result<()> {
     log::info!("Properties: {:?}", decoration.properties);
     log::info!("Constraints: {:?}", decoration.constraints);
 
+    log::info!(" 👍🏻 Example completed successfully ❤️");
     Ok(())
 }

--- a/core/payment/examples/release_allocation.rs
+++ b/core/payment/examples/release_allocation.rs
@@ -23,10 +23,12 @@ async fn main() -> anyhow::Result<()> {
         .interface()?;
 
     log::info!("Creating allocation...");
+    let accounts = requestor.get_requestor_accounts().await?;
+    let account = accounts.first().expect("No account available");
     let allocation = requestor
         .create_allocation(&NewAllocation {
-            address: None,          // Use default address (i.e. identity)
-            payment_platform: None, // Use default payment platform
+            address: Some(account.address.clone()),
+            payment_platform: Some(account.platform.clone()),
             total_amount: BigDecimal::from(10u64),
             timeout: None,
             make_deposit: false,
@@ -86,8 +88,8 @@ async fn main() -> anyhow::Result<()> {
     log::info!("Creating another allocation...");
     let allocation = requestor
         .create_allocation(&NewAllocation {
-            address: None,          // Use default address (i.e. identity)
-            payment_platform: None, // Use default payment platform
+            address: Some(account.address.clone()),
+            payment_platform: Some(account.platform.clone()),
             total_amount: BigDecimal::from(10u64),
             timeout: None,
             make_deposit: false,
@@ -120,5 +122,6 @@ async fn main() -> anyhow::Result<()> {
     assert!(result.is_err());
     log::info!("Done.");
 
+    log::info!(" 👍🏻 Example completed successfully ❤️");
     Ok(())
 }

--- a/core/payment/examples/validate_allocation.rs
+++ b/core/payment/examples/validate_allocation.rs
@@ -42,8 +42,20 @@ async fn main() -> anyhow::Result<()> {
         .interface()?;
 
     let (requestor_balance, payment_platform) = get_requestor_balance_and_platform().await?;
+    log::info!(
+        "Requestor balance: {}, platform: {}",
+        requestor_balance,
+        payment_platform
+    );
+
+    if "dummy-glm" == &payment_platform {
+        log::info!(
+            " 🖐  Example will not work with Dummy driver as it does not validate requests 💛"
+        );
+        return Ok(());
+    }
+
     let payment_platform = Some(payment_platform);
-    log::info!("Requestor balance: {}", requestor_balance);
 
     log::info!("Attempting to create allocation with invalid address...");
     let result = requestor
@@ -102,5 +114,6 @@ async fn main() -> anyhow::Result<()> {
     requestor.create_allocation(&new_allocation).await?;
     log::info!("Allocation created.");
 
+    log::info!(" 👍🏻 Example completed successfully ❤️");
     Ok(())
 }


### PR DESCRIPTION
## Examples reviewed 

| Example | Dummy | ZkSync |
| ------- | ----- | ------ |
| account_ballance | ✔️ | ✔️ |
| cancel_invoice | ✔️ | ✔️ |
| debit_note_flow | ️[fails on this unwrap](https://github.com/golemfactory/yagna/blob/c40b190db0dded0abfd574c921d029ad95a535d3/core/payment/src/processor.rs#L364) | ✔️ |
| get_accounts | ✔️ | |
| invoice_flow | ✔️ | ✔️ |
| market_decoration | ✔️ | ✔️ |
| release_allocation | ✔️ | ✔️ |
| validate_allocation | ✔️ | ✔️ |

## ⚠️  Drawbacks
- cancel_invoice accepts `driver` & `network` parameters while *_flows `platform` parameter.
<ins>**UPDATE:**</ins> Discussed that example are meant to be straigh-forward, do not complicate it with boilerplate argument manipulation

- one cannot tell what parameter (and if any) particular example accepts
<ins>**UPDATE:**</ins> I will prepare a table in the `README` describing the arguments (default + rinkeby)

Added (log) info message that communicates the result of invocation clearly

```
[2021-03-05T12:45:08Z INFO  release_allocation]  👍 Example completed successfully ❤️

[2021-03-05T12:48:33Z INFO  validate_allocation]  🖐  Example will not work with Dummy driver as it does not validate requests 💛
```

