### PR TITLE
ExeUnit: fix run -> term -> PID response race condition

### DIFF
--- a/exe-unit/src/runtime/process.rs
+++ b/exe-unit/src/runtime/process.rs
@@ -314,12 +314,12 @@ impl RuntimeProcess {
             run_process.bin = entry_point;
             run_process.args = args;
 
-            let process = match service.run_process(run_process).await {
-                Ok(result) => result,
-                Err(error) => return Err(Error::RuntimeError(format!("{:?}", error))),
+            let handle = monitor.next_process(ctx);
+            if let Err(error) = service.run_process(run_process).await {
+                return Err(Error::RuntimeError(format!("{:?}", error)));
             };
 
-            Ok(monitor.process(ctx, process.pid).await)
+            Ok(handle.await)
         };
 
         async move {


### PR DESCRIPTION
In case of processes that finish almost instantaneously, the process ID response might be received after the termination event. Process IDs were used for tracking process completion and thus process termination was never registered.