### PR TITLE
Enforce payment signature validation

### DIFF
--- a/core/model/src/payment.rs
+++ b/core/model/src/payment.rs
@@ -677,14 +677,12 @@ pub mod public {
     // *************************** PAYMENT ****************************
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub struct SendPayment {
-        #[serde(flatten)] // Flatten is required for backwards compatability with 0.6.x
         pub payment: Payment,
-        #[serde(default)] // Optional is required for backwards compatability with 0.6.x
-        pub signature: Option<Vec<u8>>,
+        pub signature: Vec<u8>,
     }
 
     impl SendPayment {
-        pub fn new(payment: Payment, signature: Option<Vec<u8>>) -> Self {
+        pub fn new(payment: Payment, signature: Vec<u8>) -> Self {
             Self { payment, signature }
         }
     }

--- a/core/model/src/payment.rs
+++ b/core/model/src/payment.rs
@@ -677,6 +677,7 @@ pub mod public {
     // *************************** PAYMENT ****************************
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub struct SendPayment {
+        #[serde(flatten)]
         pub payment: Payment,
         pub signature: Vec<u8>,
     }


### PR DESCRIPTION
Resolves https://github.com/golemfactory/yagna/issues/1654

In release v0.6 the payment signature verification was added. 
To keep backwards compatibility this field was made optional.
Now we released v0.8 we can remove the "optional" part because all nodes 2 versions back include the signature.