### PR TITLE
Let golemsp wait for 15s before killing yagna

### DIFF
--- a/golem_cli/src/service.rs
+++ b/golem_cli/src/service.rs
@@ -40,7 +40,8 @@ impl AbortableChild {
                 let pid = child.id() as i32;
                 let _ret = ::nix::sys::signal::kill(Pid::from_raw(pid), SIGTERM);
             }
-            match future::select(tokio::time::delay_for(Duration::from_secs(2)), child).await {
+            // Yagna service should get ~10 seconds to clean up
+            match future::select(tokio::time::delay_for(Duration::from_secs(15)), child).await {
                 future::Either::Left((_, mut child)) => {
                     child.kill()?;
                     child.await


### PR DESCRIPTION
I noticed the yagna service does not get enough time to clean up

Resolves:
```
[2021-03-31T17:28:56Z WARN  ya_sb_router::unix] GSB socket already exists and will be removed. path=/tmp/yagna.sock
```