### PR TITLE
deb: subsidy terms of use in line with ya-installer

### DIFF
--- a/debian/provider/preinst
+++ b/debian/provider/preinst
@@ -4,25 +4,15 @@
 
 . /usr/share/debconf/confmodule
 
-accept_tos() {
-  template=$1
-  rejected=$2
-
-  db_input critical $template
-  db_go
-
-  db_get $template || true
-
-  if [ "$RET" != "yes" ]; then
-      db_input critical $rejected
-      db_go
-      db_reset $template
-      exit 1
-  fi
-}
-
-
 db_version 2.0
+db_input critical golem/terms/subsidy-01
+db_go
 
-accept_tos "golem/terms/testnet-01" "golem/tos-rejected"
-accept_tos "golem/terms/subsidy-01" "golem/subsidy-tos-rejected"
+db_get golem/terms/subsidy-01 || true
+
+if [ "$RET" != "yes" ]; then
+    db_input critical golem/subsidy-tos-rejected
+    db_go
+    db_reset golem/terms/subsidy-01
+    exit 1
+fi

--- a/debian/provider/templates
+++ b/debian/provider/templates
@@ -1,27 +1,18 @@
-Template: golem/terms/testnet-01
-Type: select
-Choices: no, yes
-Description: Do you accept ?
-  By installing this software you declare that you have read,
-  understood and hereby accept the disclaimer and privacy warning
-  found at https://handbook.golem.network/see-also/terms
-
 Template: golem/terms/subsidy-01
 Type: select
 Choices: no, yes
 Description: Do you accept ?
   By installing this software you declare that you have read,
-  understood and hereby accept the disclaimer and privacy warning
-  found at https://handbook.golem.network/see-also/provider-subsidy-terms
+  understood and hereby accept the disclaimers and privacy warnings
+  found at
+    https://handbook.golem.network/see-also/terms
+  and
+    https://handbook.golem.network/see-also/provider-subsidy-terms
 
 Template: golem/gsb-port
 Type: string
 Default: 7464
 Description: Local GSB port
-
-Template: golem/tos-rejected
-Type: note
-Description: You must accept the terms of use to install this package.
 
 Template: golem/subsidy-tos-rejected
 Type: note


### PR DESCRIPTION
Allows accepting both terms of use via a single prompt. Brings the installation flow closer to https://github.com/golemfactory/ya-installer/pull/22

A part of #1724