### PR TITLE
Dao: order debit notes by ts, desc

### DIFF
--- a/core/payment/src/dao/debit_note.rs
+++ b/core/payment/src/dao/debit_note.rs
@@ -195,7 +195,7 @@ impl<'c> DebitNoteDao<'c> {
 
     pub async fn get_all(&self) -> DbResult<Vec<DebitNote>> {
         readonly_transaction(self.pool, move |conn| {
-            let debit_notes: Vec<ReadObj> = query!().load(conn)?;
+            let debit_notes: Vec<ReadObj> = query!().order_by(dsl::timestamp.desc()).load(conn)?;
             debit_notes.into_iter().map(TryInto::try_into).collect()
         })
         .await
@@ -212,6 +212,7 @@ impl<'c> DebitNoteDao<'c> {
             if let Some(date) = after_timestamp {
                 query = query.filter(dsl::timestamp.gt(date))
             }
+            query = query.order_by(dsl::timestamp.desc());
             if let Some(items) = max_items {
                 query = query.limit(items.into())
             }

--- a/goth_tests/domain/exe_units/test_runtime_counters.py
+++ b/goth_tests/domain/exe_units/test_runtime_counters.py
@@ -115,7 +115,7 @@ async def test_custom_runtime_counter(
         )
 
         debit_notes = await requestor.api.payment.get_debit_notes()
-        last_debit_note = debit_notes[-1]
+        last_debit_note = debit_notes[0]
         logger.info("last debit note: %r", last_debit_note)
 
         assert len(last_debit_note.usage_counter_vector) == len(usage_vector)


### PR DESCRIPTION
Introduces ordering for queries returning multiple debit notes

Resolves #1715 