### PR TITLE
Fix git_tag() to properly match pre-rel tags

### DIFF
--- a/utils/compile-time-utils/src/lib.rs
+++ b/utils/compile-time-utils/src/lib.rs
@@ -9,7 +9,7 @@ pub fn git_tag() -> &'static str {
             "--tag",
             "--abbrev=0",
             "--match=v[0-9]*",
-            "--match=pre-rel-[0-9]*"
+            "--match=pre-rel-v[0-9]*"
         ],
         cargo_prefix = ""
     )


### PR DESCRIPTION
fixes: #1239 