### PR TITLE
VPN connection t-out / ExeUnit fixes

### DIFF
--- a/core/market/src/testing/mock_node.rs
+++ b/core/market/src/testing/mock_node.rs
@@ -95,7 +95,7 @@ impl MockNodeKind {
 fn testname_from_backtrace(bn: &str) -> String {
     log::info!("Test name to regex match: {}", &bn);
     // Extract test name
-    let captures = Regex::new(r"(.*)::(.*)::\{\{.*")
+    let captures = Regex::new(r"(.*)::(.*)::.*")
         .unwrap()
         .captures(&bn)
         .unwrap();

--- a/core/vpn/src/socket.rs
+++ b/core/vpn/src/socket.rs
@@ -4,7 +4,7 @@ use smoltcp::wire::{IpProtocol, IpVersion};
 use std::time::Duration;
 use ya_utils_networking::vpn::MAX_FRAME_SIZE;
 
-pub const TCP_CONN_TIMEOUT: Duration = Duration::from_secs(3);
+pub const TCP_CONN_TIMEOUT: Duration = Duration::from_secs(5);
 const TCP_KEEP_ALIVE: Duration = Duration::from_secs(60);
 
 pub fn tcp_socket<'a>() -> TcpSocket<'a> {

--- a/exe-unit/src/network.rs
+++ b/exe-unit/src/network.rs
@@ -251,9 +251,9 @@ impl Handler<Packet> for Vpn {
             };
 
             if let Some(ip) = ip {
-                log::debug!("Adding new node: {} {}", ip, node_id);
                 self.networks.get_mut(&network_id).map(|network| {
                     if !network.nodes().contains_key(&node_id) {
+                        log::debug!("Adding new node: {} {}", ip, node_id);
                         network.add_node(ip, &node_id, gsb_endpoint);
                     }
                 });

--- a/exe-unit/src/util/cache.rs
+++ b/exe-unit/src/util/cache.rs
@@ -151,29 +151,23 @@ impl CachePath {
     }
     /// Creates the long version of path, including hash and the "random" token.
     pub fn temp_path(&self) -> PathBuf {
-        self.to_path_buf(true, true)
+        let mut digest = sha3::Sha3_224::default();
+        digest.input(&self.hash);
+        digest.input(&self.nonce);
+        let hash = digest.result();
+        PathBuf::from(hex::encode(hash))
     }
 
     /// Creates a shorter version of path, including hash and excluding the "random" token.
     pub fn final_path(&self) -> PathBuf {
-        self.to_path_buf(true, false)
-    }
-
-    fn to_path_buf(&self, with_hash: bool, with_nonce: bool) -> PathBuf {
         let stem = self.path.file_stem().unwrap();
         let extension = self.path.extension();
         let hash = hex::encode(&self.hash);
 
         let mut file_name = stem.to_os_string();
+        file_name.push("_");
+        file_name.push(hash);
 
-        if with_hash {
-            file_name.push("_");
-            file_name.push(hash);
-        }
-        if with_nonce {
-            file_name.push("_");
-            file_name.push(&self.nonce);
-        }
         if let Some(ext) = extension {
             file_name.push(".");
             file_name.push(ext);


### PR DESCRIPTION
- VPN: increase TCP connection timeout
- ExeUnit: shorter temporary file names ( resolves https://github.com/golemfactory/yagna/issues/1580 )
- ExeUnit: less 'Adding new node' debug logs