### PR TITLE
[CI] Always run Market test suite

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,23 +51,11 @@ jobs:
           vcpkg list
           vcpkg integrate install
 
-      - name: Unit tests
+      - name: Unit tests + Market Test Suite (semi-integration tests)
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace --locked
-
-      - name: Market Test Suite (semi-integration tests)
-        uses: actions-rs/cargo@v1
-        if: startsWith( github.head_ref, 'market/' )
-        with:
-          command: test
-          # Due to cargo quirks it is more efficient to run all tests from workspace as:
-          #   --tests --workspace
-          # than just:
-          #   --tests -p ya-market
-          # because the latter needs separate compilation of lots of dependant crates again.
-          args: --tests --workspace --features ya-market/test-suite
+          args: --tests --workspace --features ya-market/test-suite --locked
 
       - name: Build binaries
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Why:
- There is no Market team, so not all contributors do remember to prefix branch with `market/` to invoke Market test suite on CI.
- Market test suite adds a little (~2-4mins) overhead comparing to the whole CI run, especally Rust compilation. And when run as separate step it incurs ~9 mins overhead.

What:
- merge `Unit test` step with `Market test suite` in Rust CI.