### PR TITLE
Payment service: fixed race condition in PaymentProcessor

### DIFF
--- a/core/payment/src/service.rs
+++ b/core/payment/src/service.rs
@@ -1,6 +1,8 @@
 use crate::processor::PaymentProcessor;
+use futures::lock::Mutex;
 use futures::prelude::*;
 use metrics::counter;
+use std::sync::Arc;
 use ya_core_model as core;
 use ya_persistence::executor::DbExecutor;
 use ya_service_bus::typed::ServiceBinder;
@@ -8,6 +10,7 @@ use ya_service_bus::typed::ServiceBinder;
 pub fn bind_service(db: &DbExecutor, processor: PaymentProcessor) {
     log::debug!("Binding payment service to service bus");
 
+    let processor = Arc::new(Mutex::new(processor));
     local::bind_service(db, processor.clone());
     public::bind_service(db, processor);
 
@@ -22,7 +25,7 @@ mod local {
     use ya_core_model::payment::local::*;
     use ya_persistence::types::Role;
 
-    pub fn bind_service(db: &DbExecutor, processor: PaymentProcessor) {
+    pub fn bind_service(db: &DbExecutor, processor: Arc<Mutex<PaymentProcessor>>) {
         log::debug!("Binding payment local service to service bus");
 
         ServiceBinder::new(BUS_ID, db, processor)
@@ -68,74 +71,74 @@ mod local {
 
     async fn schedule_payment(
         db: DbExecutor,
-        processor: PaymentProcessor,
+        processor: Arc<Mutex<PaymentProcessor>>,
         sender: String,
         msg: SchedulePayment,
     ) -> Result<(), GenericError> {
-        processor.schedule_payment(msg).await?;
+        processor.lock().await.schedule_payment(msg).await?;
         Ok(())
     }
 
     async fn register_driver(
         db: DbExecutor,
-        processor: PaymentProcessor,
+        processor: Arc<Mutex<PaymentProcessor>>,
         sender: String,
         msg: RegisterDriver,
     ) -> Result<(), RegisterDriverError> {
-        processor.register_driver(msg).await
+        processor.lock().await.register_driver(msg).await
     }
 
     async fn unregister_driver(
         db: DbExecutor,
-        processor: PaymentProcessor,
+        processor: Arc<Mutex<PaymentProcessor>>,
         sender: String,
         msg: UnregisterDriver,
     ) -> Result<(), NoError> {
-        processor.unregister_driver(msg).await;
+        processor.lock().await.unregister_driver(msg).await;
         Ok(())
     }
 
     async fn register_account(
         db: DbExecutor,
-        processor: PaymentProcessor,
+        processor: Arc<Mutex<PaymentProcessor>>,
         sender: String,
         msg: RegisterAccount,
     ) -> Result<(), RegisterAccountError> {
-        processor.register_account(msg).await
+        processor.lock().await.register_account(msg).await
     }
 
     async fn unregister_account(
         db: DbExecutor,
-        processor: PaymentProcessor,
+        processor: Arc<Mutex<PaymentProcessor>>,
         sender: String,
         msg: UnregisterAccount,
     ) -> Result<(), NoError> {
-        processor.unregister_account(msg).await;
+        processor.lock().await.unregister_account(msg).await;
         Ok(())
     }
 
     async fn get_accounts(
         db: DbExecutor,
-        processor: PaymentProcessor,
+        processor: Arc<Mutex<PaymentProcessor>>,
         sender: String,
         msg: GetAccounts,
     ) -> Result<Vec<Account>, GenericError> {
-        Ok(processor.get_accounts().await)
+        Ok(processor.lock().await.get_accounts().await)
     }
 
     async fn notify_payment(
         db: DbExecutor,
-        processor: PaymentProcessor,
+        processor: Arc<Mutex<PaymentProcessor>>,
         sender: String,
         msg: NotifyPayment,
     ) -> Result<(), GenericError> {
-        processor.notify_payment(msg).await?;
+        processor.lock().await.notify_payment(msg).await?;
         Ok(())
     }
 
     async fn get_status(
         db: DbExecutor,
-        processor: PaymentProcessor,
+        processor: Arc<Mutex<PaymentProcessor>>,
         _caller: String,
         msg: GetStatus,
     ) -> Result<StatusResult, GenericError> {
@@ -148,6 +151,8 @@ mod local {
         } = msg;
 
         let (network, network_details) = processor
+            .lock()
+            .await
             .get_network(driver.clone(), network)
             .await
             .map_err(GenericError::new)?;
@@ -183,9 +188,14 @@ mod local {
         }
         .map_err(GenericError::new);
 
-        let amount_fut = processor
-            .get_status(platform.clone(), address.clone())
-            .map_err(GenericError::new);
+        let amount_fut = async {
+            processor
+                .lock()
+                .await
+                .get_status(platform.clone(), address.clone())
+                .await
+        }
+        .map_err(GenericError::new);
 
         let (incoming, outgoing, amount, reserved) =
             future::try_join4(incoming_fut, outgoing_fut, amount_fut, reserved_fut).await?;
@@ -203,7 +213,7 @@ mod local {
 
     async fn get_invoice_stats(
         db: DbExecutor,
-        processor: PaymentProcessor,
+        processor: Arc<Mutex<PaymentProcessor>>,
         _caller: String,
         msg: GetInvoiceStats,
     ) -> Result<InvoiceStats, GenericError> {
@@ -255,11 +265,13 @@ mod local {
 
     async fn validate_allocation(
         db: DbExecutor,
-        processor: PaymentProcessor,
+        processor: Arc<Mutex<PaymentProcessor>>,
         sender: String,
         msg: ValidateAllocation,
     ) -> Result<bool, ValidateAllocationError> {
         Ok(processor
+            .lock()
+            .await
             .validate_allocation(msg.platform, msg.address, msg.amount)
             .await?)
     }
@@ -277,7 +289,7 @@ mod public {
     use ya_core_model::payment::public::*;
     use ya_persistence::types::Role;
 
-    pub fn bind_service(db: &DbExecutor, processor: PaymentProcessor) {
+    pub fn bind_service(db: &DbExecutor, processor: Arc<Mutex<PaymentProcessor>>) {
         log::debug!("Binding payment public service to service bus");
 
         ServiceBinder::new(BUS_ID, db, processor)
@@ -591,7 +603,7 @@ mod public {
 
     async fn send_payment(
         db: DbExecutor,
-        processor: PaymentProcessor,
+        processor: Arc<Mutex<PaymentProcessor>>,
         sender_id: String,
         msg: SendPayment,
     ) -> Result<Ack, SendError> {
@@ -604,7 +616,12 @@ mod public {
         let platform = payment.payment_platform.clone();
         let amount = payment.amount.clone();
         let num_paid_invoices = payment.agreement_payments.len() as u64;
-        match processor.verify_payment(payment, signature).await {
+        match processor
+            .lock()
+            .await
+            .verify_payment(payment, signature)
+            .await
+        {
             Ok(_) => {
                 counter!("payment.amount.received", ya_metrics::utils::cryptocurrency_to_u64(&amount), "platform" => platform);
                 counter!("payment.invoices.provider.paid", num_paid_invoices);


### PR DESCRIPTION
If `NotifyPayment` got called during processing of `SchedulePayment` (which happened when running `debit_note_flow` example with dummy driver) it would fail because the payment order had not been saved in the database yet.

To avoid this race condition (and possibly others) `PaymentProcessor` has been wrapped in a mutex. This allowed to remove the mutex from `DriverRegistry`. Also, sending `SendPayment` message needs to be done via `Arbiter::spawn` now to avoid deadlock in case it is sent to the same node.

---
Testing instructions: Run `debit_note_flow` with dummy driver. (A few times preferably)