### PR TITLE
Runtime API service: refactor run_async's factory to FnOnce

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7590,7 +7590,7 @@ dependencies = [
 
 [[package]]
 name = "ya-runtime-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",

--- a/exe-unit/runtime-api/Cargo.toml
+++ b/exe-unit/runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-runtime-api"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/exe-unit/runtime-api/src/server/service.rs
+++ b/exe-unit/runtime-api/src/server/service.rs
@@ -68,7 +68,7 @@ impl RuntimeEvent for EventEmitter {
 
 pub async fn run_async<Factory, FutureRuntime, Runtime>(factory: Factory)
 where
-    Factory: Fn(EventEmitter) -> FutureRuntime,
+    Factory: FnOnce(EventEmitter) -> FutureRuntime,
     FutureRuntime: Future<Output = Runtime>,
     Runtime: RuntimeService + 'static,
 {


### PR DESCRIPTION
Improves the runtime factory function by allowing to capture outer variables