### PR TITLE
Fix got log after rust update

### DIFF
--- a/goth_tests/helpers/probe.py
+++ b/goth_tests/helpers/probe.py
@@ -33,7 +33,7 @@ class ProviderProbe(BaseProviderProbe):
     async def wait_for_exeunit_finished(self):
         """Wait until exe-unit finishes."""
         await self.provider_agent.wait_for_log(
-            r"(.*)ExeUnit process exited with status Finished - exit code: 0(.*)"
+            r"(.*)ExeUnit process exited with status Finished - exit status: 0(.*)"
         )
 
     @step()

--- a/utils/process/src/lib.rs
+++ b/utils/process/src/lib.rs
@@ -76,12 +76,7 @@ impl ProcessGroupExt<tokio::process::Command> for tokio::process::Command {
 pub enum ExeUnitExitStatus {
     #[display(fmt = "Aborted - {}", _0)]
     Aborted(std::process::ExitStatus),
-    // workaround for goth being bound to previous stdlib Display impl for ExitCode
-    // it was changed recently: https://github.com/rust-lang/rust/commit/11e40ce240d884303bee142a727decaeeef43bdb#diff-7015a38ee6056bbfa832b33281ffeaad5531c4dbfaff60ddfce0934475e040f4R532
-    #[display(
-        fmt = "Finished - exit code: {}",
-        "_0.code().map(|code| format!(\"{}\", code)).unwrap_or(\"None\".into())"
-    )]
+    #[display(fmt = "Finished - {}", _0)]
     Finished(std::process::ExitStatus),
     #[display(fmt = "Error - {}", _0)]
     Error(std::io::Error),


### PR DESCRIPTION
Revert the old hack and apply the required log line change

This reverts commit 76c3b218cf3c62b800afcc99b2fffba32bce991d.