### PR TITLE
[CI] fix copying binaries on windows

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,7 +85,7 @@ jobs:
             cp target/debug/{yagna,gftp} build
             strip -x build/*
           elif [ "$RUNNER_OS" == "Windows" ]; then
-            cp target\debug\{yagna,gftp}.exe build
+            cp target/debug/{yagna,gftp}.exe build
           else
             echo "$RUNNER_OS not supported"
             exit 1


### PR DESCRIPTION
Fixes failing CI build (copying binaries under windows) introduced within #1347 