### PR TITLE
Set a default timeout value for `/activity/{activity_id}/exec/{batch_id}`

### DIFF
--- a/core/activity/src/common.rs
+++ b/core/activity/src/common.rs
@@ -34,7 +34,7 @@ pub struct QueryTimeout {
 
 #[derive(Deserialize)]
 pub struct QueryTimeoutCommandIndex {
-    #[serde(rename = "timeout")]
+    #[serde(rename = "timeout", default = "default_query_timeout")]
     pub timeout: Option<f32>,
     #[serde(rename = "commandIndex")]
     pub command_index: Option<usize>,


### PR DESCRIPTION
This PR is a draft awaiting the spec compatiblity update in  `ya*api`.

The timeout value is set to 5s (https://github.com/golemfactory/ya-client/blob/master/specs/activity-api.yaml#L185)