### PR TITLE
Updated ya-relay and ya-client for a test in yagna

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6736,7 +6736,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.5.3"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=e4d2f41199f2e15fcb588c0d225dd17f1caabb41#e4d2f41199f2e15fcb588c0d225dd17f1caabb41"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=0b6a9a5b24cd1d858fb483f616e0e4df00842955#0b6a9a5b24cd1d858fb483f616e0e4df00842955"
 dependencies = [
  "actix-codec",
  "awc",
@@ -6761,7 +6761,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.3.2"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=e4d2f41199f2e15fcb588c0d225dd17f1caabb41#e4d2f41199f2e15fcb588c0d225dd17f1caabb41"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=0b6a9a5b24cd1d858fb483f616e0e4df00842955#0b6a9a5b24cd1d858fb483f616e0e4df00842955"
 dependencies = [
  "bigdecimal 0.2.0",
  "chrono",
@@ -7274,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-client"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=8e5fc0661bb7963d2c2328a24a7e438fb0091b8a#8e5fc0661bb7963d2c2328a24a7e438fb0091b8a"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=469f34d445cb96a3e912d65aa4480f29cbe65750#469f34d445cb96a3e912d65aa4480f29cbe65750"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7284,7 +7284,6 @@ dependencies = [
  "log",
  "tokio 0.2.25",
  "url",
- "ya-client-model",
  "ya-relay-core",
  "ya-relay-proto",
  "ya-relay-stack",
@@ -7293,7 +7292,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-core"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=8e5fc0661bb7963d2c2328a24a7e438fb0091b8a#8e5fc0661bb7963d2c2328a24a7e438fb0091b8a"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=469f34d445cb96a3e912d65aa4480f29cbe65750#469f34d445cb96a3e912d65aa4480f29cbe65750"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7321,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-proto"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=8e5fc0661bb7963d2c2328a24a7e438fb0091b8a#8e5fc0661bb7963d2c2328a24a7e438fb0091b8a"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=469f34d445cb96a3e912d65aa4480f29cbe65750#469f34d445cb96a3e912d65aa4480f29cbe65750"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -7338,7 +7337,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-stack"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=8e5fc0661bb7963d2c2328a24a7e438fb0091b8a#8e5fc0661bb7963d2c2328a24a7e438fb0091b8a"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=469f34d445cb96a3e912d65aa4480f29cbe65750#469f34d445cb96a3e912d65aa4480f29cbe65750"
 dependencies = [
  "derive_more",
  "futures 0.3.13",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7274,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-client"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=469f34d445cb96a3e912d65aa4480f29cbe65750#469f34d445cb96a3e912d65aa4480f29cbe65750"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=9458a94a49d16686174c8e8fd7a1f6dee2e8f5c9#9458a94a49d16686174c8e8fd7a1f6dee2e8f5c9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7292,7 +7292,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-core"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=469f34d445cb96a3e912d65aa4480f29cbe65750#469f34d445cb96a3e912d65aa4480f29cbe65750"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=9458a94a49d16686174c8e8fd7a1f6dee2e8f5c9#9458a94a49d16686174c8e8fd7a1f6dee2e8f5c9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7320,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-proto"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=469f34d445cb96a3e912d65aa4480f29cbe65750#469f34d445cb96a3e912d65aa4480f29cbe65750"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=9458a94a49d16686174c8e8fd7a1f6dee2e8f5c9#9458a94a49d16686174c8e8fd7a1f6dee2e8f5c9"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -7337,7 +7337,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-stack"
 version = "0.1.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=469f34d445cb96a3e912d65aa4480f29cbe65750#469f34d445cb96a3e912d65aa4480f29cbe65750"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=9458a94a49d16686174c8e8fd7a1f6dee2e8f5c9#9458a94a49d16686174c8e8fd7a1f6dee2e8f5c9"
 dependencies = [
  "derive_more",
  "futures 0.3.13",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,8 +180,8 @@ ya-service-api-web = { path = "core/serv-api/web" }
 #ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "c4f16a69be383d9534f99928fccb64a558c47ff2"}
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "e4d2f41199f2e15fcb588c0d225dd17f1caabb41"}
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "e4d2f41199f2e15fcb588c0d225dd17f1caabb41"}
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "0b6a9a5b24cd1d858fb483f616e0e4df00842955"}
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "0b6a9a5b24cd1d858fb483f616e0e4df00842955"}
 
 #ya-client = { path = "../ya-client" }
 #ya-client-model = { path = "../ya-client/model" }

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -12,9 +12,9 @@ hybrid-net = []
 
 [dependencies]
 ya-core-model = { version = "^0.5", features=["net", "identity"] }
-ya-relay-client = { git = "https://github.com/golemfactory/ya-relay.git", rev = "469f34d445cb96a3e912d65aa4480f29cbe65750" }
-ya-relay-core = { git = "https://github.com/golemfactory/ya-relay.git", rev = "469f34d445cb96a3e912d65aa4480f29cbe65750" }
-ya-relay-proto = { git = "https://github.com/golemfactory/ya-relay.git", rev = "469f34d445cb96a3e912d65aa4480f29cbe65750", features = ["codec"] }
+ya-relay-client = { git = "https://github.com/golemfactory/ya-relay.git", rev = "9458a94a49d16686174c8e8fd7a1f6dee2e8f5c9" }
+ya-relay-core = { git = "https://github.com/golemfactory/ya-relay.git", rev = "9458a94a49d16686174c8e8fd7a1f6dee2e8f5c9" }
+ya-relay-proto = { git = "https://github.com/golemfactory/ya-relay.git", rev = "9458a94a49d16686174c8e8fd7a1f6dee2e8f5c9", features = ["codec"] }
 ya-sb-proto = { version = "0.4" }
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -12,9 +12,9 @@ hybrid-net = []
 
 [dependencies]
 ya-core-model = { version = "^0.5", features=["net", "identity"] }
-ya-relay-client = { git = "https://github.com/golemfactory/ya-relay.git", rev = "8e5fc0661bb7963d2c2328a24a7e438fb0091b8a" }
-ya-relay-core = { git = "https://github.com/golemfactory/ya-relay.git", rev = "8e5fc0661bb7963d2c2328a24a7e438fb0091b8a" }
-ya-relay-proto = { git = "https://github.com/golemfactory/ya-relay.git", rev = "8e5fc0661bb7963d2c2328a24a7e438fb0091b8a", features = ["codec"] }
+ya-relay-client = { git = "https://github.com/golemfactory/ya-relay.git", rev = "469f34d445cb96a3e912d65aa4480f29cbe65750" }
+ya-relay-core = { git = "https://github.com/golemfactory/ya-relay.git", rev = "469f34d445cb96a3e912d65aa4480f29cbe65750" }
+ya-relay-proto = { git = "https://github.com/golemfactory/ya-relay.git", rev = "469f34d445cb96a3e912d65aa4480f29cbe65750", features = ["codec"] }
 ya-sb-proto = { version = "0.4" }
 ya-service-api = "0.1"
 ya-service-api-interfaces = "0.1"


### PR DESCRIPTION
Resolves https://github.com/golemfactory/ya-relay/issues/14

WIP...

requires https://github.com/golemfactory/ya-relay/pull/75 to be merged first.


- update ya-relay with `ReverseConnection` implementation
- update ya-client with `&Vec<u8> into NodeId`