### PR TITLE
Market/config upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7326,6 +7326,7 @@ dependencies = [
 name = "ya-market"
 version = "0.3.0"
 dependencies = [
+ "actix 0.10.0",
  "actix-http",
  "actix-rt",
  "actix-service",
@@ -7365,7 +7366,6 @@ dependencies = [
  "ya-client",
  "ya-core-model",
  "ya-diesel-utils",
- "ya-market",
  "ya-market-resolver",
  "ya-net",
  "ya-persistence",
@@ -7374,6 +7374,7 @@ dependencies = [
  "ya-service-api-web",
  "ya-service-bus",
  "ya-std-utils",
+ "ya-utils-actix",
 ]
 
 [[package]]

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 [features]
 test-suite = []
 bcast-singleton = []
-testing = ["actix-http", "actix-service", "env_logger"]
 
 [dependencies]
 ya-agreement-utils = { version = "^0.2"}
@@ -23,8 +22,13 @@ ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-api-web = "0.1"
 ya-service-bus = "0.4"
+ya-utils-actix = "0.1"
 
+
+actix = { version = "0.10", default-features = false }
+actix-http = { version = "2.2" }
 actix-rt = { version = "1.0.0" }
+actix-service = { version = "1.0" }
 actix-web = "3.2"
 anyhow = "1.0"
 async-trait = { version = "0.1.33" }
@@ -34,6 +38,7 @@ derive_more = "0.99.5"
 diesel = { version = "1.4", features = ["chrono", "sqlite", "r2d2"] }
 diesel_migrations = "1.4"
 digest = "0.8.1"
+env_logger = { version = "0.7" }
 futures = "0.3"
 humantime = "2.0.0"
 lazy_static = "1.4"
@@ -44,6 +49,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 r2d2 = "0.8"
 rand = "0.7.2"
+regex = "1.4.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha3 = "0.8.2"
@@ -54,15 +60,7 @@ thiserror = "1.0"
 tokio = { version = "0.2", features = ["time", "sync"] }
 uuid = { version = "0.8", features = ["v4"] }
 
-# testing
-actix-http = { version = "2.2", optional = true }
-actix-service = { version = "1.0", optional = true }
-env_logger = { version = "0.7", optional = true }
-regex = "1.4.2"
-
 [dev-dependencies]
-ya-market = { path = ".", features = ["testing"] }
-
 all_asserts = "2.2.0"
 serde_json = "1.0"
 #serial_test = "0.5.0"

--- a/core/market/Cargo.toml
+++ b/core/market/Cargo.toml
@@ -11,10 +11,9 @@ bcast-singleton = []
 
 [dependencies]
 ya-agreement-utils = { version = "^0.2"}
-ya-diesel-utils = { version = "0.1" }
-ya-std-utils = "0.1"
 ya-client = "0.5"
 ya-core-model = { version = "^0.3", features = ["market", "net"] }
+ya-diesel-utils = { version = "0.1" }
 ya-market-resolver = "0.2"
 ya-net = "0.2"
 ya-persistence = "0.2"
@@ -22,8 +21,8 @@ ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"
 ya-service-api-web = "0.1"
 ya-service-bus = "0.4"
+ya-std-utils = "0.1"
 ya-utils-actix = "0.1"
-
 
 actix = { version = "0.10", default-features = false }
 actix-http = { version = "2.2" }

--- a/core/market/src/config.rs
+++ b/core/market/src/config.rs
@@ -5,9 +5,9 @@ use structopt::StructOpt;
 pub struct Config {
     #[structopt(flatten)]
     pub discovery: DiscoveryConfig,
-    #[structopt(skip)]
+    #[structopt(flatten)]
     pub subscription: SubscriptionConfig,
-    #[structopt(skip)]
+    #[structopt(flatten)]
     pub events: EventsConfig,
 }
 
@@ -33,37 +33,40 @@ pub struct SubscriptionConfig {
     pub default_ttl: chrono::Duration,
 }
 
-#[derive(Clone)]
+#[derive(StructOpt, Clone)]
 pub struct EventsConfig {
+    #[structopt(env = "MAX_MARKET_EVENTS_DEFAULT", default_value = "20")]
     pub max_events_default: i32,
+    #[structopt(env = "MAX_MARKET_EVENTS_MAX", default_value = "100")]
     pub max_events_max: i32,
 }
 
 impl Config {
     pub fn from_env() -> Result<Config, structopt::clap::Error> {
-        // Mock command line arguments, because we want to use ENV fallback
-        // or default values if ENV variables don't exist.
-        Ok(Config::from_iter_safe(vec!["yagna"].iter())?)
-    }
-}
-
-impl Default for SubscriptionConfig {
-    fn default() -> Self {
-        SubscriptionConfig {
-            default_ttl: chrono::Duration::hours(1),
-        }
-    }
-}
-
-impl Default for EventsConfig {
-    fn default() -> Self {
-        EventsConfig {
-            max_events_default: 20,
-            max_events_max: 100,
-        }
+        // Empty command line arguments, because we want to use ENV fallback
+        // or default values if ENV variables are not set.
+        Ok(Config::from_iter_safe(&[""])?)
     }
 }
 
 fn parse_chrono_duration(s: &str) -> Result<chrono::Duration, anyhow::Error> {
     Ok(chrono::Duration::from_std(humantime::parse_duration(s)?)?)
+}
+
+#[cfg(test)]
+mod test {
+    use super::Config;
+
+    #[test]
+    fn test_default_structopt_subscription_ttl() {
+        let c = Config::from_env().unwrap();
+        assert_eq!(60, c.subscription.default_ttl.num_minutes());
+    }
+
+    #[test]
+    fn test_default_structopt_events() {
+        let c = Config::from_env().unwrap();
+        assert_eq!(20, c.events.max_events_default);
+        assert_eq!(100, c.events.max_events_max);
+    }
 }

--- a/core/market/src/config.rs
+++ b/core/market/src/config.rs
@@ -37,9 +37,9 @@ pub struct SubscriptionConfig {
 
 #[derive(StructOpt, Clone)]
 pub struct EventsConfig {
-    #[structopt(env = "MAX_MARKET_EVENTS_DEFAULT", default_value = "20")]
+    #[structopt(env = "MARKET_MAX_EVENTS_DEFAULT", default_value = "20")]
     pub max_events_default: i32,
-    #[structopt(env = "MAX_MARKET_EVENTS_MAX", default_value = "100")]
+    #[structopt(env = "MARKET_MAX_EVENTS_MAX", default_value = "100")]
     pub max_events_max: i32,
 }
 

--- a/core/market/src/config.rs
+++ b/core/market/src/config.rs
@@ -10,7 +10,7 @@ pub struct Config {
     #[structopt(flatten)]
     pub events: EventsConfig,
     #[structopt(flatten)]
-    pub db: DBConfig,
+    pub db: DbConfig,
 }
 
 #[derive(StructOpt, Clone)]
@@ -44,7 +44,7 @@ pub struct EventsConfig {
 }
 
 #[derive(StructOpt, Clone)]
-pub struct DBConfig {
+pub struct DbConfig {
     /// Interval in which Market cleaner will be invoked
     #[structopt(env = "MARKET_DB_CLEANUP_INTERVAL", parse(try_from_str = humantime::parse_duration), default_value = "24h")]
     pub cleanup_interval: Duration,

--- a/core/market/src/db/dao/agreement.rs
+++ b/core/market/src/db/dao/agreement.rs
@@ -4,7 +4,7 @@ use diesel::prelude::*;
 use ya_client::model::NodeId;
 use ya_persistence::executor::{do_with_transaction, AsDao, ConnType, PoolType};
 
-use crate::config::DBConfig;
+use crate::config::DbConfig;
 use crate::db::dao::agreement_events::create_event;
 use crate::db::dao::proposal::{has_counter_proposal, update_proposal_state};
 use crate::db::dao::sql_functions::datetime;
@@ -277,7 +277,7 @@ impl<'c> AgreementDao<'c> {
         .await
     }
 
-    pub async fn clean(&self, db_config: &DBConfig) -> DbResult<()> {
+    pub async fn clean(&self, db_config: &DbConfig) -> DbResult<()> {
         log::trace!("Clean market agreements: start");
         let interval_days = db_config.agreement_store_days;
         let (num_agreements, num_events) = do_with_transaction(self.pool, move |conn| {

--- a/core/market/src/db/dao/agreement.rs
+++ b/core/market/src/db/dao/agreement.rs
@@ -4,6 +4,7 @@ use diesel::prelude::*;
 use ya_client::model::NodeId;
 use ya_persistence::executor::{do_with_transaction, AsDao, ConnType, PoolType};
 
+use crate::config::DBConfig;
 use crate::db::dao::agreement_events::create_event;
 use crate::db::dao::proposal::{has_counter_proposal, update_proposal_state};
 use crate::db::dao::sql_functions::datetime;
@@ -16,13 +17,6 @@ use crate::db::schema::market_agreement::dsl::market_agreement;
 use crate::db::schema::market_agreement_event::dsl as event;
 use crate::db::schema::market_agreement_event::dsl::market_agreement_event;
 use crate::db::{DbError, DbResult};
-use crate::market::EnvConfig;
-
-const AGREEMENT_STORE_DAYS: EnvConfig<'static, u64> = EnvConfig {
-    name: "YAGNA_MARKET_AGREEMENT_STORE_DAYS",
-    default: 90, // days
-    min: 30,     // days
-};
 
 #[derive(thiserror::Error, Debug)]
 pub enum SaveAgreementError {
@@ -283,10 +277,9 @@ impl<'c> AgreementDao<'c> {
         .await
     }
 
-    pub async fn clean(&self) -> DbResult<()> {
-        // FIXME use grace time from config file when #460 is merged
+    pub async fn clean(&self, db_config: &DBConfig) -> DbResult<()> {
         log::trace!("Clean market agreements: start");
-        let interval_days = AGREEMENT_STORE_DAYS.get_value();
+        let interval_days = db_config.agreement_store_days;
         let (num_agreements, num_events) = do_with_transaction(self.pool, move |conn| {
             let agreements_to_clean = market_agreement.filter(
                 agreement::valid_to.lt(datetime("NOW", format!("-{} days", interval_days))),

--- a/core/market/src/db/dao/cleaner.rs
+++ b/core/market/src/db/dao/cleaner.rs
@@ -1,10 +1,10 @@
+use crate::config::DBConfig;
 use crate::db::dao::{AgreementDao, DemandDao, NegotiationEventsDao, OfferDao, ProposalDao};
 use futures::join;
-use std::time::Duration;
 use tokio::time;
 use ya_persistence::executor::DbExecutor;
 
-pub async fn clean(db: DbExecutor) {
+pub async fn clean(db: DbExecutor, cfg: &DBConfig) {
     let demand_db = db.clone();
     let events_db = db.clone();
     let offer_db = db.clone();
@@ -14,9 +14,9 @@ pub async fn clean(db: DbExecutor) {
     let results = join!(
         async move { demand_db.as_dao::<DemandDao>().clean().await },
         async move { offer_db.as_dao::<OfferDao>().clean().await },
-        async move { agreement_db.as_dao::<AgreementDao>().clean().await },
+        async move { agreement_db.as_dao::<AgreementDao>().clean(cfg).await },
         async move { proposal_db.as_dao::<ProposalDao>().clean().await },
-        async move { events_db.as_dao::<NegotiationEventsDao>().clean().await },
+        async move { events_db.as_dao::<NegotiationEventsDao>().clean(cfg).await },
     );
     let v_results = vec![results.0, results.1, results.2, results.3, results.4];
     for db_result in v_results.into_iter() {
@@ -27,14 +27,13 @@ pub async fn clean(db: DbExecutor) {
     }
 }
 
-pub async fn clean_forever(db: DbExecutor) {
-    // TODO: Use value from market config once #460 is merged
-    let mut interval = time::interval(Duration::from_secs(3600 * 24));
+pub async fn clean_forever(db: DbExecutor, cfg: DBConfig) {
+    let mut interval = time::interval(cfg.cleanup_interval);
     loop {
         interval.tick().await;
         log::debug!("Market database cleaner job started");
         let db = db.clone();
-        clean(db).await;
+        clean(db, &cfg).await;
         log::debug!("Market database cleaner job done");
     }
 }

--- a/core/market/src/db/dao/cleaner.rs
+++ b/core/market/src/db/dao/cleaner.rs
@@ -1,10 +1,10 @@
-use crate::config::DBConfig;
+use crate::config::DbConfig;
 use crate::db::dao::{AgreementDao, DemandDao, NegotiationEventsDao, OfferDao, ProposalDao};
 use futures::join;
 use tokio::time;
 use ya_persistence::executor::DbExecutor;
 
-pub async fn clean(db: DbExecutor, cfg: &DBConfig) {
+pub async fn clean(db: DbExecutor, cfg: &DbConfig) {
     let demand_db = db.clone();
     let events_db = db.clone();
     let offer_db = db.clone();
@@ -27,7 +27,7 @@ pub async fn clean(db: DbExecutor, cfg: &DBConfig) {
     }
 }
 
-pub async fn clean_forever(db: DbExecutor, cfg: DBConfig) {
+pub async fn clean_forever(db: DbExecutor, cfg: DbConfig) {
     let mut interval = time::interval(cfg.cleanup_interval);
     loop {
         interval.tick().await;

--- a/core/market/src/db/dao/negotiation_events.rs
+++ b/core/market/src/db/dao/negotiation_events.rs
@@ -5,20 +5,14 @@ use thiserror::Error;
 use ya_persistence::executor::ConnType;
 use ya_persistence::executor::{do_with_transaction, AsDao, PoolType};
 
+use crate::config::DBConfig;
 use crate::db::dao::demand::{demand_status, DemandState};
 use crate::db::dao::offer::{query_state, OfferState};
 use crate::db::dao::sql_functions::datetime;
 use crate::db::model::{Agreement, EventType, MarketEvent, Owner, Proposal, SubscriptionId};
 use crate::db::schema::market_negotiation_event::dsl;
 use crate::db::{DbError, DbResult};
-use crate::market::EnvConfig;
 use diesel::dsl::sql;
-
-const EVENT_STORE_DAYS: EnvConfig<'static, u64> = EnvConfig {
-    name: "YAGNA_MARKET_EVENT_STORE_DAYS",
-    default: 1, // days
-    min: 1,     // days
-};
 
 #[derive(Error, Debug)]
 pub enum TakeEventsError {
@@ -141,9 +135,9 @@ impl<'c> NegotiationEventsDao<'c> {
         .await
     }
 
-    pub async fn clean(&self) -> DbResult<()> {
+    pub async fn clean(&self, db_config: &DBConfig) -> DbResult<()> {
         log::debug!("Clean market events: start");
-        let interval_days = EVENT_STORE_DAYS.get_value();
+        let interval_days = db_config.event_store_days;
         let num_deleted = do_with_transaction(self.pool, move |conn| {
             let nd = diesel::delete(
                 dsl::market_negotiation_event

--- a/core/market/src/db/dao/negotiation_events.rs
+++ b/core/market/src/db/dao/negotiation_events.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use ya_persistence::executor::ConnType;
 use ya_persistence::executor::{do_with_transaction, AsDao, PoolType};
 
-use crate::config::DBConfig;
+use crate::config::DbConfig;
 use crate::db::dao::demand::{demand_status, DemandState};
 use crate::db::dao::offer::{query_state, OfferState};
 use crate::db::dao::sql_functions::datetime;
@@ -135,7 +135,7 @@ impl<'c> NegotiationEventsDao<'c> {
         .await
     }
 
-    pub async fn clean(&self, db_config: &DBConfig) -> DbResult<()> {
+    pub async fn clean(&self, db_config: &DbConfig) -> DbResult<()> {
         log::debug!("Clean market events: start");
         let interval_days = db_config.event_store_days;
         let num_deleted = do_with_transaction(self.pool, move |conn| {

--- a/core/market/src/lib.rs
+++ b/core/market/src/lib.rs
@@ -11,7 +11,6 @@ mod protocol;
 mod rest_api;
 mod utils;
 
-#[cfg(feature = "testing")]
 pub mod testing;
 
 pub use market::MarketService;

--- a/core/market/src/market.rs
+++ b/core/market/src/market.rs
@@ -32,21 +32,6 @@ use ya_service_api_web::scope::ExtendableScope;
 
 pub mod agreement;
 
-pub struct EnvConfig<'a, T> {
-    pub name: &'a str,
-    pub default: T,
-    pub min: T,
-}
-
-impl<'a> EnvConfig<'a, u64> {
-    pub fn get_value(&self) -> u64 {
-        std::env::var(self.name)
-            .and_then(|v| v.parse::<u64>().map_err(|_| std::env::VarError::NotPresent))
-            .unwrap_or(self.default)
-            .max(self.min)
-    }
-}
-
 #[derive(Error, Debug)]
 pub enum MarketError {
     #[error(transparent)]
@@ -113,7 +98,7 @@ impl MarketService {
         )?;
         let cleaner_db = db.clone();
         tokio::spawn(async move {
-            crate::db::dao::cleaner::clean_forever(cleaner_db).await;
+            crate::db::dao::cleaner::clean_forever(cleaner_db, config.db.clone()).await;
         });
 
         Ok(MarketService {

--- a/core/market/src/testing.rs
+++ b/core/market/src/testing.rs
@@ -21,5 +21,5 @@ pub mod mock_node;
 pub mod mock_offer;
 pub mod proposal_util;
 
-pub use mock_node::{wait_for_bcast, MarketServiceExt, MarketsNetwork};
+pub use mock_node::{MarketServiceExt, MarketsNetwork};
 pub use mock_offer::{client, sample_demand, sample_offer};

--- a/core/market/src/testing/mock_node.rs
+++ b/core/market/src/testing/mock_node.rs
@@ -5,7 +5,6 @@ use anyhow::{anyhow, bail, Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
 use std::{fs, path::PathBuf, sync::Arc, time::Duration};
-use structopt::StructOpt;
 
 use ya_client::model::market::RequestorEvent;
 use ya_persistence::executor::DbExecutor;
@@ -21,7 +20,7 @@ use super::bcast::BCastService;
 use super::mock_net::{gsb_prefixes, MockNet};
 use super::negotiation::{provider, requestor};
 use super::{store::SubscriptionStore, Matcher};
-use crate::config::{Config, DiscoveryConfig, EventsConfig, SubscriptionConfig};
+use crate::config::{Config, DiscoveryConfig};
 use crate::db::dao::ProposalDao;
 use crate::db::model::{Demand, Offer, Proposal, ProposalId, SubscriptionId};
 use crate::identity::IdentityApi;
@@ -679,11 +678,9 @@ pub fn create_market_config_for_test() -> Config {
         unsub_broadcast_delay: Duration::from_millis(200),
     };
 
-    Config {
-        discovery,
-        subscription: SubscriptionConfig::from_iter(&[""]),
-        events: EventsConfig::from_iter(&[""]),
-    }
+    let mut cfg = Config::from_env().unwrap();
+    cfg.discovery = discovery;
+    cfg
 }
 
 /// Assure that all given nodes have the same knowledge about given Subscriptions (Offers).

--- a/core/market/src/testing/mock_node.rs
+++ b/core/market/src/testing/mock_node.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use regex::Regex;
 use std::collections::HashMap;
 use std::{fs, path::PathBuf, sync::Arc, time::Duration};
+use structopt::StructOpt;
 
 use ya_client::model::market::RequestorEvent;
 use ya_persistence::executor::DbExecutor;
@@ -20,7 +21,7 @@ use super::bcast::BCastService;
 use super::mock_net::{gsb_prefixes, MockNet};
 use super::negotiation::{provider, requestor};
 use super::{store::SubscriptionStore, Matcher};
-use crate::config::{Config, DiscoveryConfig};
+use crate::config::{Config, DiscoveryConfig, EventsConfig, SubscriptionConfig};
 use crate::db::dao::ProposalDao;
 use crate::db::model::{Demand, Offer, Proposal, ProposalId, SubscriptionId};
 use crate::identity::IdentityApi;
@@ -680,8 +681,8 @@ pub fn create_market_config_for_test() -> Config {
 
     Config {
         discovery,
-        subscription: Default::default(),
-        events: Default::default(),
+        subscription: SubscriptionConfig::from_iter(&[""]),
+        events: EventsConfig::from_iter(&[""]),
     }
 }
 

--- a/core/market/src/testing/mock_node.rs
+++ b/core/market/src/testing/mock_node.rs
@@ -744,21 +744,3 @@ where
         "At least one of the offer unsubscribes was not propagated to all nodes"
     );
 }
-
-/// Facilitates waiting for broadcast propagation.
-pub async fn wait_for_bcast(
-    grace_millis: u64,
-    market: &MarketService,
-    subscription_id: &SubscriptionId,
-    stop_is_ok: bool,
-) {
-    let steps = 20;
-    let wait_step = Duration::from_millis(grace_millis / steps);
-    let store = market.matcher.store.clone();
-    for _ in 0..steps {
-        tokio::time::delay_for(wait_step).await;
-        if store.get_offer(&subscription_id).await.is_ok() == stop_is_ok {
-            break;
-        }
-    }
-}

--- a/core/market/src/testing/mock_node.rs
+++ b/core/market/src/testing/mock_node.rs
@@ -712,8 +712,8 @@ where
     );
 }
 
-/// Assure that all given nodes have the same knowledge about given Subscriptions (Offers).
-/// Wait if needed at most 1,5s ( = 10 x 150ms).
+/// Assure that all given nodes have the same knowledge about given Offer Unsubscribes.
+/// Wait if needed at most 2,5s ( = 10 x 250ms).
 pub async fn assert_unsunbscribes_broadcasted<'a, S>(mkts: &[&MarketService], subscriptions: S)
 where
     S: IntoIterator<Item = &'a SubscriptionId>,
@@ -730,7 +730,7 @@ where
                     Ok(_) => {
                         // Every 150ms we should get at least one broadcast from each Node.
                         // After a few tries all nodes should have the same knowledge about Offers.
-                        tokio::time::delay_for(Duration::from_millis(150)).await;
+                        tokio::time::delay_for(Duration::from_millis(250)).await;
                         continue 'retry;
                     }
                 }

--- a/core/market/tests/test_cyclic_broadcasts.rs
+++ b/core/market/tests/test_cyclic_broadcasts.rs
@@ -55,7 +55,7 @@ async fn test_startup_offers_sharing() {
     let mkt3 = network.get_market("Node-3");
 
     // Make sure we got all offers that, were created.
-    assert_offers_broadcasted(&[&mkt1, &mkt2, &mkt3], subscriptions.iter()).await;
+    assert_offers_broadcasted(&[&mkt1, &mkt2, &mkt3], &subscriptions).await;
 }
 
 /// Unsubscribes are sent immediately after Offer is unsubscribed and
@@ -310,8 +310,8 @@ async fn test_sharing_someones_else_unsubscribes() {
     network.enable_networking_for("Node-3").unwrap();
 
     // We expect that all unsubscribed will be shared with Node-3 after this delay.
-    assert_unsunbscribes_broadcasted(&[&mkt1, &mkt2, &mkt3], subscriptions[3..].iter()).await;
+    assert_unsunbscribes_broadcasted(&[&mkt1, &mkt2, &mkt3], &subscriptions[3..]).await;
 
     // All other Offers should remain untouched.
-    assert_offers_broadcasted(&[&mkt1, &mkt2, &mkt3], subscriptions[0..3].iter()).await;
+    assert_offers_broadcasted(&[&mkt1, &mkt2, &mkt3], &subscriptions[0..3]).await;
 }

--- a/core/market/tests/test_negotiations.rs
+++ b/core/market/tests/test_negotiations.rs
@@ -920,7 +920,7 @@ async fn test_proposal_events_last() {
         .unwrap();
 
     // wait for Offer broadcast.
-    assert_offers_broadcasted(&[&market1], [offer2_id].iter()).await;
+    assert_offers_broadcasted(&[&market1], &[offer2_id]).await;
 
     let proposal2 = provider::query_proposal(&market2, &offer1_id, "Initial #P")
         .await

--- a/core/market/tests/test_offer_broadcast.rs
+++ b/core/market/tests/test_offer_broadcast.rs
@@ -258,7 +258,7 @@ async fn test_broadcast_stop_conditions() {
         .unwrap();
 
     // Wait for broadcast.
-    tokio::time::timeout(Duration::from_millis(250), rx.next())
+    tokio::time::timeout(Duration::from_millis(500), rx.next())
         .await
         .unwrap();
 

--- a/core/market/tests/test_rest_api.rs
+++ b/core/market/tests/test_rest_api.rs
@@ -15,7 +15,7 @@ use ya_market::testing::agreement_utils::negotiate_agreement;
 use ya_market::testing::events_helper::requestor::expect_approve;
 use ya_market::testing::{
     client::{sample_demand, sample_offer},
-    mock_node::{wait_for_bcast, MarketServiceExt},
+    mock_node::{assert_offers_broadcasted, MarketServiceExt},
     proposal_util::exchange_draft_proposals,
     DemandError, MarketsNetwork, ModifyOfferError, Owner, SubscriptionId, SubscriptionParseError,
 };
@@ -68,7 +68,7 @@ async fn test_rest_get_offers() {
         .await
         .unwrap();
 
-    wait_for_bcast(1000, &market_remote, &subscription_id_local, true).await;
+    assert_offers_broadcasted(&[&market_remote], &[subscription_id_local.clone()]).await;
 
     let mut app = network.get_rest_app("Node-1").await;
 


### PR DESCRIPTION
Why:
- sync config changes from `master` to `release/v0.6`
- enable users to configure cleanup intervals (will help @cryptobench)

What:
- cherry-pick commit from #1304 which was targeting `master`
- make cleanup interval configurable
- move two other env vars to the config

Relates to #453 and #460 