### PR TITLE
Allow dead_code on cache tmp_dir field

### DIFF
--- a/exe-unit/src/util/cache.rs
+++ b/exe-unit/src/util/cache.rs
@@ -8,6 +8,7 @@ use ya_transfer::TransferUrl;
 #[derive(Debug, Clone)]
 pub(crate) struct Cache {
     dir: PathBuf,
+    #[allow(dead_code)]
     tmp_dir: PathBuf,
 }
 


### PR DESCRIPTION
After rust update 1.57

Extension of #1746 