### PR TITLE
Cherry-pick of #1448 (move goth log assertions to yagna)

### DIFF
--- a/goth_tests/README.md
+++ b/goth_tests/README.md
@@ -288,3 +288,23 @@ async def test_something(
 ):
     goth_config = load_yaml(Path("path/to/goth-config.yml", config_overrides)
 ```
+
+### Maintenance
+
+#### Updating expected `yagna` log lines
+Some `goth` test steps rely on scanning the logs from a process running on one or more `yagna` nodes. In particular, this is used extensively in the case of provider agent logs (e.g. determining if the exeunit has finished successfully).
+
+
+Since log messages are subject to change, these log line patterns need to be kept up to date.
+
+`yagna` tests implement a custom `ProviderProbe` class (`goth_tests/helpers/probe.py`) which includes all the commonly used log patterns as its methods.
+
+When a test fails due to an updated log message, the expected pattern can be updated by modifying one of `ProviderProbe`'s methods, e.g.:
+```
+@step()
+async def wait_for_exeunit_finished(self):
+    """Wait until exe-unit finishes."""
+    await self.provider_agent.wait_for_log(
+        r"(.*)ExeUnit process exited with status Finished - exit code: 0(.*)"
+    )
+```

--- a/goth_tests/conftest.py
+++ b/goth_tests/conftest.py
@@ -21,12 +21,21 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope="session")
 def common_assets() -> Path:
+    """Fixture providing path to dir containing generated goth assets."""
     assets_path = Path(__file__).parent / "assets"
     return assets_path.resolve()
 
 
 @pytest.fixture(scope="session")
+def default_config() -> Path:
+    """Fixture providing path to yagna's default goth config."""
+    config_path = Path(__file__).parent / "goth-config.yml"
+    return config_path.resolve()
+
+
+@pytest.fixture(scope="session")
 def log_dir() -> Path:
+    """Fixture providing unique directory for logs from a test run."""
     base_dir = Path("/", "tmp", "goth-tests")
     date_str = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S%z")
     log_dir = base_dir / f"goth_{date_str}"

--- a/goth_tests/domain/payments/test_payment_driver_list_cmd.py
+++ b/goth_tests/domain/payments/test_payment_driver_list_cmd.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.asyncio
 async def test_payment_driver_list(
     common_assets: Path,
+    default_config: Path,
     config_overrides: List[Override],
     log_dir: Path,
 ):
@@ -30,7 +31,7 @@ async def test_payment_driver_list(
         {"name": "requestor", "type": "Requestor"},
     ]
     config_overrides.append(("nodes", nodes))
-    goth_config = load_yaml(common_assets / "goth-config.yml", config_overrides)
+    goth_config = load_yaml(default_config, config_overrides)
 
     runner = Runner(
         base_log_dir=log_dir,

--- a/goth_tests/domain/payments/test_zero_amount_txs.py
+++ b/goth_tests/domain/payments/test_zero_amount_txs.py
@@ -13,11 +13,12 @@ from goth.address import (
 from goth.configuration import load_yaml, Override
 from goth.node import node_environment
 from goth.runner import Runner
-from goth.runner.probe import ProviderProbe, RequestorProbe
+from goth.runner.probe import RequestorProbe
 from ya_payment import InvoiceStatus
 
 from goth_tests.helpers.activity import wasi_exe_script, wasi_task_package
 from goth_tests.helpers.negotiation import DemandBuilder, negotiate_agreements
+from goth_tests.helpers.probe import ProviderProbe
 
 logger = logging.getLogger("goth.test.zero_amount_txs")
 
@@ -25,6 +26,7 @@ logger = logging.getLogger("goth.test.zero_amount_txs")
 @pytest.mark.asyncio
 async def test_zero_amount_invoice(
     common_assets: Path,
+    default_config: Path,
     config_overrides: List[Override],
     log_dir: Path,
 ):
@@ -36,7 +38,7 @@ async def test_zero_amount_invoice(
     ]
     config_overrides.append(("nodes", nodes))
 
-    goth_config = load_yaml(common_assets / "goth-config.yml", config_overrides)
+    goth_config = load_yaml(default_config, config_overrides)
 
     runner = Runner(
         base_log_dir=log_dir,

--- a/goth_tests/domain/ya-provider/goth-config.yml
+++ b/goth_tests/domain/ya-provider/goth-config.yml
@@ -1,0 +1,62 @@
+# Note: values of keys denoting paths are resolved relative to the directory
+# in which this file is located.
+# The tokens `~` and `~user` are also replaced by the corresponding users's
+# home directory.
+
+docker-compose:
+
+  docker-dir: "../../assets/docker/"
+
+  build-environment:
+    # TODO:
+    # For now these settings are common to all `yagna` containers.
+    # In future we may want to have nodes running different versions
+    # of `yagna` in the test network.
+
+    # binary-path: ...
+    # deb-path: ...
+    # branch: ...
+    # commit-hash: ...
+    # release-tag: ...
+
+  compose-log-patterns:
+    ethereum: ".*Wallets supplied."
+    zksync: ".*Running on http://0.0.0.0:3030/.*"
+
+
+key-dir: "../../assets/keys"
+
+
+web-root: "../../assets/web-root"
+
+
+node-types:
+  # Each node type is a collection of attributes common to a group of nodes.
+  # Required attributes are "name" and "class".
+
+  - name: "Requestor"
+    class: "goth.runner.probe.RequestorProbe"
+
+  - name: "Wasm-Provider"
+    class: "goth_tests.helpers.probe.ProviderProbe"
+    mount:
+      - read-only: "../../assets/provider/presets.json"
+        destination: "/root/.local/share/ya-provider/presets.json"
+      - read-only: "../../assets/provider/hardware.json"
+        destination: "/root/.local/share/ya-provider/hardware.json"
+      - read-write: "~/.local/share/ya-provider/vm-images"
+        destination: "/root/.local/share/ya-provider/exe-unit/cache/tmp"
+    privileged-mode: True
+    environment:
+      - "IDLE_AGREEMENT_TIMEOUT=5s"
+      - "DEBIT_NOTE_ACCEPTANCE_DEADLINE=8s"
+      - "DEBIT_NOTE_INTERVAL=6"
+
+nodes:
+
+  - name: "requestor"
+    type: "Requestor"
+
+  - name: "provider-1"
+    type: "Wasm-Provider"
+    use-proxy: True

--- a/goth_tests/domain/ya-provider/test_provider_break_agreement.py
+++ b/goth_tests/domain/ya-provider/test_provider_break_agreement.py
@@ -1,0 +1,235 @@
+"""End to end tests for various scenarios which involve breaking agreements."""
+
+import logging
+from pathlib import Path
+from typing import List, Tuple
+
+import pytest
+
+from goth.address import (
+    PROXY_HOST,
+    YAGNA_REST_URL,
+)
+from goth.configuration import load_yaml, Override, Configuration
+from goth.node import node_environment
+from goth.runner import Runner
+from goth.runner.container.payment import PaymentIdPool
+from goth.runner.container.yagna import YagnaContainerConfig
+from goth.runner.probe import RequestorProbe
+
+from goth_tests.helpers.activity import run_activity, wasi_exe_script, wasi_task_package
+from goth_tests.helpers.negotiation import negotiate_agreements, DemandBuilder
+from goth_tests.helpers.payment import pay_all
+from goth_tests.helpers.probe import ProviderProbe
+
+logger = logging.getLogger("goth.test.breaking-agreement")
+
+
+def build_demand(
+    requestor: RequestorProbe,
+    runner: Runner,
+    task_package_template: str,
+    require_debit_notes=True,
+):
+    """Simplifies creating demand."""
+
+    task_package = task_package_template.format(
+        web_server_addr=runner.host_address, web_server_port=runner.web_server_port
+    )
+
+    demand = (
+        DemandBuilder(requestor)
+        .props_from_template(task_package)
+        .property("golem.srv.caps.multi-activity", True)
+        .constraints(
+            "(&(golem.com.pricing.model=linear)\
+            (golem.srv.caps.multi-activity=true)\
+            (golem.runtime.name=wasmtime))"
+        )
+    )
+
+    if require_debit_notes:
+        demand = demand.property("golem.com.payment.debit-notes.accept-timeout?", 8)
+    return demand.build()
+
+
+def _create_runner(
+    common_assets: Path, config_overrides: List[Override], log_dir: Path
+) -> Tuple[Runner, Configuration]:
+    goth_config = load_yaml(
+        Path(__file__).parent / "goth-config.yml",
+        config_overrides,
+    )
+
+    runner = Runner(
+        base_log_dir=log_dir,
+        compose_config=goth_config.compose_config,
+        web_root_path=common_assets / "web-root",
+    )
+
+    return runner, goth_config
+
+
+@pytest.mark.asyncio
+async def test_provider_idle_agreement(
+    common_assets: Path,
+    config_overrides: List[Override],
+    log_dir: Path,
+):
+    """Test provider breaking idle Agreement.
+
+    Provider is expected to break Agreement in time configured by
+    variable: IDLE_AGREEMENT_TIMEOUT, if there are no Activities created.
+    """
+    runner, config = _create_runner(common_assets, config_overrides, log_dir)
+
+    async with runner(config.containers):
+        requestor = runner.get_probes(probe_type=RequestorProbe)[0]
+        providers = runner.get_probes(probe_type=ProviderProbe)
+        assert providers
+
+        agreement_providers = await negotiate_agreements(
+            requestor,
+            build_demand(requestor, runner, wasi_task_package),
+            providers,
+        )
+
+        # Break after 5s + 3s margin
+        await providers[0].wait_for_agreement_broken(r"No activity created", timeout=8)
+
+        await pay_all(requestor, agreement_providers)
+
+
+@pytest.mark.asyncio
+async def test_provider_idle_agreement_after_2_activities(
+    common_assets: Path,
+    config_overrides: List[Override],
+    log_dir: Path,
+):
+    """Test provider breaking idle Agreement after 2 Activities were computed.
+
+    Provider is expected to break Agreement, if no new Activity was created
+    after time configured by variable: IDLE_AGREEMENT_TIMEOUT.
+    This test checks case, when Requestor already computed some Activities,
+    but orphaned Agreement at some point.
+    """
+    runner, config = _create_runner(common_assets, config_overrides, log_dir)
+
+    async with runner(config.containers):
+        requestor = runner.get_probes(probe_type=RequestorProbe)[0]
+        providers = runner.get_probes(probe_type=ProviderProbe)
+        assert providers
+
+        agreement_providers = await negotiate_agreements(
+            requestor,
+            build_demand(
+                requestor, runner, wasi_task_package, require_debit_notes=False
+            ),
+            providers,
+        )
+
+        agreement_id, provider = agreement_providers[0]
+        for i in range(0, 2):
+            logger.info("Running activity %d-th time on %s", i, provider.name)
+            await run_activity(
+                requestor, provider, agreement_id, wasi_exe_script(runner)
+            )
+
+        # Break after 5s + 3s margin
+        await providers[0].wait_for_agreement_broken("No activity created", timeout=8)
+
+        await pay_all(requestor, agreement_providers)
+
+
+@pytest.mark.asyncio
+async def test_provider_debit_notes_accept_timeout(
+    common_assets: Path,
+    config_overrides: List[Override],
+    log_dir: Path,
+):
+    """Test provider breaking Agreement if Requestor doesn't accept DebitNotes.
+
+    Requestor is expected to accept DebitNotes in timeout negotiated in Offer.
+    """
+    runner, config = _create_runner(common_assets, config_overrides, log_dir)
+
+    async with runner(config.containers):
+        requestor = runner.get_probes(probe_type=RequestorProbe)[0]
+        providers = runner.get_probes(probe_type=ProviderProbe)
+        assert providers
+
+        agreement_providers = await negotiate_agreements(
+            requestor,
+            build_demand(requestor, runner, wasi_task_package),
+            providers,
+        )
+
+        agreement_id, provider = agreement_providers[0]
+
+        await requestor.create_activity(agreement_id)
+        await provider.wait_for_exeunit_started()
+
+        # Wait for first DebitNote sent by Provider.
+        await providers[0].wait_for_log(
+            r"Debit note \[.*\] for activity \[.*\] sent.", timeout=30
+        )
+
+        # Negotiated timeout is 8s. Let's wait with some margin.
+        await providers[0].wait_for_agreement_broken(
+            "Requestor isn't accepting DebitNotes in time",
+            timeout=12,
+        )
+
+        await pay_all(requestor, agreement_providers)
+
+
+@pytest.mark.asyncio
+async def test_provider_timeout_unresponsive_requestor(
+    common_assets: Path,
+    config_overrides: List[Override],
+    log_dir: Path,
+):
+    """Test provider breaking Agreement if Requestor goes offline.
+
+    If Provider is unable to send DebitNotes for some period of time, he should
+    break Agreement. This is separate mechanism from DebitNotes keep alive, because
+    here we are unable to send them, so they can't timeout.
+    """
+    runner, config = _create_runner(common_assets, config_overrides, log_dir)
+
+    # Stopping container takes a little bit more time, so we must send
+    # DebitNote later, otherwise Agreement will be terminated due to
+    # not accepting DebitNotes by Requestor.
+    config.containers[1].environment["DEBIT_NOTE_INTERVAL"] = "15"
+
+    async with runner(config.containers):
+        requestor = runner.get_probes(probe_type=RequestorProbe)[0]
+        providers = runner.get_probes(probe_type=ProviderProbe)
+        assert providers
+
+        agreement_providers = await negotiate_agreements(
+            requestor,
+            build_demand(requestor, runner, wasi_task_package),
+            providers,
+        )
+
+        agreement_id, provider = agreement_providers[0]
+
+        # Create activity without waiting. Otherwise Provider will manage
+        # to send first DebitNote, before we kill Requestor Yagna daemon.
+        # loop = asyncio.get_event_loop()
+        await requestor.create_activity(agreement_id)
+
+        # Stop Requestor probe. This should kill Yagna Daemon and
+        # make Requestor unreachable, so Provider won't be able to send DebitNotes.
+        requestor.container.stop()
+
+        # First DebitNote will be sent after 15s. Let's wait with some margin.
+        await providers[0].wait_for_agreement_broken(
+            "Requestor is unreachable more than",
+            timeout=18,
+        )
+
+        # Note that Agreement will be broken, but Provider won't be
+        # able to terminate it, because other Yagna daemon is unreachable,
+        # so Provider will retry terminating in infinity.

--- a/goth_tests/domain/ya-provider/test_provider_multi_activity.py
+++ b/goth_tests/domain/ya-provider/test_provider_multi_activity.py
@@ -2,25 +2,36 @@
 
 import json
 import logging
+import re
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 import pytest
+from ya_activity.exceptions import ApiException
 
-from goth.address import (
-    PROXY_HOST,
-    YAGNA_REST_URL,
-)
-from goth.configuration import load_yaml, Override
-from goth.node import node_environment
+from goth.configuration import load_yaml, Override, Configuration
 from goth.runner import Runner
-from goth.runner.probe import ProviderProbe, RequestorProbe
+from goth.runner.probe import RequestorProbe
 
 from goth_tests.helpers.activity import wasi_exe_script, wasi_task_package
 from goth_tests.helpers.negotiation import negotiate_agreements, DemandBuilder
 from goth_tests.helpers.payment import pay_all
+from goth_tests.helpers.probe import ProviderProbe
 
 logger = logging.getLogger("goth.test.multi-activity")
+
+
+def _create_runner(
+    common_assets: Path, config_overrides: List[Override], log_dir: Path
+) -> Tuple[Runner, Configuration]:
+    goth_config = load_yaml(Path(__file__).parent / "goth-config.yml", config_overrides)
+
+    runner = Runner(
+        base_log_dir=log_dir,
+        compose_config=goth_config.compose_config,
+        web_root_path=common_assets / "web-root",
+    )
+    return runner, goth_config
 
 
 @pytest.mark.asyncio
@@ -29,30 +40,26 @@ async def test_provider_multi_activity(
     config_overrides: List[Override],
     log_dir: Path,
 ):
-    """Test provider handling multiple activities in single Agreement."""
+    """Test provider handling multiple activities in single Agreement.
 
-    nodes = [
-        {"name": "requestor", "type": "Requestor"},
-        {"name": "provider-1", "type": "VM-Wasm-Provider", "use-proxy": True},
-    ]
-    config_overrides.append(("nodes", nodes))
+    Tests running multiple activities on single Provider.
+    In this case Requestor is responsible for terminating Agreement.
+    """
+    runner, config = _create_runner(common_assets, config_overrides, log_dir)
 
-    goth_config = load_yaml(common_assets / "goth-config.yml", config_overrides)
-
-    runner = Runner(
-        base_log_dir=log_dir,
-        compose_config=goth_config.compose_config,
-        web_root_path=common_assets / "web-root",
-    )
-
-    async with runner(goth_config.containers):
+    async with runner(config.containers):
         requestor = runner.get_probes(probe_type=RequestorProbe)[0]
         providers = runner.get_probes(probe_type=ProviderProbe)
+        assert providers
 
         # Market
+        task_package = wasi_task_package.format(
+            web_server_addr=runner.host_address, web_server_port=runner.web_server_port
+        )
+
         demand = (
             DemandBuilder(requestor)
-            .props_from_template(wasi_task_package)
+            .props_from_template(task_package)
             .property("golem.srv.caps.multi-activity", True)
             .constraints(
                 "(&(golem.com.pricing.model=linear)\
@@ -66,7 +73,6 @@ async def test_provider_multi_activity(
             requestor,
             demand,
             providers,
-            lambda p: p.properties.get("golem.runtime.name") == "wasmtime",
         )
 
         #  Activity
@@ -74,7 +80,7 @@ async def test_provider_multi_activity(
 
         for agreement_id, provider in agreement_providers:
             for i in range(0, 3):
-                logger.info("Running activity %s-th time on %s", i, provider.name)
+                logger.info("Running activity %d-th time on %s", i, provider.name)
                 activity_id = await requestor.create_activity(agreement_id)
                 await provider.wait_for_exeunit_started()
                 batch_id = await requestor.call_exec(
@@ -91,3 +97,65 @@ async def test_provider_multi_activity(
 
         # Payment
         await pay_all(requestor, agreement_providers)
+
+
+@pytest.mark.asyncio
+async def test_provider_single_simultaneous_activity(
+    common_assets: Path,
+    config_overrides: List[Override],
+    log_dir: Path,
+):
+    """Test provider rejecting second activity if one is already running.
+
+    Provider is expected to reject second activity, if one is already running.
+    """
+    runner, config = _create_runner(common_assets, config_overrides, log_dir)
+
+    async with runner(config.containers):
+        requestor = runner.get_probes(probe_type=RequestorProbe)[0]
+        providers = runner.get_probes(probe_type=ProviderProbe)
+        assert providers
+
+        # Market
+        task_package = wasi_task_package.format(
+            web_server_addr=runner.host_address, web_server_port=runner.web_server_port
+        )
+
+        demand = (
+            DemandBuilder(requestor)
+            .props_from_template(task_package)
+            .property("golem.srv.caps.multi-activity", True)
+            .constraints(
+                "(&(golem.com.pricing.model=linear)\
+                (golem.srv.caps.multi-activity=true)\
+                (golem.runtime.name=wasmtime))"
+            )
+            .build()
+        )
+
+        agreement_providers = await negotiate_agreements(
+            requestor,
+            demand,
+            providers,
+        )
+
+        #  Activity
+        agreement_id, provider = agreement_providers[0]
+
+        first_activity_id = await requestor.create_activity(agreement_id)
+
+        # Creation should fail here.
+        with pytest.raises(ApiException) as e:
+            await requestor.create_activity(agreement_id)
+
+        assert re.search(
+            r"terminated. Reason: Only single Activity allowed,"
+            r" message: Can't create 2 simultaneous Activities.",
+            e.value.body,
+        )
+
+        await requestor.destroy_activity(first_activity_id)
+        await provider.wait_for_exeunit_finished()
+
+        await requestor.terminate_agreement(agreement_id, None)
+        await provider.wait_for_agreement_terminated()

--- a/goth_tests/e2e/vm/test_e2e_vm.py
+++ b/goth_tests/e2e/vm/test_e2e_vm.py
@@ -17,10 +17,11 @@ from goth.node import node_environment
 from goth.runner import Runner
 from goth.runner.container.payment import PaymentIdPool
 from goth.runner.container.yagna import YagnaContainerConfig
-from goth.runner.probe import ProviderProbe, RequestorProbe
+from goth.runner.probe import RequestorProbe
 
-from goth_tests.helpers.negotiation import DemandBuilder, negotiate_agreements
 from goth_tests.helpers.activity import vm_exe_script, vm_task_package
+from goth_tests.helpers.negotiation import DemandBuilder, negotiate_agreements
+from goth_tests.helpers.probe import ProviderProbe
 
 logger = logging.getLogger("goth.test.e2e_vm")
 
@@ -28,12 +29,13 @@ logger = logging.getLogger("goth.test.e2e_vm")
 @pytest.mark.asyncio
 async def test_e2e_vm(
     common_assets: Path,
+    default_config: Path,
     config_overrides: List[Override],
     log_dir: Path,
 ):
     """Test successful flow requesting a Blender task with goth REST API client."""
 
-    goth_config = load_yaml(common_assets / "goth-config.yml", config_overrides)
+    goth_config = load_yaml(default_config, config_overrides)
 
     runner = Runner(
         base_log_dir=log_dir,
@@ -44,6 +46,7 @@ async def test_e2e_vm(
     async with runner(goth_config.containers):
         requestor = runner.get_probes(probe_type=RequestorProbe)[0]
         providers = runner.get_probes(probe_type=ProviderProbe)
+        assert providers
 
         # Market
         demand = DemandBuilder(requestor).props_from_template(vm_task_package).build()

--- a/goth_tests/e2e/wasi/test_e2e_wasi.py
+++ b/goth_tests/e2e/wasi/test_e2e_wasi.py
@@ -14,10 +14,11 @@ from goth.address import (
 from goth.configuration import load_yaml, Override
 from goth.node import node_environment
 from goth.runner import Runner
-from goth.runner.probe import ProviderProbe, RequestorProbe
+from goth.runner.probe import RequestorProbe
 
 from goth_tests.helpers.activity import wasi_exe_script, wasi_task_package
 from goth_tests.helpers.negotiation import DemandBuilder, negotiate_agreements
+from goth_tests.helpers.probe import ProviderProbe
 
 logger = logging.getLogger("goth.test.e2e_wasi")
 
@@ -25,12 +26,13 @@ logger = logging.getLogger("goth.test.e2e_wasi")
 @pytest.mark.asyncio
 async def test_e2e_wasi(
     common_assets: Path,
+    default_config: Path,
     config_overrides: List[Override],
     log_dir: Path,
 ):
     """Test successful flow requesting WASM tasks with goth REST API client."""
 
-    goth_config = load_yaml(common_assets / "goth-config.yml", config_overrides)
+    goth_config = load_yaml(default_config, config_overrides)
 
     runner = Runner(
         base_log_dir=log_dir,
@@ -41,6 +43,7 @@ async def test_e2e_wasi(
     async with runner(goth_config.containers):
         requestor = runner.get_probes(probe_type=RequestorProbe)[0]
         providers = runner.get_probes(probe_type=ProviderProbe)
+        assert providers
 
         # Market
         demand = DemandBuilder(requestor).props_from_template(wasi_task_package).build()
@@ -72,6 +75,5 @@ async def test_e2e_wasi(
             await provider.wait_for_invoice_sent()
             invoices = await requestor.gather_invoices(agreement_id)
             assert all(inv.agreement_id == agreement_id for inv in invoices)
-            # TODO:
             await requestor.pay_invoices(invoices)
             await provider.wait_for_invoice_paid()

--- a/goth_tests/goth-config.yml
+++ b/goth_tests/goth-config.yml
@@ -1,0 +1,62 @@
+# Note: values of keys denoting paths are resolved relative to the directory
+# in which this file is located.
+# The tokens `~` and `~user` are also replaced by the corresponding users's
+# home directory.
+
+docker-compose:
+
+  docker-dir: "assets/docker/"
+
+  build-environment:
+    # TODO:
+    # For now these settings are common to all `yagna` containers.
+    # In future we may want to have nodes running different versions
+    # of `yagna` in the test network.
+
+    # binary-path: ...
+    # deb-path: ...
+    # branch: ...
+    # commit-hash: ...
+    # release-tag: ...
+
+  compose-log-patterns:
+    ethereum: ".*Wallets supplied."
+    zksync: ".*Running on http://0.0.0.0:3030/.*"
+
+
+key-dir: "assets/keys"
+
+
+web-root: "assets/web-root"
+
+
+node-types:
+  # Each node type is a collection of attributes common to a group of nodes.
+  # Required attributes are "name" and "class".
+
+  - name: "Requestor"
+    class: "goth.runner.probe.RequestorProbe"
+
+  - name: "VM-Wasm-Provider"
+    class: "goth_tests.helpers.probe.ProviderProbe"
+    mount:
+      - read-only: "assets/provider/presets.json"
+        destination: "/root/.local/share/ya-provider/presets.json"
+      - read-only: "assets/provider/hardware.json"
+        destination: "/root/.local/share/ya-provider/hardware.json"
+      - read-write: "~/.local/share/ya-provider/vm-images"
+        destination: "/root/.local/share/ya-provider/exe-unit/cache/tmp"
+    privileged-mode: True
+
+nodes:
+
+  - name: "requestor"
+    type: "Requestor"
+
+  - name: "provider-1"
+    type: "VM-Wasm-Provider"
+    use-proxy: True
+
+  - name: "provider-2"
+    type: "VM-Wasm-Provider"
+    use-proxy: True

--- a/goth_tests/helpers/activity.py
+++ b/goth_tests/helpers/activity.py
@@ -1,9 +1,11 @@
 """Activity helpers."""
 
+import json
 import os
 from pathlib import Path
 
 from goth.runner import Runner
+from goth.runner.probe import ProviderProbe, RequestorProbe
 
 
 wasi_task_package: str = (
@@ -15,6 +17,24 @@ vm_task_package: str = (
     "hash:sha3:9a3b5d67b0b27746283cb5f287c13eab1beaa12d92a9f536b747c7ae:"
     "http://yacn2.dev.golem.network:8000/local-image-c76719083b.gvmi"
 )
+
+
+async def run_activity(
+    requestor: RequestorProbe,
+    provider: ProviderProbe,
+    agreement_id: str,
+    exe_script: dict,
+):
+    """Run single Activity from start to end."""
+
+    activity_id = await requestor.create_activity(agreement_id)
+    await provider.wait_for_exeunit_started()
+
+    batch_id = await requestor.call_exec(activity_id, json.dumps(exe_script))
+    await requestor.collect_results(activity_id, batch_id, len(exe_script), timeout=30)
+
+    await requestor.destroy_activity(activity_id)
+    await provider.wait_for_exeunit_finished()
 
 
 def vm_exe_script(runner: Runner, output_file: str = "output.png"):

--- a/goth_tests/helpers/probe.py
+++ b/goth_tests/helpers/probe.py
@@ -1,0 +1,78 @@
+"""This contains extensions of original `Probe` classes from `goth`."""
+
+from goth.runner.probe import ProviderProbe as BaseProviderProbe
+from goth.runner.step import step
+
+
+class ProviderProbe(BaseProviderProbe):
+    """Extension of `ProviderProbe` which adds steps related to agent logs."""
+
+    @step()
+    async def wait_for_offer_subscribed(self):
+        """Wait until the provider agent subscribes to the offer."""
+        await self.provider_agent.wait_for_log("Subscribed offer")
+
+    @step()
+    async def wait_for_proposal_accepted(self):
+        """Wait until the provider agent subscribes to the offer."""
+        await self.provider_agent.wait_for_log("Decided to CounterProposal")
+
+    @step()
+    async def wait_for_agreement_approved(self):
+        """Wait until the provider agent subscribes to the offer."""
+        await self.provider_agent.wait_for_log("Decided to ApproveAgreement")
+
+    @step()
+    async def wait_for_exeunit_started(self):
+        """Wait until the provider agent starts the exe-unit."""
+        await self.provider_agent.wait_for_log(
+            r"(.*)\[ExeUnit\](.+)Supervisor initialized$"
+        )
+
+    @step()
+    async def wait_for_exeunit_finished(self):
+        """Wait until exe-unit finishes."""
+        await self.provider_agent.wait_for_log(
+            r"(.*)ExeUnit process exited with status Finished - exit code: 0(.*)"
+        )
+
+    @step()
+    async def wait_for_agreement_terminated(self):
+        """Wait until Agreement will be terminated.
+
+        This can happen for 2 reasons (both caught by this function):
+        - Requestor terminates - most common case
+        - Provider terminates - it happens for compatibility with previous
+        versions of API without `terminate` endpoint implemented. Moreover
+        Provider can terminate, because Agreements condition where broken.
+        """
+        await self.provider_agent.wait_for_log(r"Agreement \[.*\] terminated by")
+
+    @step()
+    async def wait_for_agreement_cleanup(self):
+        """Wait until Provider will cleanup all allocated resources.
+
+        This can happen before or after Agreement terminated log will be printed.
+        """
+        await self.provider_agent.wait_for_log(r"Agreement \[.*\] cleanup finished.")
+
+    @step()
+    async def wait_for_invoice_sent(self):
+        """Wait until the invoice is sent."""
+        await self.provider_agent.wait_for_log("Invoice (.+) sent")
+
+    @step(default_timeout=300)
+    async def wait_for_invoice_paid(self):
+        """Wait until the invoice is paid."""
+        await self.provider_agent.wait_for_log("Invoice .+? for agreement .+? was paid")
+
+    @step()
+    async def wait_for_agreement_broken(self, reason: str):
+        """Wait until Provider will break Agreement."""
+        pattern = rf"Breaking agreement .*, reason: {reason}"
+        await self.provider_agent.wait_for_log(pattern)
+
+    @step()
+    async def wait_for_log(self, pattern: str):
+        """Wait for specific log."""
+        await self.provider_agent.wait_for_log(pattern)

--- a/goth_tests/poetry.lock
+++ b/goth_tests/poetry.lock
@@ -326,7 +326,7 @@ dev = ["jsonref"]
 
 [[package]]
 name = "goth"
-version = "0.4.0"
+version = "0.5.0"
 description = "Golem Test Harness - integration testing framework"
 category = "main"
 optional = false
@@ -732,11 +732,11 @@ python-versions = "*"
 
 [[package]]
 name = "pyrsistent"
-version = "0.17.3"
+version = "0.18.0"
 description = "Persistent/Functional/Immutable data structures"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [[package]]
 name = "pytest"
@@ -786,7 +786,7 @@ six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
-version = "0.17.1"
+version = "0.18.0"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 category = "main"
 optional = false
@@ -854,7 +854,7 @@ jinja2 = ["ruamel.yaml.jinja2 (>=0.2)"]
 
 [[package]]
 name = "ruamel.yaml.clib"
-version = "0.2.2"
+version = "0.2.4"
 description = "C version of reader, parser and emitter for ruamel.yaml derived from libyaml"
 category = "main"
 optional = false
@@ -941,7 +941,7 @@ python-versions = "*"
 
 [[package]]
 name = "urllib3"
-version = "1.26.5"
+version = "1.26.6"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -996,7 +996,7 @@ h11 = ">=0.8.1"
 
 [[package]]
 name = "ya-aioclient"
-version = "0.5.0"
+version = "0.5.1"
 description = ""
 category = "main"
 optional = false
@@ -1030,7 +1030,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8.0"
-content-hash = "bad19eaaee706785a281d9025e30703c6f7c7279ed913b163ad8508501666f57"
+content-hash = "b217eabee9c06cf1e9238d16e095801513f5911be16a4b9de0893c8f46ec248b"
 
 [metadata.files]
 aiohttp = [
@@ -1273,8 +1273,8 @@ ghapi = [
     {file = "ghapi-0.1.17.tar.gz", hash = "sha256:915e2c8ac52b6ab208c97f748c1660d6eca537de8f2833ae442949dd2c511e65"},
 ]
 goth = [
-    {file = "goth-0.4.0-py3-none-any.whl", hash = "sha256:929144f70fa8bc0aebd4056e94476d95f9dd031f1b4cf167e097de09d37e39ee"},
-    {file = "goth-0.4.0.tar.gz", hash = "sha256:0efc8bf59f5214b0b98b78090c26cdd59ce677efe03fd7c2745c1066f0425d28"},
+    {file = "goth-0.5.0-py3-none-any.whl", hash = "sha256:0b43d8a0d02b21d49fcb49ede690e2bbc5798394459b6fd9edff3b34bdb5e457"},
+    {file = "goth-0.5.0.tar.gz", hash = "sha256:51ea85e774e8a4181506bc6355f443946317d5810278de4f2291a6417e9f6f17"},
 ]
 h11 = [
     {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
@@ -1561,7 +1561,27 @@ pyperclip = [
     {file = "pyperclip-1.8.2.tar.gz", hash = "sha256:105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57"},
 ]
 pyrsistent = [
-    {file = "pyrsistent-0.17.3.tar.gz", hash = "sha256:2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"},
+    {file = "pyrsistent-0.18.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"},
+    {file = "pyrsistent-0.18.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:da6e5e818d18459fa46fac0a4a4e543507fe1110e808101277c5a2b5bab0cd2d"},
+    {file = "pyrsistent-0.18.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5e4395bbf841693eaebaa5bb5c8f5cdbb1d139e07c975c682ec4e4f8126e03d2"},
+    {file = "pyrsistent-0.18.0-cp36-cp36m-win32.whl", hash = "sha256:527be2bfa8dc80f6f8ddd65242ba476a6c4fb4e3aedbf281dfbac1b1ed4165b1"},
+    {file = "pyrsistent-0.18.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2aaf19dc8ce517a8653746d98e962ef480ff34b6bc563fc067be6401ffb457c7"},
+    {file = "pyrsistent-0.18.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58a70d93fb79dc585b21f9d72487b929a6fe58da0754fa4cb9f279bb92369396"},
+    {file = "pyrsistent-0.18.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4916c10896721e472ee12c95cdc2891ce5890898d2f9907b1b4ae0f53588b710"},
+    {file = "pyrsistent-0.18.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:73ff61b1411e3fb0ba144b8f08d6749749775fe89688093e1efef9839d2dcc35"},
+    {file = "pyrsistent-0.18.0-cp37-cp37m-win32.whl", hash = "sha256:b29b869cf58412ca5738d23691e96d8aff535e17390128a1a52717c9a109da4f"},
+    {file = "pyrsistent-0.18.0-cp37-cp37m-win_amd64.whl", hash = "sha256:097b96f129dd36a8c9e33594e7ebb151b1515eb52cceb08474c10a5479e799f2"},
+    {file = "pyrsistent-0.18.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:772e94c2c6864f2cd2ffbe58bb3bdefbe2a32afa0acb1a77e472aac831f83427"},
+    {file = "pyrsistent-0.18.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c1a9ff320fa699337e05edcaae79ef8c2880b52720bc031b219e5b5008ebbdef"},
+    {file = "pyrsistent-0.18.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cd3caef37a415fd0dae6148a1b6957a8c5f275a62cca02e18474608cb263640c"},
+    {file = "pyrsistent-0.18.0-cp38-cp38-win32.whl", hash = "sha256:e79d94ca58fcafef6395f6352383fa1a76922268fa02caa2272fff501c2fdc78"},
+    {file = "pyrsistent-0.18.0-cp38-cp38-win_amd64.whl", hash = "sha256:a0c772d791c38bbc77be659af29bb14c38ced151433592e326361610250c605b"},
+    {file = "pyrsistent-0.18.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d5ec194c9c573aafaceebf05fc400656722793dac57f254cd4741f3c27ae57b4"},
+    {file = "pyrsistent-0.18.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:6b5eed00e597b5b5773b4ca30bd48a5774ef1e96f2a45d105db5b4ebb4bca680"},
+    {file = "pyrsistent-0.18.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:48578680353f41dca1ca3dc48629fb77dfc745128b56fc01096b2530c13fd426"},
+    {file = "pyrsistent-0.18.0-cp39-cp39-win32.whl", hash = "sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b"},
+    {file = "pyrsistent-0.18.0-cp39-cp39-win_amd64.whl", hash = "sha256:404e1f1d254d314d55adb8d87f4f465c8693d6f902f67eb6ef5b4526dc58e6ea"},
+    {file = "pyrsistent-0.18.0.tar.gz", hash = "sha256:773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b"},
 ]
 pytest = [
     {file = "pytest-6.2.4-py3-none-any.whl", hash = "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"},
@@ -1576,8 +1596,8 @@ python-dateutil = [
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
 ]
 python-dotenv = [
-    {file = "python-dotenv-0.17.1.tar.gz", hash = "sha256:b1ae5e9643d5ed987fc57cc2583021e38db531946518130777734f9589b3141f"},
-    {file = "python_dotenv-0.17.1-py2.py3-none-any.whl", hash = "sha256:00aa34e92d992e9f8383730816359647f358f4a3be1ba45e5a5cefd27ee91544"},
+    {file = "python-dotenv-0.18.0.tar.gz", hash = "sha256:effaac3c1e58d89b3ccb4d04a40dc7ad6e0275fda25fd75ae9d323e2465e202d"},
+    {file = "python_dotenv-0.18.0-py2.py3-none-any.whl", hash = "sha256:dd8fe852847f4fbfadabf6183ddd4c824a9651f02d51714fa075c95561959c7d"},
 ]
 pywin32 = [
     {file = "pywin32-227-cp27-cp27m-win32.whl", hash = "sha256:371fcc39416d736401f0274dd64c2302728c9e034808e37381b5e1b22be4a6b0"},
@@ -1676,37 +1696,27 @@ requests = [
     {file = "ruamel.yaml-0.16.13.tar.gz", hash = "sha256:bb48c514222702878759a05af96f4b7ecdba9b33cd4efcf25c86b882cef3a942"},
 ]
 "ruamel.yaml.clib" = [
-    {file = "ruamel.yaml.clib-0.2.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:28116f204103cb3a108dfd37668f20abe6e3cafd0d3fd40dba126c732457b3cc"},
-    {file = "ruamel.yaml.clib-0.2.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:daf21aa33ee9b351f66deed30a3d450ab55c14242cfdfcd377798e2c0d25c9f1"},
-    {file = "ruamel.yaml.clib-0.2.2-cp27-cp27m-win32.whl", hash = "sha256:30dca9bbcbb1cc858717438218d11eafb78666759e5094dd767468c0d577a7e7"},
-    {file = "ruamel.yaml.clib-0.2.2-cp27-cp27m-win_amd64.whl", hash = "sha256:f6061a31880c1ed6b6ce341215336e2f3d0c1deccd84957b6fa8ca474b41e89f"},
-    {file = "ruamel.yaml.clib-0.2.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:73b3d43e04cc4b228fa6fa5d796409ece6fcb53a6c270eb2048109cbcbc3b9c2"},
-    {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:53b9dd1abd70e257a6e32f934ebc482dac5edb8c93e23deb663eac724c30b026"},
-    {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:839dd72545ef7ba78fd2aa1a5dd07b33696adf3e68fae7f31327161c1093001b"},
-    {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1236df55e0f73cd138c0eca074ee086136c3f16a97c2ac719032c050f7e0622f"},
-    {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-win32.whl", hash = "sha256:b1e981fe1aff1fd11627f531524826a4dcc1f26c726235a52fcb62ded27d150f"},
-    {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-win_amd64.whl", hash = "sha256:4e52c96ca66de04be42ea2278012a2342d89f5e82b4512fb6fb7134e377e2e62"},
-    {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a873e4d4954f865dcb60bdc4914af7eaae48fb56b60ed6daa1d6251c72f5337c"},
-    {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ab845f1f51f7eb750a78937be9f79baea4a42c7960f5a94dde34e69f3cce1988"},
-    {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:2fd336a5c6415c82e2deb40d08c222087febe0aebe520f4d21910629018ab0f3"},
-    {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-win32.whl", hash = "sha256:e9f7d1d8c26a6a12c23421061f9022bb62704e38211fe375c645485f38df34a2"},
-    {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:2602e91bd5c1b874d6f93d3086f9830f3e907c543c7672cf293a97c3fabdcd91"},
-    {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:44c7b0498c39f27795224438f1a6be6c5352f82cb887bc33d962c3a3acc00df6"},
-    {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8e8fd0a22c9d92af3a34f91e8a2594eeb35cba90ab643c5e0e643567dc8be43e"},
-    {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:75f0ee6839532e52a3a53f80ce64925ed4aed697dd3fa890c4c918f3304bd4f4"},
-    {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-win32.whl", hash = "sha256:464e66a04e740d754170be5e740657a3b3b6d2bcc567f0c3437879a6e6087ff6"},
-    {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:52ae5739e4b5d6317b52f5b040b1b6639e8af68a5b8fd606a8b08658fbd0cab5"},
-    {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4df5019e7783d14b79217ad9c56edf1ba7485d614ad5a385d1b3c768635c81c0"},
-    {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5254af7d8bdf4d5484c089f929cb7f5bafa59b4f01d4f48adda4be41e6d29f99"},
-    {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8be05be57dc5c7b4a0b24edcaa2f7275866d9c907725226cdde46da09367d923"},
-    {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-win32.whl", hash = "sha256:74161d827407f4db9072011adcfb825b5258a5ccb3d2cd518dd6c9edea9e30f1"},
-    {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:058a1cc3df2a8aecc12f983a48bda99315cebf55a3b3a5463e37bb599b05727b"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c6ac7e45367b1317e56f1461719c853fd6825226f45b835df7436bb04031fd8a"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b4b0d31f2052b3f9f9b5327024dc629a253a83d8649d4734ca7f35b60ec3e9e5"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1f8c0a4577c0e6c99d208de5c4d3fd8aceed9574bb154d7a2b21c16bb924154c"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-win32.whl", hash = "sha256:46d6d20815064e8bb023ea8628cfb7402c0f0e83de2c2227a88097e239a7dffd"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:6c0a5dc52fc74eb87c67374a4e554d4761fd42a4d01390b7e868b30d21f4b8bb"},
-    {file = "ruamel.yaml.clib-0.2.2.tar.gz", hash = "sha256:2d24bd98af676f4990c4d715bcdc2a60b19c56a3fb3a763164d2d8ca0e806ba7"},
+    {file = "ruamel.yaml.clib-0.2.4-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:329ac9064c1cfff9fc77fbecd90d07d698176fcd0720bfef9c2d27faa09dcc0e"},
+    {file = "ruamel.yaml.clib-0.2.4-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:091a38f04f8a332ba7b3dba26197cd522bc29936943b3d1732ce3c463bb6b275"},
+    {file = "ruamel.yaml.clib-0.2.4-cp35-cp35m-win32.whl", hash = "sha256:650cc8e65e2568fac84dc14970a09fe21b013a90621fff1626ea6d656cc03dc4"},
+    {file = "ruamel.yaml.clib-0.2.4-cp35-cp35m-win_amd64.whl", hash = "sha256:729869106d5b7eb5e0260f7da4fcfef2cd9b324729fadc08edc27b1e86ad3013"},
+    {file = "ruamel.yaml.clib-0.2.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2ae2f58c18991c8565d41018177548a91c2f1511d8a185254632388f142fbae9"},
+    {file = "ruamel.yaml.clib-0.2.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c8a04c3f62a0b6a2696d003dd30e96e0b9d4a5ff450fe359c39a4a7466b9b935"},
+    {file = "ruamel.yaml.clib-0.2.4-cp36-cp36m-win32.whl", hash = "sha256:fd400bd19ea3e86bad9fb5176ab7efb6efb5e440cc2fd435c86de021620d8fa7"},
+    {file = "ruamel.yaml.clib-0.2.4-cp36-cp36m-win_amd64.whl", hash = "sha256:b1772bff158f785085ebc8e635a0b9450f0072413bc89d8fc7f0ee803d1ab7f8"},
+    {file = "ruamel.yaml.clib-0.2.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3271fb4a379050735f90177d1e61b5cc9acb5130baf995f3c775fa2aa2b113fb"},
+    {file = "ruamel.yaml.clib-0.2.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:aa157cee912030d8abfb97b278295abbb7923dedfd892f2e94c22adbf5730398"},
+    {file = "ruamel.yaml.clib-0.2.4-cp37-cp37m-win32.whl", hash = "sha256:202e4751f038383241036e79640e7efd23d7272e3ce0cc8a11b9804ad604c5da"},
+    {file = "ruamel.yaml.clib-0.2.4-cp37-cp37m-win_amd64.whl", hash = "sha256:3e506603394f5a678e9b924324bc1352c0493d7010ab4df687eb6d868631f9fb"},
+    {file = "ruamel.yaml.clib-0.2.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b9f95ae85986b53d6d0d253d570a9bb3a229e5319f1f76b2ba7809fa86cad890"},
+    {file = "ruamel.yaml.clib-0.2.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2b9a62080d18c7fa17443e37f0d941d1be0a66ddcf5be5253f91cc59a15a9c1e"},
+    {file = "ruamel.yaml.clib-0.2.4-cp38-cp38-win32.whl", hash = "sha256:769468005ce63bad78575b9d9f095f388ac1f45a331969e04135ac9626c3529d"},
+    {file = "ruamel.yaml.clib-0.2.4-cp38-cp38-win_amd64.whl", hash = "sha256:83d72c5434151071cb67690be0034f9162ea282e58e47f9e8d23e8d14ca96584"},
+    {file = "ruamel.yaml.clib-0.2.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:243941fe8f98053662f0394057b29d7146fe56e1b0011971302ea75e4b111529"},
+    {file = "ruamel.yaml.clib-0.2.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2d75c965c407fdef9d1b33cd39faf47aa106d3fa2cf83960ec9ed95c4c9a55bc"},
+    {file = "ruamel.yaml.clib-0.2.4-cp39-cp39-win32.whl", hash = "sha256:f012b89c56f936e31f12a1484f08964c4681ae75488bc79c8909f37c517500f6"},
+    {file = "ruamel.yaml.clib-0.2.4-cp39-cp39-win_amd64.whl", hash = "sha256:a6d8749819403338093c61ee897b97d0f4aa73297e97feb1705d143c002b5bed"},
+    {file = "ruamel.yaml.clib-0.2.4.tar.gz", hash = "sha256:f997f13fd94e37e8b7d7dbe759088bb428adc6570da06b64a913d932d891ac8d"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -1813,8 +1823,8 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.5-py2.py3-none-any.whl", hash = "sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c"},
-    {file = "urllib3-1.26.5.tar.gz", hash = "sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098"},
+    {file = "urllib3-1.26.6-py2.py3-none-any.whl", hash = "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4"},
+    {file = "urllib3-1.26.6.tar.gz", hash = "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"},
 ]
 urwid = [
     {file = "urwid-2.1.2.tar.gz", hash = "sha256:588bee9c1cb208d0906a9f73c613d2bd32c3ed3702012f51efe318a3f2127eae"},
@@ -1832,8 +1842,8 @@ wsproto = [
     {file = "wsproto-0.15.0.tar.gz", hash = "sha256:614798c30e5dc2b3f65acc03d2d50842b97621487350ce79a80a711229edfa9d"},
 ]
 ya-aioclient = [
-    {file = "ya-aioclient-0.5.0.tar.gz", hash = "sha256:07d834e53ea692f9587f135ab5fb9a23c4d50b6f8d7a536a9f621ccffe18eeb6"},
-    {file = "ya_aioclient-0.5.0-py3-none-any.whl", hash = "sha256:22c754a512202dec0820e14516b90b823cc6e1db1688e01fc53deb242fcd0fb1"},
+    {file = "ya-aioclient-0.5.1.tar.gz", hash = "sha256:8f4a755967f43546210a1a5ce7bd5504b22d2b82ac936f23aaa42294beabad1b"},
+    {file = "ya_aioclient-0.5.1-py3-none-any.whl", hash = "sha256:ccfdc1a0d73341914fe75b40e5df5af5ae308e385e66f7df0da43ec6037a83c8"},
 ]
 yarl = [
     {file = "yarl-1.6.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:0355a701b3998dcd832d0dc47cc5dedf3874f966ac7f870e0f3a6788d802d434"},

--- a/goth_tests/pyproject.toml
+++ b/goth_tests/pyproject.toml
@@ -20,9 +20,9 @@ readme = "README.md"
 python = "^3.8.0"
 pytest = "^6.2"
 pytest-asyncio = "^0.14"
-goth = "^0.4"
+goth = "^0.5"
 # to use development goth version uncomment below
-#goth = { git = "https://github.com/golemfactory/goth.git", rev = "ab37bc5de60bdd6685ef3c52279704691cabb72f" }
+# goth = { git = "https://github.com/golemfactory/goth.git", branch = "your-branch-here" }
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"


### PR DESCRIPTION
This resolves recent nightly failures on `release/v0.7` branch, e.g.: https://github.com/golemfactory/yagna/runs/3100232672?check_suite_focus=true