### PR TITLE
Rename GitHub Actions workflows

### DIFF
--- a/.github/workflows/binaries-aarch64.yml
+++ b/.github/workflows/binaries-aarch64.yml
@@ -1,4 +1,4 @@
-name: CI aarch64
+name: Build binaries (aarch64)
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build binaries (aarch64)
     env:
       RUSTFLAGS: "-C link-arg=-s"
     runs-on: ubuntu-latest

--- a/.github/workflows/binaries-x86-64.yml
+++ b/.github/workflows/binaries-x86-64.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build binaries (x86-64)
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    name: Unit Tests
+    name: Build binaries (x86-64)
     env:
       # `-D warnings` means any warnings emitted will cause build to fail
       RUSTFLAGS: "-D warnings -C opt-level=z -C target-cpu=x86-64 -C debuginfo=1"
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        os: [ubuntu-latest]
 
     steps:
       - name: Checkout
@@ -38,12 +38,6 @@ jobs:
           command: tree
           args: --locked
 
-      - name: Check formatting
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
       - name: Install openssl ( Windows only )
         if: runner.os == 'Windows'
         run: |
@@ -51,9 +45,31 @@ jobs:
           vcpkg list
           vcpkg integrate install
 
-      - name: Unit tests
+      - name: Build binaries
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --tests --workspace --exclude=["./agent/provider/src/market"] --locked
+          command: build
+          args: --workspace
 
+      - name: Copy binaries
+        shell: bash
+        run: |
+          mkdir build
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            cp target/debug/{yagna,ya-provider,exe-unit,golemsp,gftp} build
+            strip -x build/*
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            cp target/debug/{yagna,gftp} build
+            strip -x build/*
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            cp target/debug/{yagna,gftp}.exe build
+          else
+            echo "$RUNNER_OS not supported"
+            exit 1
+          fi
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v1
+        with:
+          name: Yagna ${{ runner.os }}
+          path: build

--- a/.github/workflows/integration-test-nightly.yml
+++ b/.github/workflows/integration-test-nightly.yml
@@ -1,4 +1,4 @@
-name: Goth nightly
+name: Goth integration tests (nightly)
 
 on:
   workflow_dispatch:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Download artifact
         uses: dawidd6/action-download-artifact@v2
         with:
-          workflow: binaries.yml
+          workflow: binaries-x86-64.yml
           commit: ${{github.event.pull_request.head.sha || github.sha}}
           workflow_conclusion: success
           name: 'Yagna Linux'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,4 +1,4 @@
-name: Goth
+name: Goth integration tests
 
 on:
   push:
@@ -20,7 +20,7 @@ jobs:
         id: wait-for-build-ubu
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: "Build Binaries (ubuntu-latest)"
+          checkName: "Build binaries (x86-64) (ubuntu-latest)"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           timeoutSeconds: 7200
 

--- a/.github/workflows/market-test-suite.yml
+++ b/.github/workflows/market-test-suite.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Market Test Suite
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Create release
 on:
   push:
     tags:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-release:
-    name: "Create Release"
+    name: Create release
     runs-on: ubuntu-latest
     steps:
       - name: Create Release

--- a/.github/workflows/unit-test-sgx.yml
+++ b/.github/workflows/unit-test-sgx.yml
@@ -1,4 +1,4 @@
-name: SGX CI
+name: SGX Unit Tests
 
 on:
   push:
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    name: SGX Tests
+    name: SGX Unit Tests
     env:
       # `-D warnings` means any warnings emitted will cause build to fail
       RUSTFLAGS: "-D warnings -C opt-level=z -C target-cpu=x86-64 -C debuginfo=1"

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Unit Tests
 
 on:
   push:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    name: Build Binaries
+    name: Unit Tests
     env:
       # `-D warnings` means any warnings emitted will cause build to fail
       RUSTFLAGS: "-D warnings -C opt-level=z -C target-cpu=x86-64 -C debuginfo=1"
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
 
     steps:
       - name: Checkout
@@ -38,6 +38,12 @@ jobs:
           command: tree
           args: --locked
 
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
       - name: Install openssl ( Windows only )
         if: runner.os == 'Windows'
         run: |
@@ -45,31 +51,9 @@ jobs:
           vcpkg list
           vcpkg integrate install
 
-      - name: Build binaries
+      - name: Unit tests
         uses: actions-rs/cargo@v1
         with:
-          command: build
-          args: --workspace
+          command: test
+          args: --tests --workspace --exclude=["./agent/provider/src/market"] --locked
 
-      - name: Copy binaries
-        shell: bash
-        run: |
-          mkdir build
-          if [ "$RUNNER_OS" == "Linux" ]; then
-            cp target/debug/{yagna,ya-provider,exe-unit,golemsp,gftp} build
-            strip -x build/*
-          elif [ "$RUNNER_OS" == "macOS" ]; then
-            cp target/debug/{yagna,gftp} build
-            strip -x build/*
-          elif [ "$RUNNER_OS" == "Windows" ]; then
-            cp target/debug/{yagna,gftp}.exe build
-          else
-            echo "$RUNNER_OS not supported"
-            exit 1
-          fi
-
-      - name: Upload binaries
-        uses: actions/upload-artifact@v1
-        with:
-          name: Yagna ${{ runner.os }}
-          path: build


### PR DESCRIPTION
`yagna` currently has 4 different Actions workflows which are all named "CI":

![image](https://user-images.githubusercontent.com/4924466/134210135-f1af62ad-0fc3-4797-9c9e-c1606b1344c2.png)

Besides being confusing, after a recent split of the workflows (https://github.com/golemfactory/yagna/pull/1584) it's also causing `goth` tests to fail (e.g. https://github.com/golemfactory/yagna/actions/runs/1256035820) due to the wrong workflow being picked as artifact download target.