### PR TITLE
[mkt] Restore 1h as default Offer/Demand TTL

### DIFF
--- a/agent/provider/src/market/provider_market.rs
+++ b/agent/provider/src/market/provider_market.rs
@@ -73,8 +73,8 @@ pub struct NewAgreement {
 // =========================================== //
 
 /// Sent when subscribing offer to the market will be finished.
-#[rtype(result = "Result<()>")]
 #[derive(Debug, Clone, Message)]
+#[rtype(result = "Result<()>")]
 struct Subscription {
     id: String,
     preset: Preset,

--- a/core/market/src/config.rs
+++ b/core/market/src/config.rs
@@ -50,7 +50,7 @@ impl Config {
 impl Default for SubscriptionConfig {
     fn default() -> Self {
         SubscriptionConfig {
-            default_ttl: chrono::Duration::seconds(50),
+            default_ttl: chrono::Duration::hours(1),
         }
     }
 }
@@ -66,4 +66,23 @@ impl Default for EventsConfig {
 
 fn parse_chrono_duration(s: &str) -> Result<chrono::Duration, anyhow::Error> {
     Ok(chrono::Duration::from_std(humantime::parse_duration(s)?)?)
+}
+
+#[cfg(test)]
+mod test {
+    use structopt::StructOpt;
+
+    use super::SubscriptionConfig;
+
+    #[test]
+    fn test_default_subscription_ttl() {
+        let d = SubscriptionConfig::default();
+        assert_eq!(60, d.default_ttl.num_minutes());
+    }
+
+    #[test]
+    fn test_default_structopt_subscription_ttl() {
+        let d = SubscriptionConfig::from_iter(&[""]);
+        assert_eq!(60, d.default_ttl.num_minutes());
+    }
 }

--- a/core/market/src/testing/mock_node.rs
+++ b/core/market/src/testing/mock_node.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
 use std::{fs, path::PathBuf, sync::Arc, time::Duration};
+use structopt::StructOpt;
 
 use ya_client::model::market::RequestorEvent;
 use ya_persistence::executor::DbExecutor;
@@ -20,7 +21,7 @@ use super::bcast::BCastService;
 use super::mock_net::{gsb_prefixes, MockNet};
 use super::negotiation::{provider, requestor};
 use super::{store::SubscriptionStore, Matcher};
-use crate::config::{Config, DiscoveryConfig};
+use crate::config::{Config, DiscoveryConfig, EventsConfig, SubscriptionConfig};
 use crate::db::dao::ProposalDao;
 use crate::db::model::{Demand, Offer, Proposal, ProposalId, SubscriptionId};
 use crate::identity::IdentityApi;
@@ -680,8 +681,8 @@ pub fn create_market_config_for_test() -> Config {
 
     Config {
         discovery,
-        subscription: Default::default(),
-        events: Default::default(),
+        subscription: SubscriptionConfig::from_iter(&[""]),
+        events: EventsConfig::from_iter(&[""]),
     }
 }
 


### PR DESCRIPTION
Why:
- we see Offers @ `mainnet` with TTL of 50s which are expiring during negotiation

What:
- revert unintentionally (accidentally?) shortened config value (vide #1002)
- remove double default values definition (impl Default removed, StructOpt kept) 