### PR TITLE
[ci] fix goth checkout: use head_sha instead head_branch

### DIFF
--- a/.github/workflows/goth.yml
+++ b/.github/workflows/goth.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Configure Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Why:
- to enable goth builds even when the branch is already deleted

What:
- use head_sha instead head_branch