### PR TITLE
ExeUnit Supervisor: support self-contained runtimes ("services")

### DIFF
--- a/exe-unit/examples/transfer.rs
+++ b/exe-unit/examples/transfer.rs
@@ -15,7 +15,6 @@ use ya_agreement_utils::AgreementView;
 use ya_client_model::activity::TransferArgs;
 use ya_exe_unit::agreement::Agreement;
 use ya_exe_unit::error::Error;
-use ya_exe_unit::runtime::RuntimeArgs;
 use ya_exe_unit::service::transfer::{AddVolumes, DeployImage, TransferResource, TransferService};
 use ya_exe_unit::ExeUnitContext;
 use ya_runtime_api::deploy::ContainerVolume;
@@ -196,25 +195,24 @@ async fn main() -> anyhow::Result<()> {
             agreement_id: String::new(),
             json: Value::Null,
         },
-        task_package: format!(
+        task_package: Some(format!(
             "hash://sha3:{}:http://127.0.0.1:8001/rnd",
             hex::encode(hash)
-        ),
+        )),
         usage_vector: Vec::new(),
         usage_limits: HashMap::new(),
         infrastructure: HashMap::new(),
     };
 
     log::debug!("Starting TransferService");
-    let runtime_args = RuntimeArgs::new(&work_dir, &agreement, true);
     let exe_ctx = ExeUnitContext {
+        supervise: Default::default(),
         activity_id: None,
         report_url: None,
         credentials: None,
         agreement,
         work_dir: work_dir.clone(),
         cache_dir,
-        runtime_args,
         #[cfg(feature = "sgx")]
         crypto: init_crypto()?,
     };

--- a/exe-unit/examples/transfer_abort.rs
+++ b/exe-unit/examples/transfer_abort.rs
@@ -14,7 +14,6 @@ use ya_agreement_utils::AgreementView;
 use ya_client_model::activity::TransferArgs;
 use ya_exe_unit::agreement::Agreement;
 use ya_exe_unit::message::{Shutdown, ShutdownReason};
-use ya_exe_unit::runtime::RuntimeArgs;
 use ya_exe_unit::service::transfer::{AbortTransfers, TransferResource, TransferService};
 use ya_exe_unit::ExeUnitContext;
 
@@ -158,21 +157,20 @@ async fn main() -> anyhow::Result<()> {
             agreement_id: String::new(),
             json: serde_json::Value::Null,
         },
-        task_package: "".to_string(),
+        task_package: None,
         usage_vector: Vec::new(),
         usage_limits: HashMap::new(),
         infrastructure: HashMap::new(),
     };
 
-    let runtime_args = RuntimeArgs::new(&work_dir, &agreement, true);
     let exe_ctx = ExeUnitContext {
+        supervise: Default::default(),
         activity_id: None,
         report_url: None,
         credentials: None,
         agreement,
         work_dir,
         cache_dir,
-        runtime_args,
         #[cfg(feature = "sgx")]
         crypto: init_crypto()?,
     };

--- a/exe-unit/src/agreement.rs
+++ b/exe-unit/src/agreement.rs
@@ -8,7 +8,7 @@ use ya_agreement_utils::agreement::{try_from_path, AgreementView, Error};
 #[derive(Clone, Debug)]
 pub struct Agreement {
     pub inner: AgreementView,
-    pub task_package: String,
+    pub task_package: Option<String>,
     pub usage_vector: Vec<String>,
     pub usage_limits: HashMap<String, f64>,
     pub infrastructure: HashMap<String, f64>,
@@ -26,8 +26,9 @@ impl TryFrom<Value> for Agreement {
 
     fn try_from(value: Value) -> Result<Self, Self::Error> {
         let agreement = AgreementView::try_from(value)?;
-        let task_package =
-            agreement.pointer_typed::<String>("/demand/properties/golem/srv/comp/task_package")?;
+        let task_package = agreement
+            .pointer_typed::<String>("/demand/properties/golem/srv/comp/task_package")
+            .ok();
         let usage_vector =
             agreement.pointer_typed::<Vec<String>>("/offer/properties/golem/com/usage/vector")?;
         let infra = agreement.properties::<f64>("/offer/properties/golem/inf")?;

--- a/exe-unit/src/handlers/local.rs
+++ b/exe-unit/src/handlers/local.rs
@@ -112,6 +112,10 @@ impl<R: Runtime> Handler<Initialize> for ExeUnit<R> {
                     use ya_core_model::net::RemoteEndpoint;
                     use ya_core_model::sgx::VerifyAttestationEvidence;
 
+                    let task_package = task_package.ok_or_else(||
+                        Error::Other("Agreement has no `task_package` defined which is mandatory in case of SGX ExeUnit".into())
+                    )?;
+
                     let att_dev = std::path::Path::new("/dev/attestation");
                     if !att_dev.exists() {
                         let msg = format!("'{}' does not exist", att_dev.display());

--- a/exe-unit/src/lib.rs
+++ b/exe-unit/src/lib.rs
@@ -21,7 +21,7 @@ use crate::runtime::*;
 use crate::service::metrics::MetricsService;
 use crate::service::transfer::{AddVolumes, DeployImage, TransferResource, TransferService};
 use crate::service::{ServiceAddr, ServiceControl};
-use crate::state::{ExeUnitState, StateError};
+use crate::state::{ExeUnitState, StateError, Supervision};
 
 pub mod agreement;
 #[cfg(feature = "sgx")]
@@ -372,13 +372,13 @@ impl<R: Runtime> Actor for ExeUnit<R> {
 #[derivative(Debug)]
 #[derive(Clone)]
 pub struct ExeUnitContext {
+    pub supervise: Supervision,
     pub activity_id: Option<String>,
     pub report_url: Option<String>,
-    pub credentials: Option<Credentials>,
     pub agreement: Agreement,
     pub work_dir: PathBuf,
     pub cache_dir: PathBuf,
-    pub runtime_args: RuntimeArgs,
+    pub credentials: Option<Credentials>,
     #[cfg(feature = "sgx")]
     #[derivative(Debug = "ignore")]
     pub crypto: crate::crypto::Crypto,

--- a/exe-unit/src/message.rs
+++ b/exe-unit/src/message.rs
@@ -78,7 +78,7 @@ pub struct ExecuteCommand {
 
 #[derive(Debug, Message)]
 #[rtype(result = "()")]
-pub struct SetTaskPackagePath(pub PathBuf);
+pub struct SetTaskPackagePath(pub Option<PathBuf>);
 
 #[derive(Clone, Debug, Message)]
 #[rtype(result = "Result<()>")]

--- a/exe-unit/src/runtime.rs
+++ b/exe-unit/src/runtime.rs
@@ -1,8 +1,5 @@
-use crate::agreement::Agreement;
 use crate::message::*;
 use actix::prelude::*;
-use std::ffi::OsString;
-use std::path::PathBuf;
 use ya_runtime_api::deploy::StartMode;
 
 mod event;
@@ -35,63 +32,5 @@ impl From<StartMode> for RuntimeMode {
             StartMode::Empty => RuntimeMode::ProcessPerCommand,
             StartMode::Blocking => RuntimeMode::Service,
         }
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct RuntimeArgs {
-    workdir: PathBuf,
-    task_package: Option<PathBuf>,
-    cpu_cores: Option<f64>,
-    mem_gib: Option<f64>,
-    storage_gib: Option<f64>,
-}
-
-impl RuntimeArgs {
-    pub fn new(work_dir: &PathBuf, agreement: &Agreement, with_inf: bool) -> Self {
-        let mut cpu_cores = None;
-        let mut mem_gib = None;
-        let mut storage_gib = None;
-        if with_inf {
-            cpu_cores = agreement.infrastructure.get("cpu.threads").cloned();
-            mem_gib = agreement.infrastructure.get("mem.gib").cloned();
-            storage_gib = agreement.infrastructure.get("storage.gib").cloned();
-        }
-
-        RuntimeArgs {
-            workdir: work_dir.clone(),
-            task_package: None,
-            cpu_cores,
-            mem_gib,
-            storage_gib,
-        }
-    }
-
-    pub fn to_command_line(&self, package_path: &PathBuf) -> Vec<OsString> {
-        let mut args = vec![
-            OsString::from("--workdir"),
-            self.workdir.clone().into_os_string(),
-            OsString::from("--task-package"),
-            package_path.clone().into_os_string(),
-        ];
-        if let Some(val) = self.cpu_cores {
-            args.extend(vec![
-                OsString::from("--cpu-cores"),
-                OsString::from((val as u64).to_string()),
-            ]);
-        }
-        if let Some(val) = self.mem_gib {
-            args.extend(vec![
-                OsString::from("--mem-gib"),
-                OsString::from(val.to_string()),
-            ]);
-        }
-        if let Some(val) = self.storage_gib {
-            args.extend(vec![
-                OsString::from("--storage-gib"),
-                OsString::from(val.to_string()),
-            ]);
-        }
-        args
     }
 }

--- a/exe-unit/src/state.rs
+++ b/exe-unit/src/state.rs
@@ -29,6 +29,21 @@ pub enum StateError {
     },
 }
 
+#[derive(Clone, Copy, Debug)]
+pub struct Supervision {
+    pub hardware: bool,
+    pub image: bool,
+}
+
+impl Default for Supervision {
+    fn default() -> Self {
+        Supervision {
+            hardware: true,
+            image: true,
+        }
+    }
+}
+
 pub(crate) struct ExeUnitState {
     pub inner: StatePair,
     pub last_batch: Option<String>,


### PR DESCRIPTION
~Will be re-targeted to master when #1341 is merged.~ **done**

Introduces new supervisor flags to be specified in runtime descriptor:

- `--runtime-managed-image`
    "Task package" is no longer required to be included in the agreement. The `--task-package <path>` argument will not be passed to the runtime binary

- `--runtime-managed-hardware`
    `--cap-handoff` becomes an alias for backward compatibility