### PR TITLE
Fix Mkt Bcast metrics

### DIFF
--- a/core/market/src/matcher.rs
+++ b/core/market/src/matcher.rs
@@ -87,6 +87,7 @@ impl Matcher {
         counter!("market.offers.incoming", 0);
         counter!("market.offers.broadcasts", 0);
         counter!("market.offers.broadcasts.size", 0);
+        counter!("market.offers.broadcasts.skip", 0);
         counter!("market.offers.broadcasts.net", 0);
         counter!("market.offers.broadcasts.net_errors", 0);
         counter!("market.offers.unsubscribes.incoming", 0);

--- a/core/market/src/matcher.rs
+++ b/core/market/src/matcher.rs
@@ -86,13 +86,11 @@ impl Matcher {
         // until first change to value will be made.
         counter!("market.offers.incoming", 0);
         counter!("market.offers.broadcasts", 0);
-        counter!("market.offers.broadcasts.size", 0);
         counter!("market.offers.broadcasts.skip", 0);
         counter!("market.offers.broadcasts.net", 0);
         counter!("market.offers.broadcasts.net_errors", 0);
         counter!("market.offers.unsubscribes.incoming", 0);
         counter!("market.offers.unsubscribes.broadcasts", 0);
-        counter!("market.offers.unsubscribes.broadcasts.size", 0);
         counter!("market.offers.unsubscribes.broadcasts.net", 0);
         counter!("market.offers.unsubscribes.broadcasts.net_errors", 0);
 

--- a/core/market/src/matcher/handlers.rs
+++ b/core/market/src/matcher/handlers.rs
@@ -36,7 +36,6 @@ pub(super) async fn receive_remote_offers(
     let added_offers_ids = futures::stream::iter(msg.offers.into_iter())
         .filter_map(|offer| {
             let resolver = resolver.clone();
-            let offer_id = offer.id.clone();
             async move {
                 resolver
                     .store
@@ -46,10 +45,7 @@ pub(super) async fn receive_remote_offers(
                         resolver.receive(&offer);
                         offer.id
                     })
-                    .map_err(|e| {
-                        log::info!("Failed to save Offer [{}]. Error: {}", &offer_id, &e);
-                        e
-                    })
+                    .map_err(|e| log::info!("Skipping foreign Offer: {}", e))
                     .ok()
             }
         })

--- a/core/market/src/protocol/discovery.rs
+++ b/core/market/src/protocol/discovery.rs
@@ -1,6 +1,6 @@
 //! Discovery protocol interface
 use actix_rt::Arbiter;
-use metrics::{counter, gauge, timing};
+use metrics::{counter, timing, value};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
@@ -112,7 +112,7 @@ impl Discovery {
         let bcast_msg = SendBroadcastMessage::new(OffersBcast { offer_ids });
 
         counter!("market.offers.broadcasts.net", 1);
-        gauge!("market.offers.broadcasts.size", size as i64);
+        value!("market.offers.broadcasts.size", size as u64);
 
         // TODO: We shouldn't use send_as. Put identity inside broadcasted message instead.
         if let Err(e) = bus::service(local_net::BUS_ID)
@@ -210,7 +210,7 @@ impl Discovery {
         log::debug!("Broadcasting unsubscribes. count={}", size);
         let bcast_msg = SendBroadcastMessage::new(UnsubscribedOffersBcast { offer_ids });
         counter!("market.offers.unsubscribes.broadcasts.net", 1);
-        gauge!("market.offers.unsubscribes.broadcasts.size", size as i64);
+        value!("market.offers.unsubscribes.broadcasts.size", size as u64);
 
         // TODO: We shouldn't use send_as. Put identity inside broadcasted message instead.
         if let Err(e) = bus::service(local_net::BUS_ID)
@@ -284,6 +284,7 @@ impl Discovery {
                 Ok(h) => h,
                 Err(_) => {
                     log::trace!("Already handling bcast_offers, skipping...");
+                    counter!("market.offers.broadcasts.skip", 1);
                     return Ok(());
                 }
             };

--- a/core/market/src/protocol/discovery.rs
+++ b/core/market/src/protocol/discovery.rs
@@ -112,7 +112,7 @@ impl Discovery {
         let bcast_msg = SendBroadcastMessage::new(OffersBcast { offer_ids });
 
         counter!("market.offers.broadcasts.net", 1);
-        value!("market.offers.broadcasts.size", size as u64);
+        value!("market.offers.broadcasts.len", size as u64);
 
         // TODO: We shouldn't use send_as. Put identity inside broadcasted message instead.
         if let Err(e) = bus::service(local_net::BUS_ID)
@@ -210,7 +210,7 @@ impl Discovery {
         log::debug!("Broadcasting unsubscribes. count={}", size);
         let bcast_msg = SendBroadcastMessage::new(UnsubscribedOffersBcast { offer_ids });
         counter!("market.offers.unsubscribes.broadcasts.net", 1);
-        value!("market.offers.unsubscribes.broadcasts.size", size as u64);
+        value!("market.offers.unsubscribes.broadcasts.len", size as u64);
 
         // TODO: We shouldn't use send_as. Put identity inside broadcasted message instead.
         if let Err(e) = bus::service(local_net::BUS_ID)

--- a/core/metrics/src/pusher.rs
+++ b/core/metrics/src/pusher.rs
@@ -61,6 +61,9 @@ pub async fn push(client: &Client, push_url: String) {
         .await;
     match res {
         Ok(r) if r.status().is_success() => log::trace!("Pushed metrics: {:#?}", r),
+        Ok(r) if r.status().is_server_error() => {
+            log::debug!("Metrics server @ {} error: {:#?}", push_url, r)
+        }
         Ok(mut r) => {
             let body = r.body().await.unwrap_or_default().to_vec();
             let msg = String::from_utf8_lossy(&body);


### PR DESCRIPTION
Why:
- initialization of the metric `market.offers.broadcasts.size` as `counter` conflicts with its usage, which causes `400 Bad Request` from Prometheus and prevents metrics retention for such nodes.
- bcast size has potentially fastly changing value, so histogram is better than gauge
- in order to asses how many bcats are skipped network-wide, we need this to be reported as a metric

What:
- restore bcast size metric to use `value!` rather than `gauge!`(revert change from #1392)
- adding a missing metric to count skipped bcasts

Bonus:
- Fixes message for #1087