### PR TITLE
Http file transfer: handle complete temporary files

### DIFF
--- a/exe-unit/examples/transfer_resume.rs
+++ b/exe-unit/examples/transfer_resume.rs
@@ -110,6 +110,22 @@ fn hash_file<P: AsRef<Path>>(path: P) -> GenericArray<u8, <sha3::Sha3_224 as Dig
     hasher.result()
 }
 
+fn verify_file_hash<P: AsRef<Path>>(path: P, expected: &str) -> anyhow::Result<()> {
+    let hash = hex::encode(hash_file(path));
+
+    log::info!("input  hash: {}", expected);
+    log::info!("result hash: {}", hash);
+
+    if hash.as_str() != expected {
+        anyhow::bail!(
+            "hash mismatch: {} vs {} (expected)",
+            hash.as_str(),
+            expected
+        );
+    }
+    Ok(())
+}
+
 async fn download<P: AsRef<Path>>(dst_path: P, args: Cli) -> anyhow::Result<()> {
     let dst_path = dst_path.as_ref();
 
@@ -123,18 +139,16 @@ async fn download<P: AsRef<Path>>(dst_path: P, args: Cli) -> anyhow::Result<()> 
     retry.backoff(1., 1.);
     ctx.state.retry_with(retry);
 
+    log::info!("Transferring file");
     transfer_with(&src, &src_url, &dst, &dst_url, &ctx).await?;
-
     log::info!("File downloaded, verifying contents");
+    verify_file_hash(&dst_path, &args.hash)?;
 
-    let hash = hex::encode(hash_file(&dst_path));
+    log::info!("Retrying transfer on a completed file");
+    transfer_with(&src, &src_url, &dst, &dst_url, &ctx).await?;
+    log::info!("Verifying contents");
+    verify_file_hash(&dst_path, &args.hash)?;
 
-    log::info!("input  hash: {}", args.hash);
-    log::info!("result hash: {}", hash);
-
-    if args.hash != hash {
-        anyhow::bail!("hash mismatch");
-    }
     Ok(())
 }
 

--- a/exe-unit/src/service/transfer.rs
+++ b/exe-unit/src/service/transfer.rs
@@ -273,7 +273,13 @@ impl Handler<DeployImage> for TransferService {
                     Ok::<_, Error>(
                         Abortable::new(retry, reg)
                             .await
-                            .map_err(TransferError::from)??,
+                            .map_err(TransferError::from)?
+                            .map_err(|err| {
+                                if let TransferError::InvalidHashError { .. } = err {
+                                    let _ = std::fs::remove_file(&path_tmp);
+                                }
+                                err
+                            })?,
                     )
                 }?;
 


### PR DESCRIPTION
Resolves https://github.com/golemfactory/yagna-triage/issues/134

- finalize http transfers of complete temporary files, which weren't moved to the designated location;
  `transfer_resume` example now demonstrates this case
- deploy: remove temporary files when hash does not match