### PR TITLE
VPN - handle multiple calls to `add node`

### DIFF
--- a/core/market/src/testing/mock_node.rs
+++ b/core/market/src/testing/mock_node.rs
@@ -95,7 +95,7 @@ impl MockNodeKind {
 fn testname_from_backtrace(bn: &str) -> String {
     log::info!("Test name to regex match: {}", &bn);
     // Extract test name
-    let captures = Regex::new(r"(.*)::(.*)::\{\{.*")
+    let captures = Regex::new(r"(.*)::(.*)::.*")
         .unwrap()
         .captures(&bn)
         .unwrap();

--- a/core/vpn/src/network.rs
+++ b/core/vpn/src/network.rs
@@ -409,7 +409,10 @@ impl Handler<AddNode> for Vpn {
 
     fn handle(&mut self, msg: AddNode, _: &mut Self::Context) -> Self::Result {
         let ip = to_ip(&msg.address)?;
-        self.vpn.add_node(ip, &msg.id, gsb_remote_url)?;
+        match self.vpn.add_node(ip, &msg.id, gsb_remote_url) {
+            Ok(_) | Err(Error::IpAddrTaken(_)) => {}
+            Err(err) => return Err(err),
+        }
 
         let vpn_id = self.vpn.id().clone();
         let futs = self


### PR DESCRIPTION
Propagates the node information in the network despite that the IP address is already registered on requestor's side