### PR TITLE
Add team mention to goth nightly failure messages

### DIFF
--- a/.github/workflows/nightly-goth.yml
+++ b/.github/workflows/nightly-goth.yml
@@ -122,4 +122,5 @@ jobs:
           REPO_NAME: ${{ github.repository }}
           WORKFLOW_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
-          args: 'Goth nightly run failed for `{{ REPO_NAME }}` on branch `{{ BRANCH_NAME }}`! {{ WORKFLOW_URL }}'
+          # <@&717621825957396540> = @core
+          args: '<@&717621825957396540> Goth nightly run failed for `{{ REPO_NAME }}` on branch `{{ BRANCH_NAME }}`! <{{ WORKFLOW_URL }}>'


### PR DESCRIPTION
This also removes the auto-embed added to the message by Discord by wrapping the workflow URL in `<>`.