### PR TITLE
[CI] sync changes to workflows and CODEOWNERS from master to release/v0.6

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 
-/.github/                                @prekucki
-/.github/workflows/rust.yml              @golemfactory/ya-integration
+/.github/                                @prekucki @tworec
+/.github/workflows/goth.yml              @golemfactory/ya-integration
 
 # Activity
 /core/activity/                          @golemfactory/exe-unit

--- a/.github/workflows/goth.yml
+++ b/.github/workflows/goth.yml
@@ -1,0 +1,94 @@
+name: Goth
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  triggering-workflow-info:
+    name: Triggerin Workflow Info
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dump GitHub event context
+        env:
+          GH_EVENT_CONTEXT: ${{ toJSON(github.event) }}
+        run: echo "$GH_EVENT_CONTEXT"
+
+  integration-test:
+    name: Integration Tests
+    runs-on: goth
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    defaults:
+      run:
+        working-directory: './goth_tests'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Configure Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8.0'
+
+      - name: Configure Poetry
+        uses: Gr1N/setup-poetry@v4
+        with:
+          poetry-version: 1.1.4
+          working-directory: './goth_tests'
+
+      - name: Install dependencies
+        run: poetry install --no-root
+
+      - name: Disconnect Docker containers from default network
+        continue-on-error: true
+        run: |
+          docker network inspect docker_default
+          sudo apt-get install -y jq
+          docker network inspect docker_default | jq ".[0].Containers | map(.Name)[]" | tee /dev/stderr | xargs --max-args 1 -- docker network disconnect -f docker_default
+
+      - name: Remove Docker containers
+        continue-on-error: true
+        run: docker rm -f $(docker ps -a -q)
+
+      - name: Log in to GitHub Docker repository
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u ${{github.actor}} --password-stdin
+
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: rust.yml
+          commit: ${{github.event.workflow_run.head_sha}}
+          workflow_conclusion: success
+          name: 'Yagna Linux'
+          path: /tmp/yagna-build
+
+      - name: Run test suite
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          poetry run poe goth-assets
+          poetry run poe goth-tests --config-override docker-compose.build-environment.binary-path=/tmp/yagna-build
+
+      - name: Upload test logs
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: goth-logs
+          path: /tmp/goth-tests
+
+      # Only relevant for self-hosted runners
+      - name: Remove test logs
+        if: always()
+        run: rm -rf /tmp/goth-tests
+
+      # Only relevant for self-hosted runners
+      - name: Remove Poetry virtual env
+        if: always()
+        # Python version below should agree with the version set up by this job.
+        # In the future we'll be able to use the `--all` flag here to remove envs for
+        # all Python versions (https://github.com/python-poetry/poetry/issues/3208).
+        run: poetry env remove python3.8

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,57 +11,57 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Tests & Build
     env:
+      # `-D warnings` means any warnings emitted will cause build to fail
       RUSTFLAGS: "-D warnings -C opt-level=z -C target-cpu=x86-64 -C debuginfo=1"
       X86_64_PC_WINDOWS_MSVC_OPENSSL_DIR: c:/vcpkg/installed/x64-windows
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # was commented bc of too much spend on Macos which is counted 10x, Windows is 2x
         os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Install Last Stable Rust
+      - name: Install last stable Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           components: rustfmt, clippy
 
-      - name: cargo tree - to check lockfile validity
+      - name: Check lockfile
         uses: actions-rs/cargo@v1
         with:
           command: tree
           args: --locked
 
-      - name: cargo fmt
+      - name: Check formatting
         uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
 
-      - name: Install openssl
-        if: matrix.os == 'windows-latest'
+      - name: Install openssl ( Windows only )
+        if: runner.os == 'Windows'
         run: |
           vcpkg install openssl:x64-windows openssl:x64-windows-static
           vcpkg list
           vcpkg integrate install
 
-      - name: cargo test
+      - name: Unit tests
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --workspace --locked
 
-      - name: cargo test sgx
-        if: matrix.os == 'ubuntu-latest'
+      - name: Unit tests for SGX
+        if: ${{ runner.os == 'Linux' && startsWith( github.head_ref, 'sgx/' ) }}
         working-directory: exe-unit
         run: cargo test --features sgx
 
-      - name: decentralized market test suite
+      - name: Market Test Suite (semi-integration tests)
         uses: actions-rs/cargo@v1
         if: startsWith( github.head_ref, 'market/' )
         with:
@@ -73,80 +73,31 @@ jobs:
           # because the latter needs separate compilation of lots of dependant crates again.
           args: --tests --workspace --features ya-market/test-suite
 
-      - name: cargo build
+      - name: Build binaries
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --workspace
 
-      - name: Copy binaries Unix
-        if: runner.os != 'Windows'
+      - name: Copy binaries
+        shell: bash
         run: |
           mkdir build
-          cp target/debug/{yagna,ya-provider,exe-unit,golemsp} build
-          strip -x build/*
-
-      - name: Copy binaries Windows
-        if: runner.os == 'Windows'
-        run: |
-          mkdir build
-          copy target\debug\yagna.exe build
-          copy target\debug\ya-provider.exe build
-          copy target\debug\exe-unit.exe build
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            cp target/debug/{yagna,ya-provider,exe-unit,golemsp,gftp} build
+            strip -x build/*
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            cp target/debug/{yagna,gftp} build
+            strip -x build/*
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            cp target/debug/{yagna,gftp}.exe build
+          else
+            echo "$RUNNER_OS not supported"
+            exit 1
+          fi
 
       - name: Upload binaries
         uses: actions/upload-artifact@v1
         with:
           name: Yagna ${{ runner.os }}
           path: build
-
-  integration-test:
-    name: Run integration tests
-    runs-on: goth
-    needs: build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          repository: 'golemfactory/goth'
-          token: ${{ secrets.YAGNA_WORKFLOW_TOKEN }}
-
-      - name: Configure python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.8.0'
-
-      - name: Configure poetry
-        uses: Gr1N/setup-poetry@v4
-        with:
-          poetry-version: 1.1.4
-
-      - name: Install dependencies
-        run: poetry install --no-root
-
-      - name: Log in to GitHub Docker repository
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u ${{github.actor}} --password-stdin
-
-      - name: Download yagna artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: 'Yagna Linux'
-          path: /tmp/yagna-build
-
-      - name: Run test suite
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # --assets-path: https://github.com/golemfactory/goth/issues/336
-        run: poetry run poe ci_test_self_hosted
-
-      - name: Upload test logs
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: goth-logs
-          path: /tmp/goth-tests
-
-      # Only relevant for self-hosted runners
-      - name: Remove test logs
-        if: always()
-        run: rm -rf /tmp/goth-tests


### PR DESCRIPTION
Why:
- because required builds have been changes and we cannot further merege PR against release/v0.6

What:
- cherry-pick changes to .github folder all together from `master` branch 