### PR TITLE
[golemsp] status command with better UX for Tasks column

### DIFF
--- a/golem_cli/src/status.rs
+++ b/golem_cli/src/status.rs
@@ -190,6 +190,7 @@ pub async fn run() -> Result</*exit code*/ i32> {
             table.add_row(row!["last 1h processed", status.last1h_processed()]);
             table.add_row(row!["last 1h in progress", status.in_progress()]);
             table.add_row(row!["total processed", status.total_processed()]);
+            table.add_row(row!["(including failures)"]);
 
             table
         };


### PR DESCRIPTION
Now `golemsp status` will show `(including failures)` at the bottom of **Tasks** column, not to confuse our providers on the network.
They see that they completed tasks overnight by watching the `total processed` amount, and then their wallet doesn't match because it hasn't gone up.
```
┌────────────────────────────┬───────────────────────────────────────────────────┬───────────────────────────┐
│  Status                    │  Wallet                                           │  Tasks                    │
│                            │  0x979db95461652299c34e15df09441b8dfc4edf7a       │                           │
│  Service    is running     │                                                   │  last 1h processed     0  │
│  Version    0.7.3-rc1      │  network               mainnet                    │  last 1h in progress   0  │
│  Commit     f1f6e471       │  amount (total)        31.922945251204737818 GLM  │  total processed       0  │
│  Date       2021-07-19     │      (on-chain)        3.727634841182177818 GLM   │  (including failures)     │
│  Build      -              │       (zk-sync)        28.19531041002256 GLM      │                           │
│                            │                                                   │                           │
│  Node Name  2rec-iMac      │  pending               0 GLM (0)                  │                           │
│  Subnet     devnet-beta.2  │  issued                0 GLM (0)                  │                           │
└────────────────────────────┴───────────────────────────────────────────────────┴───────────────────────────┘
```

This is only a workaround for https://github.com/golemfactory/yagna-triage/issues/136
