### PR TITLE
ExeUnit Supervisor: ProcessStatus handling tweaks (incl. fixes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6624,7 +6624,7 @@ dependencies = [
 
 [[package]]
 name = "ya-exe-unit"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "actix",
  "actix-files",

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-exe-unit"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/exe-unit/src/message.rs
+++ b/exe-unit/src/message.rs
@@ -76,6 +76,26 @@ pub struct ExecuteCommand {
     pub tx: mpsc::Sender<RuntimeEvent>,
 }
 
+impl ExecuteCommand {
+    pub fn split(self) -> (ExeScriptCommand, CommandContext) {
+        (
+            self.command,
+            CommandContext {
+                batch_id: self.batch_id,
+                idx: self.idx,
+                tx: self.tx,
+            },
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CommandContext {
+    pub batch_id: String,
+    pub idx: usize,
+    pub tx: mpsc::Sender<RuntimeEvent>,
+}
+
 #[derive(Debug, Message)]
 #[rtype(result = "()")]
 pub struct SetTaskPackagePath(pub Option<PathBuf>);

--- a/exe-unit/src/runtime/event.rs
+++ b/exe-unit/src/runtime/event.rs
@@ -24,7 +24,7 @@ pub(crate) struct EventMonitor {
 impl EventMonitor {
     pub fn any_process<'a>(&mut self, ctx: CommandContext) -> Handle<'a> {
         let mut inner = self.fallback.lock().unwrap();
-        inner.replace(Channel::plain(ctx));
+        inner.replace(Channel::simple(ctx));
 
         Handle::Fallback {
             monitor: self.clone(),
@@ -32,7 +32,7 @@ impl EventMonitor {
     }
 
     pub fn process<'a>(&mut self, ctx: CommandContext, pid: u64) -> Handle<'a> {
-        let entry = Channel::new(ctx, Default::default());
+        let entry = Channel::new(ctx);
         let done_rx = entry.done_rx().unwrap();
 
         let mut inner = self.processes.lock().unwrap();
@@ -142,14 +142,14 @@ struct Channel {
 }
 
 impl Channel {
-    fn new(ctx: CommandContext, done: DoneChannel) -> Self {
+    fn new(ctx: CommandContext) -> Self {
         Channel {
             ctx,
-            done: Some(done),
+            done: Some(Default::default()),
         }
     }
 
-    fn plain(ctx: CommandContext) -> Self {
+    fn simple(ctx: CommandContext) -> Self {
         Channel { ctx, done: None }
     }
 

--- a/exe-unit/src/runtime/event.rs
+++ b/exe-unit/src/runtime/event.rs
@@ -1,84 +1,180 @@
-use futures::channel::mpsc::{channel, Receiver, Sender};
-use futures::future::BoxFuture;
-use futures::{FutureExt, SinkExt};
 use std::collections::HashMap;
+use std::future::Future;
+use std::ops::Not;
+use std::pin::Pin;
 use std::sync::{Arc, Mutex};
-use ya_runtime_api::server::{ProcessStatus, RuntimeEvent};
+use std::task::{Context, Poll};
 
-#[derive(Clone)]
-pub struct EventMonitor {
-    inner: Arc<Mutex<HashMap<u64, EventChannel>>>,
-}
+use futures::channel::mpsc::SendError;
+use futures::channel::oneshot;
+use futures::future::{BoxFuture, Fuse, Shared};
+use futures::{FutureExt, SinkExt, TryFutureExt};
 
-pub struct EventReceiver {
-    pub rx: Receiver<ProcessStatus>,
-    pid: u64,
-    monitor: EventMonitor,
-}
+use crate::message::CommandContext;
 
-impl Drop for EventReceiver {
-    fn drop(&mut self) {
-        self.monitor.remove(self.pid);
-    }
-}
+use ya_client_model::activity::{CommandOutput, RuntimeEvent};
+use ya_runtime_api::server::ProcessStatus;
 
-#[allow(unused)]
-struct EventChannel {
-    tx: Sender<ProcessStatus>,
-    rx: Option<Receiver<ProcessStatus>>,
-}
-
-impl Default for EventChannel {
-    fn default() -> Self {
-        let (tx, rx) = channel(1);
-        EventChannel { tx, rx: Some(rx) }
-    }
+#[derive(Default, Clone)]
+pub(crate) struct EventMonitor {
+    processes: Arc<Mutex<HashMap<u64, Channel>>>,
+    fallback: Arc<Mutex<Option<Channel>>>,
 }
 
 impl EventMonitor {
-    pub fn events(&mut self, pid: u64) -> Option<EventReceiver> {
-        let mut inner = self.inner.lock().unwrap();
-        inner
-            .entry(pid)
-            .or_insert_with(Default::default)
-            .rx
-            .take()
-            .map(|rx| EventReceiver {
-                rx,
-                pid,
-                monitor: self.clone(),
-            })
+    pub fn any_process<'a>(&mut self, ctx: CommandContext) -> Handle<'a> {
+        let mut inner = self.fallback.lock().unwrap();
+        inner.replace(Channel::plain(ctx));
+
+        Handle::Fallback {
+            monitor: self.clone(),
+        }
     }
 
-    pub fn remove(&mut self, pid: u64) {
-        self.inner.lock().unwrap().remove(&pid);
-    }
-}
+    pub fn process<'a>(&mut self, ctx: CommandContext, pid: u64) -> Handle<'a> {
+        let entry = Channel::new(ctx, Default::default());
+        let done_rx = entry.done_rx().unwrap();
 
-impl Default for EventMonitor {
-    fn default() -> Self {
-        EventMonitor {
-            inner: Arc::new(Mutex::new(Default::default())),
+        let mut inner = self.processes.lock().unwrap();
+        inner.insert(pid, entry);
+
+        Handle::Process {
+            monitor: self.clone(),
+            pid,
+            done_rx,
         }
     }
 }
 
-impl RuntimeEvent for EventMonitor {
+impl ya_runtime_api::server::RuntimeEvent for EventMonitor {
     fn on_process_status<'a>(&self, status: ProcessStatus) -> BoxFuture<'a, ()> {
-        let mut tx = {
-            self.inner
-                .lock()
-                .unwrap()
-                .entry(status.pid)
-                .or_insert_with(Default::default)
-                .tx
-                .clone()
+        let (ctx, done_tx) = {
+            let mut proc_map = self.processes.lock().unwrap();
+            let mut fallback = self.fallback.lock().unwrap();
+
+            let entry = match proc_map.get_mut(&status.pid).or(fallback.as_mut()) {
+                Some(entry) => entry,
+                None => return futures::future::ready(()).boxed(),
+            };
+            let done_tx = status.running.not().then(|| entry.done_tx()).flatten();
+
+            (entry.ctx.clone(), done_tx)
         };
-        async move {
-            if let Err(err) = tx.send(status).await {
-                log::error!("Event channel error: {:?}", err);
+
+        publish(status, ctx, done_tx)
+            .map_err(|err| log::error!("Event channel error: {:?}", err))
+            .then(|_| async {})
+            .boxed()
+    }
+}
+
+async fn publish(
+    status: ProcessStatus,
+    mut ctx: CommandContext,
+    done_tx: Option<oneshot::Sender<i32>>,
+) -> Result<(), SendError> {
+    if !status.stdout.is_empty() {
+        ctx.tx
+            .send(RuntimeEvent::stdout(
+                ctx.batch_id.clone(),
+                ctx.idx,
+                CommandOutput::Bin(status.stdout),
+            ))
+            .await?;
+    }
+    if !status.stderr.is_empty() {
+        ctx.tx
+            .send(RuntimeEvent::stderr(
+                ctx.batch_id,
+                ctx.idx,
+                CommandOutput::Bin(status.stderr),
+            ))
+            .await?;
+    }
+    if let Some(done_tx) = done_tx {
+        let _ = done_tx.send(status.return_code);
+    }
+    Ok(())
+}
+
+pub(crate) enum Handle<'a> {
+    Process {
+        monitor: EventMonitor,
+        pid: u64,
+        done_rx: BoxFuture<'a, Result<i32, ()>>,
+    },
+    Fallback {
+        monitor: EventMonitor,
+    },
+}
+
+impl<'a> Drop for Handle<'a> {
+    fn drop(&mut self) {
+        match self {
+            Handle::Process { monitor, pid, .. } => {
+                monitor.processes.lock().unwrap().remove(pid);
+            }
+            Handle::Fallback { monitor, .. } => {
+                monitor.fallback.lock().unwrap().take();
             }
         }
-        .boxed()
+    }
+}
+
+impl<'a> Future for Handle<'a> {
+    type Output = i32;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.get_mut() {
+            Handle::Process { done_rx, .. } => match Pin::new(done_rx).poll(cx) {
+                Poll::Ready(Ok(c)) => Poll::Ready(c),
+                Poll::Ready(Err(_)) => Poll::Ready(1),
+                Poll::Pending => Poll::Pending,
+            },
+            Handle::Fallback { .. } => Poll::Ready(0),
+        }
+    }
+}
+
+struct Channel {
+    ctx: CommandContext,
+    done: Option<DoneChannel>,
+}
+
+impl Channel {
+    fn new(ctx: CommandContext, done: DoneChannel) -> Self {
+        Channel {
+            ctx,
+            done: Some(done),
+        }
+    }
+
+    fn plain(ctx: CommandContext) -> Self {
+        Channel { ctx, done: None }
+    }
+
+    fn done_tx(&mut self) -> Option<oneshot::Sender<i32>> {
+        self.done.as_mut().map(|d| d.tx.take()).flatten()
+    }
+
+    fn done_rx<'a>(&self) -> Option<BoxFuture<'a, Result<i32, ()>>> {
+        self.done
+            .as_ref()
+            .map(|d| d.rx.clone().map_err(|_| ()).boxed())
+    }
+}
+
+struct DoneChannel {
+    tx: Option<oneshot::Sender<i32>>,
+    rx: Shared<Fuse<oneshot::Receiver<i32>>>,
+}
+
+impl Default for DoneChannel {
+    fn default() -> Self {
+        let (tx, rx) = oneshot::channel();
+        Self {
+            tx: Some(tx),
+            rx: rx.fuse().shared(),
+        }
     }
 }


### PR DESCRIPTION
- handle output from the start command in server (blocking) mode
- drop events from pids we're not listening the status of
- change the way runtime binary args are built and handled (cleanup)