### PR TITLE
Remove poetry virtual env at the end of the CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -197,6 +197,6 @@ jobs:
       - name: Remove poetry virtual env
         if: always()
         # Python version below should agree with the version set up by this job.
-        # In future we'll be able to use the `--all` flag here to remove envs for
+        # In the future we'll be able to use the `--all` flag here to remove envs for
         # all Python versions (https://github.com/python-poetry/poetry/issues/3208).
         run: poetry env remove python3.8

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -192,3 +192,11 @@ jobs:
       - name: Remove test logs
         if: always()
         run: rm -rf /tmp/goth-tests
+
+      # Only relevant for self-hosted runners
+      - name: Remove poetry virtual env
+        if: always()
+        # Python version below should agree with the version set up by this job.
+        # In future we'll be able to use the `--all` flag here to remove envs for
+        # all Python versions (https://github.com/python-poetry/poetry/issues/3208).
+        run: poetry env remove python3.8


### PR DESCRIPTION
This PR adds a step that removes the virtual environment created by poetry to the CI workflow. This ensures that a virtual environment created by a run of that workflow will not be re-used by subsequent runs.

This is a port of a PR for `golemfactory/goth`: https://github.com/golemfactory/goth/pull/449