### PR TITLE
Remove debit note accept timeout from counters test

### DIFF
--- a/goth_tests/domain/exe_units/test_runtime_counters.py
+++ b/goth_tests/domain/exe_units/test_runtime_counters.py
@@ -24,7 +24,6 @@ def build_demand(
         DemandBuilder(requestor)
         .props_from_template(None)
         .property("golem.srv.caps.multi-activity", True)
-        .property("golem.com.payment.debit-notes.accept-timeout?", 8)
         .constraints(
             "(&(golem.com.pricing.model=linear)\
                 (golem.srv.caps.multi-activity=true)\


### PR DESCRIPTION
This test is not testing debit notes, so removed the low timeout.