### PR TITLE
Deb version fix via `ya-compile-time-utils`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4988,7 +4988,7 @@ version = "0.5.1"
 source = "git+https://github.com/tworec/serial_test.git?branch=actix_rt_test#6c848541e89262f90ca693d9e1a84c6f3df0953b"
 dependencies = [
  "lazy_static",
- "parking_lot 0.10.2",
+ "parking_lot 0.11.1",
  "serial_test_derive",
 ]
 
@@ -6503,7 +6503,7 @@ dependencies = [
 
 [[package]]
 name = "ya-compile-time-utils"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "git-version",
  "metrics 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "core/serv/src/main.rs"
 
 [dependencies]
 ya-activity = "0.3"
-ya-compile-time-utils = "0.1"
+ya-compile-time-utils = "0.2"
 ya-core-model = { version = "^0.4"}
 ya-dummy-driver = { version = "0.2", optional = true }
 ya-file-logging = "0.1"

--- a/agent/provider/Cargo.toml
+++ b/agent/provider/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 ya-agreement-utils = { version = "^0.2"}
 ya-client = { version = "0.5", features = ['cli'] }
 ya-client-model = "0.3"
-ya-compile-time-utils = "0.1"
+ya-compile-time-utils = "0.2"
 ya-core-model = { version = "^0.4", features = ['activity', 'payment'] }
 ya-file-logging = "0.1"
 ya-utils-actix = "0.1"

--- a/core/gftp/Cargo.toml
+++ b/core/gftp/Cargo.toml
@@ -18,7 +18,7 @@ name="gftp"
 required-features=['bin']
 
 [dependencies]
-ya-compile-time-utils = "0.1"
+ya-compile-time-utils = "0.2"
 ya-core-model = { version = "^0.4", features = ["gftp", "identity", "net"] }
 ya-service-bus = "0.4"
 

--- a/core/version/Cargo.toml
+++ b/core/version/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client = "0.5"
-ya-compile-time-utils = "0.1"
+ya-compile-time-utils = "0.2"
 ya-core-model = { version = "^0.4", features = ["version"] }
 ya-persistence = "0.2"
 ya-service-api = "0.1"

--- a/core/version/src/db/dao.rs
+++ b/core/version/src/db/dao.rs
@@ -77,7 +77,7 @@ impl<'c> ReleaseDAO<'c> {
 }
 
 fn get_current_release(conn: &ConnType) -> anyhow::Result<Option<Release>> {
-    get_release(conn, ya_compile_time_utils::semver_str())
+    get_release(conn, ya_compile_time_utils::semver_str!())
 }
 
 fn get_release(conn: &ConnType, ver: &str) -> anyhow::Result<Option<Release>> {
@@ -99,7 +99,7 @@ fn get_pending_release(conn: &ConnType, include_seen: bool) -> anyhow::Result<Op
 
     match query.first::<DBRelease>(conn).optional()? {
         Some(db_rel) => {
-            let running_ver = ya_compile_time_utils::semver_str();
+            let running_ver = ya_compile_time_utils::semver_str!();
             if !bump_is_greater(running_ver, &db_rel.version)
                 .map_err(|e| {
                     log::error!(

--- a/core/version/src/db/model.rs
+++ b/core/version/src/db/model.rs
@@ -22,7 +22,7 @@ pub struct DBRelease {
 impl DBRelease {
     pub(crate) fn current() -> anyhow::Result<Self> {
         Ok(DBRelease {
-            version: ya_compile_time_utils::semver_str().into(),
+            version: ya_compile_time_utils::semver_str!().into(),
             name: format!(
                 "({} {}{})",
                 ya_compile_time_utils::git_rev(),

--- a/core/version/src/github.rs
+++ b/core/version/src/github.rs
@@ -38,7 +38,7 @@ pub async fn check_latest_release(db: &DbExecutor) -> anyhow::Result<Release> {
         Ok(r) => r,
     };
 
-    if self_update::version::bump_is_greater(ya_compile_time_utils::semver_str(), &rel.version)
+    if self_update::version::bump_is_greater(ya_compile_time_utils::semver_str!(), &rel.version)
         .map_err(|e| {
             anyhow!(
                 "Github release version `{}` parse error: {}",
@@ -58,7 +58,7 @@ pub(crate) async fn check_running_release(db: &DbExecutor) -> anyhow::Result<Rel
         return Ok(release);
     }
 
-    let running_tag = ya_compile_time_utils::git_tag();
+    let running_tag = ya_compile_time_utils::git_tag!();
     log::debug!("Checking release for running tag: {}", running_tag);
 
     let db_rel = match tokio::task::spawn_blocking(move || {

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -29,7 +29,7 @@ winapi = { version = "0.3.8", features = ["jobapi2", "processthreadsapi"] }
 [dependencies]
 ya-agreement-utils = { version = "^0.2"}
 ya-client-model = "0.3"
-ya-compile-time-utils = "0.1"
+ya-compile-time-utils = "0.2"
 ya-core-model = { version = "^0.4", features = ["activity", "appkey"] }
 ya-runtime-api = { version = "0.3", path = "runtime-api", features = ["server"] }
 ya-service-bus = "0.4"

--- a/golem_cli/Cargo.toml
+++ b/golem_cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 
 [dependencies]
 ya-client = { version = "0.5", features = ['cli'] }
-ya-compile-time-utils = "0.1"
+ya-compile-time-utils = "0.2"
 ya-core-model = { version = "^0.4", features=["payment", "version"] }
 ya-provider = "0.2"
 ya-utils-path = "0.1.0"

--- a/golem_cli/src/main.rs
+++ b/golem_cli/src/main.rs
@@ -81,7 +81,7 @@ async fn my_main() -> Result</*exit code*/ i32> {
 pub fn banner() {
     terminal::fade_in(&format!(
         include_str!("banner.txt"),
-        version = ya_compile_time_utils::semver_str(),
+        version = ya_compile_time_utils::semver_str!(),
         git_commit = ya_compile_time_utils::git_rev(),
         date = ya_compile_time_utils::build_date(),
         build = ya_compile_time_utils::build_number_str().unwrap_or("-"),

--- a/golem_cli/src/status.rs
+++ b/golem_cli/src/status.rs
@@ -77,7 +77,7 @@ pub async fn run() -> Result</*exit code*/ i32> {
                 Style::new().fg(Colour::Red).paint("is not running")
             ]);
         }
-        table.add_row(row!["Version", ya_compile_time_utils::semver_str()]);
+        table.add_row(row!["Version", ya_compile_time_utils::semver_str!()]);
         table.add_row(row!["Commit", ya_compile_time_utils::git_rev()]);
         table.add_row(row!["Date", ya_compile_time_utils::build_date()]);
         table.add_row(row![

--- a/utils/compile-time-utils/Cargo.toml
+++ b/utils/compile-time-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-compile-time-utils"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/yagna/utils/compile-time-utils"


### PR DESCRIPTION
Deb is set to proper crate version when the `git_version` crate cannot resolve the `git` binary / `git` is unavailable.

Resolves #1438 