### PR TITLE
ExeUnit: pass extra arguments down to runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6826,7 +6826,7 @@ dependencies = [
 
 [[package]]
 name = "ya-exe-unit"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "actix",
  "actix-files",

--- a/exe-unit/Cargo.toml
+++ b/exe-unit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-exe-unit"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/exe-unit/examples/transfer.rs
+++ b/exe-unit/examples/transfer.rs
@@ -214,6 +214,7 @@ async fn main() -> anyhow::Result<()> {
         agreement,
         work_dir: work_dir.clone(),
         cache_dir,
+        runtime_args: Default::default(),
         #[cfg(feature = "sgx")]
         crypto: init_crypto()?,
     };

--- a/exe-unit/examples/transfer_abort.rs
+++ b/exe-unit/examples/transfer_abort.rs
@@ -172,6 +172,7 @@ async fn main() -> anyhow::Result<()> {
         agreement,
         work_dir,
         cache_dir,
+        runtime_args: Default::default(),
         #[cfg(feature = "sgx")]
         crypto: init_crypto()?,
     };

--- a/exe-unit/src/bin.rs
+++ b/exe-unit/src/bin.rs
@@ -27,20 +27,28 @@ struct Cli {
     binary: PathBuf,
     #[structopt(flatten)]
     supervise: SuperviseCli,
+    /// Additional runtime arguments
+    #[structopt(
+        long,
+        short,
+        set = clap::ArgSettings::Global,
+        number_of_values = 1,
+    )]
+    runtime_arg: Vec<String>,
     /// Enclave secret key used in secure communication
     #[structopt(
-    long,
-    env = "EXE_UNIT_SEC_KEY",
-    hide_env_values = true,
-    set = clap::ArgSettings::Global,
+        long,
+        env = "EXE_UNIT_SEC_KEY",
+        hide_env_values = true,
+        set = clap::ArgSettings::Global,
     )]
     sec_key: Option<String>,
     /// Requestor public key used in secure communication
     #[structopt(
-    long,
-    env = "EXE_UNIT_REQUESTOR_PUB_KEY",
-    hide_env_values = true,
-    set = clap::ArgSettings::Global,
+        long,
+        env = "EXE_UNIT_REQUESTOR_PUB_KEY",
+        hide_env_values = true,
+        set = clap::ArgSettings::Global,
     )]
     requestor_pub_key: Option<String>,
     #[structopt(subcommand)]
@@ -51,17 +59,17 @@ struct Cli {
 struct SuperviseCli {
     /// Hardware resources are handled by the runtime
     #[structopt(
-    long = "runtime-managed-hardware",
-    alias = "cap-handoff",
-    parse(from_flag = std::ops::Not::not),
-    set = clap::ArgSettings::Global,
+        long = "runtime-managed-hardware",
+        alias = "cap-handoff",
+        parse(from_flag = std::ops::Not::not),
+        set = clap::ArgSettings::Global,
     )]
     hardware: bool,
     /// Images are handled by the runtime
     #[structopt(
-    long = "runtime-managed-image",
-    parse(from_flag = std::ops::Not::not),
-    set = clap::ArgSettings::Global,
+        long = "runtime-managed-image",
+        parse(from_flag = std::ops::Not::not),
+        set = clap::ArgSettings::Global,
     )]
     image: bool,
 }
@@ -261,6 +269,7 @@ fn run() -> anyhow::Result<()> {
         agreement,
         work_dir,
         cache_dir,
+        runtime_args: cli.runtime_arg.clone(),
         acl: Default::default(),
         credentials: None,
         #[cfg(feature = "sgx")]

--- a/exe-unit/src/lib.rs
+++ b/exe-unit/src/lib.rs
@@ -420,6 +420,7 @@ pub struct ExeUnitContext {
     pub agreement: Agreement,
     pub work_dir: PathBuf,
     pub cache_dir: PathBuf,
+    pub runtime_args: Vec<String>,
     pub acl: Acl,
     pub credentials: Option<Credentials>,
     #[cfg(feature = "sgx")]

--- a/exe-unit/src/runtime/process.rs
+++ b/exe-unit/src/runtime/process.rs
@@ -138,6 +138,8 @@ impl RuntimeProcess {
             }
         }
 
+        args.args(self.ctx.runtime_args.iter());
+
         Ok(args)
     }
 }


### PR DESCRIPTION
Introduces a `--runtime-arg` / `-r` argument to ExeUnit CLI for passing extra arguments to executed runtimes. The arguments are specified in a runtime descriptor.

Example runtime descriptor:

```json
[
  {
    "name": "custom-runtime",
    "version": "0.1.0",
    "supervisor-path": "exe-unit",
    "runtime-path": "custom-runtime/custom-runtime",
    "description": "My runtime",
    "extra-args": [
      "--runtime-managed-image",
      "--runtime-arg", "first",
      "--runtime-arg", "second"
    ]
  }
]
```

Example resulting invocation:

`custom-runtime <common_args> first second start <start_args>`

Example runtime implementation: https://github.com/golemfactory/ya-runtime-sdk/blob/d2bf17f9f96c7521df769f8a69b4b02c08c78de6/examples/environment/src/main.rs


Resolves #1702 