### PR TITLE
ExeUnit cache: cleaner cache/tmp, less intermediary files

### DIFF
--- a/exe-unit/src/service/transfer.rs
+++ b/exe-unit/src/service/transfer.rs
@@ -276,7 +276,6 @@ impl Handler<DeployImage> for TransferService {
         {
             let from_provider = actor_try!(self.provider(&source_url));
             let to_provider: FileTransferProvider = Default::default();
-            let cache_path = self.cache.to_cache_path(&cache_name);
             let temp_path = self.cache.to_temp_path(&cache_name);
             let temp_url = Url::from_file_path(temp_path.to_path_buf()).unwrap();
 
@@ -286,26 +285,29 @@ impl Handler<DeployImage> for TransferService {
             let fut = async move {
                 let final_path = final_path.to_path_buf();
                 let temp_path = temp_path.to_path_buf();
-                let cache_path = cache_path.to_path_buf();
 
                 let stream_fn = || Self::source(from_provider.clone(), &source_url, &args);
                 let sink_fn = || to_provider.destination(&temp_url, &args);
 
-                if cache_path.exists() {
-                    log::info!("Deploying cached image: {:?}", cache_path);
-                    std::fs::copy(cache_path, &final_path)?;
+                if final_path.exists() {
+                    log::info!("Deploying cached image: {:?}", final_path);
                     return Ok(final_path);
                 }
 
                 {
                     let _guard = AbortHandleGuard::register(address, abort).await?;
-                    Abortable::new(retry_transfer(stream_fn, sink_fn, Retry::default()), reg)
+                    let retry = retry_transfer(stream_fn, sink_fn, Retry::default());
+                    Ok(Abortable::new(retry, reg)
                         .await
-                        .map_err(TransferError::from)??;
+                        .map_err(TransferError::from)??)
                 }
+                .map_err(|e: Error| {
+                    log::warn!("Removing temporary download file: {}", temp_path.display());
+                    let _ = std::fs::remove_file(&temp_path);
+                    e
+                })?;
 
-                std::fs::rename(temp_path, &cache_path)?;
-                std::fs::copy(cache_path, &final_path)?;
+                std::fs::rename(temp_path, &final_path)?;
 
                 log::info!("Deployment from {:?} finished", source_url.url);
                 Ok(final_path)
@@ -461,18 +463,12 @@ impl Cache {
     #[inline(always)]
     #[cfg(not(feature = "sgx"))]
     fn to_temp_path(&self, path: &CachePath) -> ProjectedPath {
-        ProjectedPath::local(self.tmp_dir.clone(), path.temp_path_buf())
-    }
-
-    #[inline(always)]
-    #[cfg(not(feature = "sgx"))]
-    fn to_cache_path(&self, path: &CachePath) -> ProjectedPath {
-        ProjectedPath::local(self.tmp_dir.clone(), path.cache_path_buf())
+        ProjectedPath::local(self.tmp_dir.clone(), path.temp_path())
     }
 
     #[inline(always)]
     fn to_final_path(&self, path: &CachePath) -> ProjectedPath {
-        ProjectedPath::local(self.dir.clone(), path.final_path_buf())
+        ProjectedPath::local(self.dir.clone(), path.final_path())
     }
 }
 

--- a/exe-unit/src/util/path.rs
+++ b/exe-unit/src/util/path.rs
@@ -69,7 +69,7 @@ impl ProjectedPath {
 
 impl From<CachePath> for PathBuf {
     fn from(cache_path: CachePath) -> Self {
-        cache_path.final_path_buf()
+        cache_path.final_path()
     }
 }
 
@@ -84,20 +84,14 @@ impl CachePath {
     pub fn new(path: PathBuf, hash: Vec<u8>, nonce: String) -> Self {
         CachePath { path, hash, nonce }
     }
-
     /// Creates the long version of path, including hash and the "random" token.
-    pub fn temp_path_buf(&self) -> PathBuf {
+    pub fn temp_path(&self) -> PathBuf {
         self.to_path_buf(true, true)
     }
 
-    /// Creates the long version of path, including hash and the "random" token.
-    pub fn cache_path_buf(&self) -> PathBuf {
+    /// Creates a shorter version of path, including hash and excluding the "random" token.
+    pub fn final_path(&self) -> PathBuf {
         self.to_path_buf(true, false)
-    }
-
-    /// Creates a shorter version of path, excluding the "random" token.
-    pub fn final_path_buf(&self) -> PathBuf {
-        self.to_path_buf(false, false)
     }
 
     fn to_path_buf(&self, with_hash: bool, with_nonce: bool) -> PathBuf {


### PR DESCRIPTION
- hash is now included in target image name
- skip an intermediary cache file
- fix: remove temporary files on transfer failure

Resolves #1319