### PR TITLE
[Mkt] Discovery Builder fix + macOS build speedup + tests refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,3 +201,8 @@ ya-utils-process = { path = "utils/process"}
 ya-diesel-utils = { path = "utils/diesel-utils"}
 ya-metrics = { path = "core/metrics" }
 ya-provider = { path = "agent/provider"}
+
+# Speed up builds on macOS (will be default in next rust version probably)
+# https://jakedeichert.com/blog/reducing-rust-incremental-compilation-times-on-macos-by-70-percent/
+[profile.dev]
+split-debuginfo = "unpacked"

--- a/core/market/src/config.rs
+++ b/core/market/src/config.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 use structopt::StructOpt;
 
-#[derive(Default, StructOpt)]
+#[derive(StructOpt, Clone)]
+#[cfg_attr(feature = "testing", derive(Default))]
 pub struct Config {
     #[structopt(flatten)]
     pub discovery: DiscoveryConfig,
@@ -27,10 +28,12 @@ pub struct DiscoveryConfig {
     pub unsub_broadcast_time: Duration,
 }
 
+#[derive(Clone)]
 pub struct SubscriptionConfig {
     pub default_ttl: chrono::Duration,
 }
 
+#[derive(Clone)]
 pub struct EventsConfig {
     pub max_events_default: i32,
     pub max_events_max: i32,
@@ -45,6 +48,7 @@ impl Config {
 }
 
 // This default implementation will be used only in tests.
+#[cfg(feature = "testing")]
 impl Default for DiscoveryConfig {
     fn default() -> Self {
         DiscoveryConfig {

--- a/core/market/src/config.rs
+++ b/core/market/src/config.rs
@@ -2,7 +2,6 @@ use std::time::Duration;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Clone)]
-#[cfg_attr(feature = "testing", derive(Default))]
 pub struct Config {
     #[structopt(flatten)]
     pub discovery: DiscoveryConfig,
@@ -23,9 +22,9 @@ pub struct DiscoveryConfig {
     #[structopt(env, parse(try_from_str = humantime::parse_duration), default_value = "4min")]
     pub mean_cyclic_unsubscribes_interval: Duration,
     #[structopt(env, parse(try_from_str = humantime::parse_duration), default_value = "5sec")]
-    pub offer_broadcast_time: Duration,
+    pub offer_rebroadcast_delay: Duration,
     #[structopt(env, parse(try_from_str = humantime::parse_duration), default_value = "5sec")]
-    pub unsub_broadcast_time: Duration,
+    pub unsub_rebroadcast_delay: Duration,
 }
 
 #[derive(Clone)]
@@ -44,21 +43,6 @@ impl Config {
         // Mock command line arguments, because we want to use ENV fallback
         // or default values if ENV variables don't exist.
         Ok(Config::from_iter_safe(vec!["yagna"].iter())?)
-    }
-}
-
-// This default implementation will be used only in tests.
-#[cfg(feature = "testing")]
-impl Default for DiscoveryConfig {
-    fn default() -> Self {
-        DiscoveryConfig {
-            max_bcasted_offers: 200,
-            max_bcasted_unsubscribes: 200,
-            mean_cyclic_bcast_interval: Duration::from_secs(60),
-            mean_cyclic_unsubscribes_interval: Duration::from_secs(60),
-            offer_broadcast_time: Duration::from_secs(1),
-            unsub_broadcast_time: Duration::from_secs(1),
-        }
     }
 }
 

--- a/core/market/src/config.rs
+++ b/core/market/src/config.rs
@@ -27,8 +27,9 @@ pub struct DiscoveryConfig {
     pub unsub_rebroadcast_delay: Duration,
 }
 
-#[derive(Clone)]
+#[derive(StructOpt, Clone)]
 pub struct SubscriptionConfig {
+    #[structopt(env = "DEFAULT_SUBSCRIPTION_TTL", parse(try_from_str = parse_chrono_duration), default_value = "1h")]
     pub default_ttl: chrono::Duration,
 }
 
@@ -61,4 +62,8 @@ impl Default for EventsConfig {
             max_events_max: 100,
         }
     }
+}
+
+fn parse_chrono_duration(s: &str) -> Result<chrono::Duration, anyhow::Error> {
+    Ok(chrono::Duration::from_std(humantime::parse_duration(s)?)?)
 }

--- a/core/market/src/matcher.rs
+++ b/core/market/src/matcher.rs
@@ -59,7 +59,8 @@ impl Matcher {
             .add_data_handler(handlers::receive_remote_offers)
             .add_data_handler(handlers::get_local_offers)
             .add_data_handler(handlers::receive_remote_offer_unsubscribes)
-            .build(config.discovery.clone());
+            .with_config(config.discovery.clone())
+            .build();
 
         let matcher = Matcher {
             store,

--- a/core/market/src/protocol/discovery.rs
+++ b/core/market/src/protocol/discovery.rs
@@ -41,8 +41,6 @@ pub(super) struct OfferHandlers {
 }
 
 pub struct DiscoveryImpl {
-    config: DiscoveryConfig,
-
     identity: Arc<dyn IdentityApi>,
 
     offer_queue: Mutex<Vec<SubscriptionId>>,
@@ -51,6 +49,8 @@ pub struct DiscoveryImpl {
     offer_handlers: Mutex<OfferHandlers>,
     get_local_offers_handler: HandlerSlot<RetrieveOffers>,
     offer_unsubscribe_handler: HandlerSlot<UnsubscribedOffersBcast>,
+
+    config: DiscoveryConfig,
 }
 
 impl Discovery {

--- a/core/market/src/protocol/discovery.rs
+++ b/core/market/src/protocol/discovery.rs
@@ -76,7 +76,7 @@ impl Discovery {
             let myself = self.clone();
             let _ = Arbiter::spawn(async move {
                 // Sleep to collect multiple offers to send
-                delay_for(myself.inner.config.offer_broadcast_time).await;
+                delay_for(myself.inner.config.offer_rebroadcast_delay).await;
                 myself.send_bcast_offers().await;
             });
         }
@@ -172,7 +172,7 @@ impl Discovery {
             let myself = self.clone();
             let _ = Arbiter::spawn(async move {
                 // Sleep to collect multiple unsubscribes to send
-                delay_for(myself.inner.config.unsub_broadcast_time).await;
+                delay_for(myself.inner.config.unsub_rebroadcast_delay).await;
                 myself.send_bcast_unsubscribes().await;
             });
         }

--- a/core/market/src/protocol/discovery/builder.rs
+++ b/core/market/src/protocol/discovery/builder.rs
@@ -10,10 +10,11 @@ use super::{Discovery, DiscoveryImpl};
 use crate::config::DiscoveryConfig;
 use crate::protocol::discovery::OfferHandlers;
 
-#[derive(Default)]
+#[cfg_attr(feature = "testing", derive(Default))]
 pub struct DiscoveryBuilder {
     data: HashMap<TypeId, Box<dyn Any>>,
     handlers: HashMap<TypeId, Box<dyn Any>>,
+    config: DiscoveryConfig,
 }
 
 impl DiscoveryBuilder {
@@ -58,20 +59,26 @@ impl DiscoveryBuilder {
         data.clone()
     }
 
-    pub fn build(mut self, config: DiscoveryConfig) -> Discovery {
+    pub fn with_config(mut self, config: DiscoveryConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    pub fn build(mut self) -> Discovery {
         let offer_handlers = Mutex::new(OfferHandlers {
             filter_out_known_ids: self.get_handler(),
             receive_remote_offers: self.get_handler(),
         });
+
         Discovery {
             inner: Arc::new(DiscoveryImpl {
-                config,
                 identity: self.get_data(),
                 offer_handlers,
                 offer_queue: Mutex::new(vec![]),
                 unsub_queue: Mutex::new(vec![]),
                 get_local_offers_handler: self.get_handler(),
                 offer_unsubscribe_handler: self.get_handler(),
+                config: self.config,
             }),
         }
     }

--- a/core/market/src/protocol/discovery/builder.rs
+++ b/core/market/src/protocol/discovery/builder.rs
@@ -106,6 +106,7 @@ mod test {
 
     use crate::testing::mock_identity::{generate_identity, MockIdentity};
     use crate::testing::mock_offer::sample_retrieve_offers;
+    use crate::testing::Config;
 
     use super::super::*;
     use super::*;
@@ -152,6 +153,7 @@ mod test {
             .add_handler(|_, _: UnsubscribedOffersBcast| async { Ok(vec![]) })
             .add_handler(|_, _: OffersBcast| async { Ok(vec![]) })
             .add_handler(|_, _: RetrieveOffers| async { Ok(vec![]) })
+            .with_config(Config::from_env().unwrap().discovery)
             .build();
     }
 
@@ -164,6 +166,7 @@ mod test {
             .add_data_handler(|_: &str, _, _: UnsubscribedOffersBcast| async { Ok(vec![]) })
             .add_handler(|_, _: OffersBcast| async { Ok(vec![]) })
             .add_data_handler(|_: &str, _, _: RetrieveOffers| async { Ok(vec![]) })
+            .with_config(Config::from_env().unwrap().discovery)
             .build();
     }
 
@@ -189,6 +192,7 @@ mod test {
                 }
             })
             .add_handler(|_, _: OffersBcast| async { Ok(vec![]) })
+            .with_config(Config::from_env().unwrap().discovery)
             .build();
 
         assert_eq!(0, counter.load(SeqCst));

--- a/core/market/src/protocol/discovery/builder.rs
+++ b/core/market/src/protocol/discovery/builder.rs
@@ -10,11 +10,11 @@ use super::{Discovery, DiscoveryImpl};
 use crate::config::DiscoveryConfig;
 use crate::protocol::discovery::OfferHandlers;
 
-#[cfg_attr(feature = "testing", derive(Default))]
+#[derive(Default)]
 pub struct DiscoveryBuilder {
     data: HashMap<TypeId, Box<dyn Any>>,
     handlers: HashMap<TypeId, Box<dyn Any>>,
-    config: DiscoveryConfig,
+    config: Option<DiscoveryConfig>,
 }
 
 impl DiscoveryBuilder {
@@ -60,7 +60,7 @@ impl DiscoveryBuilder {
     }
 
     pub fn with_config(mut self, config: DiscoveryConfig) -> Self {
-        self.config = config;
+        self.config = Some(config);
         self
     }
 
@@ -78,7 +78,7 @@ impl DiscoveryBuilder {
                 unsub_queue: Mutex::new(vec![]),
                 get_local_offers_handler: self.get_handler(),
                 offer_unsubscribe_handler: self.get_handler(),
-                config: self.config,
+                config: self.config.unwrap(),
             }),
         }
     }

--- a/core/market/src/testing/bcast.rs
+++ b/core/market/src/testing/bcast.rs
@@ -5,13 +5,9 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::time::Duration;
 
 use ya_client::model::NodeId;
 use ya_core_model::net;
-
-use super::{MarketServiceExt, QueryOfferError, SubscriptionId};
-use crate::MarketService;
 
 pub mod singleton;
 
@@ -50,66 +46,4 @@ impl BCast for BCastService {
             .map(|receivers| receivers.iter().map(|endpoint| endpoint.clone()).collect())
             .unwrap_or_default()
     }
-}
-
-/// Assure that all given nodes have the same knowledge about given Subscriptions (Offers).
-/// Wait if needed at most 1,5s ( = 10 x 150ms).
-pub async fn assert_offers_broadcasted<'a, S>(mkts: &[&MarketService], subscriptions: S)
-where
-    S: IntoIterator<Item = &'a SubscriptionId>,
-    <S as IntoIterator>::IntoIter: Clone,
-{
-    let subscriptions = subscriptions.into_iter();
-    let mut all_broadcasted = false;
-    'retry: for _i in 0..10 {
-        for subscription in subscriptions.clone() {
-            for mkt in mkts {
-                if mkt.get_offer(&subscription).await.is_err() {
-                    // Every 150ms we should get at least one broadcast from each Node.
-                    // After a few tries all nodes should have the same knowledge about Offers.
-                    tokio::time::delay_for(Duration::from_millis(150)).await;
-                    continue 'retry;
-                }
-            }
-        }
-        all_broadcasted = true;
-        break;
-    }
-    assert!(
-        all_broadcasted,
-        "At least one of the offers was not propagated to all nodes"
-    );
-}
-
-/// Assure that all given nodes have the same knowledge about given Subscriptions (Offers).
-/// Wait if needed at most 1,5s ( = 10 x 150ms).
-pub async fn assert_unsunbscribes_broadcasted<'a, S>(mkts: &[&MarketService], subscriptions: S)
-where
-    S: IntoIterator<Item = &'a SubscriptionId>,
-    <S as IntoIterator>::IntoIter: Clone,
-{
-    let subscriptions = subscriptions.into_iter();
-    let mut all_broadcasted = false;
-    'retry: for _i in 0..10 {
-        for subscription in subscriptions.clone() {
-            for mkt in mkts {
-                let expect_error = QueryOfferError::Unsubscribed(subscription.clone()).to_string();
-                match mkt.get_offer(&subscription).await {
-                    Err(e) => assert_eq!(e.to_string(), expect_error),
-                    Ok(_) => {
-                        // Every 150ms we should get at least one broadcast from each Node.
-                        // After a few tries all nodes should have the same knowledge about Offers.
-                        tokio::time::delay_for(Duration::from_millis(150)).await;
-                        continue 'retry;
-                    }
-                }
-            }
-        }
-        all_broadcasted = true;
-        break;
-    }
-    assert!(
-        all_broadcasted,
-        "At least one of the offer unsubscribes was not propagated to all nodes"
-    );
 }

--- a/core/market/src/testing/mock_node.rs
+++ b/core/market/src/testing/mock_node.rs
@@ -221,8 +221,9 @@ impl MarketsNetwork {
             .await
     }
 
-    pub fn discovery_builder() -> DiscoveryBuilder {
+    pub fn discovery_builder(&self) -> DiscoveryBuilder {
         DiscoveryBuilder::default()
+            .with_config(self.config.discovery.clone())
             .add_handler(empty_on_offers_retrieved)
             .add_handler(empty_on_offers_bcast)
             .add_handler(empty_on_offer_unsubscribed_bcast)

--- a/core/market/tests/test_cyclic_broadcasts.rs
+++ b/core/market/tests/test_cyclic_broadcasts.rs
@@ -4,9 +4,11 @@ use std::time::Duration;
 
 use ya_market::assert_err_eq;
 use ya_market::testing::{
-    bcast::{assert_offers_broadcasted, assert_unsunbscribes_broadcasted},
+    mock_node::{
+        assert_offers_broadcasted, assert_unsunbscribes_broadcasted, create_market_config_for_test,
+    },
     mock_offer::client,
-    Config, MarketServiceExt, MarketsNetwork, QueryOfferError,
+    MarketServiceExt, MarketsNetwork, QueryOfferError,
 };
 
 /// Initialize two markets and add Offers.
@@ -17,14 +19,8 @@ use ya_market::testing::{
 async fn test_startup_offers_sharing() {
     let _ = env_logger::builder().try_init();
 
-    // Change expected time of sending broadcasts.
-    let mut config = Config::default();
-    config.discovery.mean_cyclic_bcast_interval = Duration::from_millis(100);
-    config.discovery.max_bcasted_offers = 7;
-
     let network = MarketsNetwork::new(None)
         .await
-        .with_config(Arc::new(config))
         .add_market_instance("Node-1")
         .await
         .add_market_instance("Node-2")
@@ -76,16 +72,8 @@ async fn test_startup_offers_sharing() {
 async fn test_unsubscribes_cyclic_broadcasts() {
     let _ = env_logger::builder().try_init();
 
-    // Change expected time of sending broadcasts.
-    let mut config = Config::default();
-    config.discovery.mean_cyclic_bcast_interval = Duration::from_millis(100);
-    config.discovery.mean_cyclic_unsubscribes_interval = Duration::from_millis(100);
-    config.discovery.max_bcasted_offers = 70;
-    config.discovery.max_bcasted_unsubscribes = 70;
-
     let network = MarketsNetwork::new(None)
         .await
-        .with_config(Arc::new(config))
         .add_market_instance("Node-1")
         .await
         .add_market_instance("Node-2")
@@ -213,14 +201,8 @@ async fn test_network_error_while_subscribing() {
 async fn test_sharing_someones_else_offers() {
     let _ = env_logger::builder().try_init();
 
-    // Change expected time of sending broadcasts.
-    let mut config = Config::default();
-    config.discovery.mean_cyclic_bcast_interval = Duration::from_millis(100);
-    config.discovery.max_bcasted_offers = 7;
-
     let network = MarketsNetwork::new(None)
         .await
-        .with_config(Arc::new(config))
         .add_market_instance("Node-1")
         .await
         .add_market_instance("Node-2")
@@ -272,16 +254,8 @@ async fn test_sharing_someones_else_offers() {
 async fn test_sharing_someones_else_unsubscribes() {
     let _ = env_logger::builder().try_init();
 
-    // Change expected time of sending broadcasts.
-    let mut config = Config::default();
-    config.discovery.mean_cyclic_bcast_interval = Duration::from_millis(100);
-    config.discovery.mean_cyclic_unsubscribes_interval = Duration::from_millis(100);
-    config.discovery.max_bcasted_offers = 7;
-    config.discovery.max_bcasted_unsubscribes = 7;
-
     let network = MarketsNetwork::new(None)
         .await
-        .with_config(Arc::new(config))
         .add_market_instance("Node-1")
         .await
         .add_market_instance("Node-2")

--- a/core/market/tests/test_cyclic_broadcasts.rs
+++ b/core/market/tests/test_cyclic_broadcasts.rs
@@ -1,12 +1,9 @@
 use rand::seq::SliceRandom;
-use std::sync::Arc;
 use std::time::Duration;
 
 use ya_market::assert_err_eq;
 use ya_market::testing::{
-    mock_node::{
-        assert_offers_broadcasted, assert_unsunbscribes_broadcasted, create_market_config_for_test,
-    },
+    mock_node::{assert_offers_broadcasted, assert_unsunbscribes_broadcasted},
     mock_offer::client,
     MarketServiceExt, MarketsNetwork, QueryOfferError,
 };

--- a/core/market/tests/test_negotiations.rs
+++ b/core/market/tests/test_negotiations.rs
@@ -1,7 +1,7 @@
 use ya_client::model::market::{proposal::State, RequestorEvent};
 use ya_market::testing::{
-    bcast::assert_offers_broadcasted,
     events_helper::{provider, requestor, ClientProposalHelper},
+    mock_node::assert_offers_broadcasted,
     mock_offer::client::{not_matching_demand, not_matching_offer, sample_demand, sample_offer},
     negotiation::error::{CounterProposalError, RemoteProposalError},
     proposal_util::{exchange_draft_proposals, NegotiationHelper},

--- a/core/market/tests/test_proposal.rs
+++ b/core/market/tests/test_proposal.rs
@@ -1,5 +1,5 @@
 use ya_market::testing::{
-    bcast::assert_offers_broadcasted,
+    mock_node::assert_offers_broadcasted,
     mock_offer::client::{sample_demand, sample_offer},
     proposal_util::exchange_draft_proposals,
     GetProposalError, MarketServiceExt, MarketsNetwork, Owner, ProposalError,

--- a/core/market/tests/test_proposal.rs
+++ b/core/market/tests/test_proposal.rs
@@ -1,10 +1,12 @@
-use ya_market::assert_err_eq;
-use ya_market::testing::mock_offer::client::{sample_demand, sample_offer};
-use ya_market::testing::proposal_util::exchange_draft_proposals;
 use ya_market::testing::{
+    bcast::assert_offers_broadcasted,
+    mock_offer::client::{sample_demand, sample_offer},
+    proposal_util::exchange_draft_proposals,
     GetProposalError, MarketServiceExt, MarketsNetwork, Owner, ProposalError,
 };
+use ya_market::{assert_err_eq, MarketService};
 
+use std::sync::Arc;
 use tokio::time::Duration;
 use ya_client::model::market::proposal::State;
 use ya_client::model::market::RequestorEvent;
@@ -112,9 +114,11 @@ async fn test_proposal_random_shuffle() {
     // will be propagated and added to queue in order.
     let mut offers = vec![];
     let mut ids = vec![];
+    let mut markets: Vec<Arc<MarketService>> = vec![];
     for i in 0..num {
         let node_name = format!("Provider-{}", i);
         let market = network.get_market(&node_name);
+        markets.push(market.clone());
         let identity = network.get_default_id(&node_name);
 
         offers.push(
@@ -127,6 +131,9 @@ async fn test_proposal_random_shuffle() {
 
         tokio::time::delay_for(Duration::from_millis(200)).await;
     }
+
+    let markets: Vec<&MarketService> = markets.iter().map(|m| m.as_ref()).collect();
+    assert_offers_broadcasted(&markets[..], offers.iter()).await;
 
     let events = market1
         .query_events(&demand_id, 1.2, Some(num + 4))

--- a/core/market/tests/test_resolver.rs
+++ b/core/market/tests/test_resolver.rs
@@ -26,7 +26,7 @@ async fn test_single_not_resolve_offer() {
 
     // then
     let listener = network.get_event_listeners("Node-1");
-    assert!(timeout1s(listener.proposal_receiver.recv()).await.is_err());
+    assert!(timeout3s(listener.proposal_receiver.recv()).await.is_err());
 }
 
 /// Test adds Offer and Demand. Resolver should emit Proposal on Demand node.
@@ -60,7 +60,7 @@ async fn test_resolve_offer_demand() {
 
     // then: It should be resolved on Requestor
     let listener = network.get_event_listeners("Requestor-1");
-    let proposal = timeout1s(listener.proposal_receiver.recv())
+    let proposal = timeout3s(listener.proposal_receiver.recv())
         .await
         .unwrap()
         .unwrap();
@@ -69,7 +69,7 @@ async fn test_resolve_offer_demand() {
 
     // and: but not resolved on Provider.
     let listener = network.get_event_listeners("Provider-1");
-    assert!(timeout1s(listener.proposal_receiver.recv()).await.is_err());
+    assert!(timeout3s(listener.proposal_receiver.recv()).await.is_err());
 }
 
 /// Test adds Demand on single node. Resolver should not emit Proposal.
@@ -92,7 +92,7 @@ async fn test_single_not_resolve_demand() {
 
     // then
     let listener = network.get_event_listeners("Node-1");
-    assert!(timeout1s(listener.proposal_receiver.recv()).await.is_err());
+    assert!(timeout3s(listener.proposal_receiver.recv()).await.is_err());
 }
 
 /// Test adds Offer on two nodes and Demand third. Resolver should emit two Proposals on Demand node.
@@ -135,11 +135,11 @@ async fn test_resolve_2xoffer_demand() {
 
     // then: It should be resolved on Requestor two times
     let listener = network.get_event_listeners("Requestor-1");
-    let proposal1 = timeout1s(listener.proposal_receiver.recv())
+    let proposal1 = timeout3s(listener.proposal_receiver.recv())
         .await
         .unwrap()
         .unwrap();
-    let proposal2 = timeout1s(listener.proposal_receiver.recv())
+    let proposal2 = timeout3s(listener.proposal_receiver.recv())
         .await
         .unwrap()
         .unwrap();
@@ -155,12 +155,12 @@ async fn test_resolve_2xoffer_demand() {
 
     // and: but not resolved on Provider-1
     let listener = network.get_event_listeners("Provider-1");
-    assert!(timeout1s(listener.proposal_receiver.recv()).await.is_err());
+    assert!(timeout3s(listener.proposal_receiver.recv()).await.is_err());
     // and: not on Provider-2.
     let listener = network.get_event_listeners("Provider-2");
-    assert!(timeout1s(listener.proposal_receiver.recv()).await.is_err());
+    assert!(timeout3s(listener.proposal_receiver.recv()).await.is_err());
 }
 
-fn timeout1s<T: Future>(fut: T) -> Timeout<T> {
-    timeout(Duration::from_secs(1), fut)
+fn timeout3s<T: Future>(fut: T) -> Timeout<T> {
+    timeout(Duration::from_secs(3), fut)
 }


### PR DESCRIPTION
@maaktweluit your branch [/market/mwu/queue-bcast](https://github.com/golemfactory/yagna/tree/market/mwu/queue-bcast) has compilation errors.
I'm proposing a fix for them here, by making `DiscoveryBuilder` API backward compatible, so we do not need to change existing code (tests mainly).

At the same time, I'm removing the `Default` impl for `DiscoveryConfig` and creating this config test specifically.

I'm fixing other tests too.

And btw. I'm applying build optimisation for macOS platform which I use, and you too afaik.