### PR TITLE
[Market] Test Suite wo compilation flag + fix flaky tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6791,7 +6791,6 @@ dependencies = [
  "ya-client",
  "ya-core-model",
  "ya-diesel-utils",
- "ya-market",
  "ya-market-resolver",
  "ya-net",
  "ya-persistence",

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 [features]
 test-suite = []
 bcast-singleton = []
-testing = ["actix-http", "actix-service", "env_logger"]
 
 [dependencies]
 ya-agreement-utils = { version = "^0.2"}
@@ -27,7 +26,9 @@ ya-utils-actix = "0.1"
 
 
 actix = { version = "0.10", default-features = false }
+actix-http = { version = "2.2" }
 actix-rt = { version = "1.0.0" }
+actix-service = { version = "1.0" }
 actix-web = "3.2"
 anyhow = "1.0"
 async-trait = { version = "0.1.33" }
@@ -37,6 +38,7 @@ derive_more = "0.99.5"
 diesel = { version = "1.4", features = ["chrono", "sqlite", "r2d2"] }
 diesel_migrations = "1.4"
 digest = "0.8.1"
+env_logger = { version = "0.7" }
 futures = "0.3"
 humantime = "2.0.0"
 lazy_static = "1.4"
@@ -47,6 +49,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 r2d2 = "0.8"
 rand = "0.7.2"
+regex = "1.4.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha3 = "0.8.2"
@@ -57,15 +60,7 @@ thiserror = "1.0"
 tokio = { version = "0.2", features = ["time", "sync"] }
 uuid = { version = "0.8", features = ["v4"] }
 
-# testing
-actix-http = { version = "2.2", optional = true }
-actix-service = { version = "1.0", optional = true }
-env_logger = { version = "0.7", optional = true }
-regex = "1.4.2"
-
 [dev-dependencies]
-ya-market = { path = ".", features = ["testing"] }
-
 all_asserts = "2.2.0"
 serde_json = "1.0"
 #serial_test = "0.5.0"

--- a/core/market/src/lib.rs
+++ b/core/market/src/lib.rs
@@ -11,7 +11,6 @@ mod protocol;
 mod rest_api;
 mod utils;
 
-#[cfg(feature = "testing")]
 pub mod testing;
 
 pub use market::MarketService;

--- a/core/market/src/testing.rs
+++ b/core/market/src/testing.rs
@@ -21,5 +21,5 @@ pub mod mock_node;
 pub mod mock_offer;
 pub mod proposal_util;
 
-pub use mock_node::{wait_for_bcast, MarketServiceExt, MarketsNetwork};
+pub use mock_node::{MarketServiceExt, MarketsNetwork};
 pub use mock_offer::{client, sample_demand, sample_offer};

--- a/core/market/src/testing/mock_node.rs
+++ b/core/market/src/testing/mock_node.rs
@@ -746,21 +746,3 @@ where
         "At least one of the offer unsubscribes was not propagated to all nodes"
     );
 }
-
-/// Facilitates waiting for broadcast propagation.
-pub async fn wait_for_bcast(
-    grace_millis: u64,
-    market: &MarketService,
-    subscription_id: &SubscriptionId,
-    stop_is_ok: bool,
-) {
-    let steps = 20;
-    let wait_step = Duration::from_millis(grace_millis / steps);
-    let store = market.matcher.store.clone();
-    for _ in 0..steps {
-        tokio::time::delay_for(wait_step).await;
-        if store.get_offer(&subscription_id).await.is_ok() == stop_is_ok {
-            break;
-        }
-    }
-}

--- a/core/market/src/testing/mock_node.rs
+++ b/core/market/src/testing/mock_node.rs
@@ -714,8 +714,8 @@ where
     );
 }
 
-/// Assure that all given nodes have the same knowledge about given Subscriptions (Offers).
-/// Wait if needed at most 1,5s ( = 10 x 150ms).
+/// Assure that all given nodes have the same knowledge about given Offer Unsubscribes.
+/// Wait if needed at most 2,5s ( = 10 x 250ms).
 pub async fn assert_unsunbscribes_broadcasted<'a, S>(mkts: &[&MarketService], subscriptions: S)
 where
     S: IntoIterator<Item = &'a SubscriptionId>,
@@ -732,7 +732,7 @@ where
                     Ok(_) => {
                         // Every 150ms we should get at least one broadcast from each Node.
                         // After a few tries all nodes should have the same knowledge about Offers.
-                        tokio::time::delay_for(Duration::from_millis(150)).await;
+                        tokio::time::delay_for(Duration::from_millis(250)).await;
                         continue 'retry;
                     }
                 }

--- a/core/market/tests/test_cyclic_broadcasts.rs
+++ b/core/market/tests/test_cyclic_broadcasts.rs
@@ -55,7 +55,7 @@ async fn test_startup_offers_sharing() {
     let mkt3 = network.get_market("Node-3");
 
     // Make sure we got all offers that, were created.
-    assert_offers_broadcasted(&[&mkt1, &mkt2, &mkt3], subscriptions.iter()).await;
+    assert_offers_broadcasted(&[&mkt1, &mkt2, &mkt3], &subscriptions).await;
 }
 
 /// Unsubscribes are sent immediately after Offer is unsubscribed and
@@ -310,8 +310,8 @@ async fn test_sharing_someones_else_unsubscribes() {
     network.enable_networking_for("Node-3").unwrap();
 
     // We expect that all unsubscribed will be shared with Node-3 after this delay.
-    assert_unsunbscribes_broadcasted(&[&mkt1, &mkt2, &mkt3], subscriptions[3..].iter()).await;
+    assert_unsunbscribes_broadcasted(&[&mkt1, &mkt2, &mkt3], &subscriptions[3..]).await;
 
     // All other Offers should remain untouched.
-    assert_offers_broadcasted(&[&mkt1, &mkt2, &mkt3], subscriptions[0..3].iter()).await;
+    assert_offers_broadcasted(&[&mkt1, &mkt2, &mkt3], &subscriptions[0..3]).await;
 }

--- a/core/market/tests/test_negotiations.rs
+++ b/core/market/tests/test_negotiations.rs
@@ -917,7 +917,7 @@ async fn test_proposal_events_last() {
         .unwrap();
 
     // wait for Offer broadcast.
-    assert_offers_broadcasted(&[&market1], [offer2_id].iter()).await;
+    assert_offers_broadcasted(&[&market1], &[offer2_id]).await;
 
     let proposal2 = provider::query_proposal(&market2, &offer1_id, "Initial #P")
         .await

--- a/core/market/tests/test_offer_broadcast.rs
+++ b/core/market/tests/test_offer_broadcast.rs
@@ -258,7 +258,7 @@ async fn test_broadcast_stop_conditions() {
         .unwrap();
 
     // Wait for broadcast.
-    tokio::time::timeout(Duration::from_millis(250), rx.next())
+    tokio::time::timeout(Duration::from_millis(500), rx.next())
         .await
         .unwrap();
 

--- a/core/market/tests/test_rest_api.rs
+++ b/core/market/tests/test_rest_api.rs
@@ -17,7 +17,7 @@ use ya_market::testing::events_helper::requestor::expect_approve;
 use ya_market::testing::{
     agreement_utils::gen_reason,
     client::{sample_demand, sample_offer},
-    mock_node::{wait_for_bcast, MarketServiceExt},
+    mock_node::{assert_offers_broadcasted, MarketServiceExt},
     mock_offer::flatten_json,
     proposal_util::exchange_draft_proposals,
     DemandError, MarketsNetwork, ModifyOfferError, Owner, SubscriptionId, SubscriptionParseError,
@@ -70,7 +70,7 @@ async fn test_rest_get_offers() {
         .await
         .unwrap();
 
-    wait_for_bcast(1000, &market_remote, &subscription_id_local, true).await;
+    assert_offers_broadcasted(&[&market_remote], &[subscription_id_local.clone()]).await;
 
     let mut app = network.get_rest_app("Node-1").await;
 


### PR DESCRIPTION
Why:
- IDE (Intellij Idea) is not able to properly index symbols behind `testing` compilation flag which prevents autocompletion
- GH Actions CI is using very slow machines. Some tests using broadcasts are flaky. 

What:
- remove `testing` flag all together
- replace old `wait_for_bcast` fn with two new more sophisticated ones