### PR TITLE
Revert broadcast optimization to prepare for p2p NET

### DIFF
--- a/core/market/src/matcher.rs
+++ b/core/market/src/matcher.rs
@@ -234,12 +234,6 @@ impl Matcher {
         demand: &NewDemand,
         id: &Identity,
     ) -> Result<Demand, MatcherError> {
-        self.discovery.lazy_bind_gsb().await.map_or_else(
-            |e| {
-                log::warn!("Failed to subscribe to broadcasts. Error: {:?}.", e,);
-            },
-            |_| (),
-        );
         let demand = self.store.create_demand(id, demand).await?;
         self.resolver.receive(&demand);
 

--- a/core/market/src/protocol/discovery.rs
+++ b/core/market/src/protocol/discovery.rs
@@ -228,10 +228,12 @@ impl Discovery {
             },
         );
         // Subscribe to receiving broadcasts only when demand is subscribed for the first time.
-        let mut prefix_guard = self.inner.lazy_binder_prefix.lock().await;
-        if let Some(old_prefix) = (*prefix_guard).replace(local_prefix.to_string()) {
-            log::info!("Dropping previous lazy_binder_prefix, and replacing it with new one. old={}, new={}", old_prefix, local_prefix);
-        };
+        {
+            let mut prefix_guard = self.inner.lazy_binder_prefix.lock().await;
+            if let Some(old_prefix) = (*prefix_guard).replace(local_prefix.to_string()) {
+                log::info!("Dropping previous lazy_binder_prefix, and replacing it with new one. old={}, new={}", old_prefix, local_prefix);
+            };
+        }
 
         // We don't lazy bind broadcasts handlers anymore on first Demand creation.
         // But we still have option to do this easy in the future.

--- a/core/market/src/protocol/discovery.rs
+++ b/core/market/src/protocol/discovery.rs
@@ -248,7 +248,7 @@ impl Discovery {
     }
 
     pub async fn bind_gsb_broadcast(&self) -> Result<(), DiscoveryInitError> {
-        log::trace!("LazyBroadcastBind");
+        log::trace!("GsbBroadcastBind");
         let myself = self.clone();
 
         // /local/market/market-protocol-mk1-offer

--- a/core/market/src/protocol/discovery.rs
+++ b/core/market/src/protocol/discovery.rs
@@ -227,7 +227,7 @@ impl Discovery {
                 myself.on_get_remote_offers(caller, msg)
             },
         );
-        // Subscribe to receiving broadcasts only when demand is subscribed for the first time.
+        // Subscribe to offer broadcasts.
         {
             let mut prefix_guard = self.inner.lazy_binder_prefix.lock().await;
             if let Some(old_prefix) = (*prefix_guard).replace(local_prefix.to_string()) {
@@ -236,8 +236,8 @@ impl Discovery {
         }
 
         // We don't lazy bind broadcasts handlers anymore on first Demand creation.
-        // But we still have option to do this easy in the future.
-        self.lazy_bind_gsb().await.map_or_else(
+        // But we still have option to do this easily in the future.
+        self.bind_gsb_broadcast().await.map_or_else(
             |e| {
                 log::warn!("Failed to subscribe to broadcasts. Error: {:?}.", e,);
             },
@@ -247,7 +247,7 @@ impl Discovery {
         Ok(())
     }
 
-    pub async fn lazy_bind_gsb(&self) -> Result<(), DiscoveryInitError> {
+    pub async fn bind_gsb_broadcast(&self) -> Result<(), DiscoveryInitError> {
         log::trace!("LazyBroadcastBind");
         let myself = self.clone();
 

--- a/core/market/src/protocol/discovery.rs
+++ b/core/market/src/protocol/discovery.rs
@@ -233,6 +233,15 @@ impl Discovery {
             log::info!("Dropping previous lazy_binder_prefix, and replacing it with new one. old={}, new={}", old_prefix, local_prefix);
         };
 
+        // We don't lazy bind broadcasts handlers anymore on first Demand creation.
+        // But we still have option to do this easy in the future.
+        self.lazy_bind_gsb().await.map_or_else(
+            |e| {
+                log::warn!("Failed to subscribe to broadcasts. Error: {:?}.", e,);
+            },
+            |_| (),
+        );
+
         Ok(())
     }
 
@@ -287,7 +296,7 @@ impl Discovery {
         // Other attempts to add them will end with error and we will filter all Offers, that already
         // occurred and re-broadcast only new ones.
         // But still it is worth to limit network traffic.
-        let _new_offer_ids = {
+        let new_offer_ids = {
             let offer_handlers = match self.inner.offer_handlers.try_lock() {
                 Ok(h) => h,
                 Err(_) => {
@@ -326,22 +335,20 @@ impl Discovery {
             }
         };
 
-        // I'm ceasing rebroadcast to reduce net traffic. It should be restored when we have P2P net
+        if !new_offer_ids.is_empty() {
+            log::debug!(
+                "Propagating {}/{} Offers received from [{}].",
+                new_offer_ids.len(),
+                num_ids_received,
+                &caller
+            );
 
-        // if !new_offer_ids.is_empty() {
-        //     log::debug!(
-        //         "Propagating {}/{} Offers received from [{}].",
-        //         new_offer_ids.len(),
-        //         num_ids_received,
-        //         &caller
-        //     );
-        //
-        //     // We could broadcast outside of lock, but it shouldn't hurt either, because
-        //     // we don't wait for any responses from remote nodes.
-        //     self.bcast_offers(new_offer_ids)
-        //         .await
-        //         .map_err(|e| log::warn!("Failed to bcast. Error: {}", e))?;
-        // }
+            // We could broadcast outside of lock, but it shouldn't hurt either, because
+            // we don't wait for any responses from remote nodes.
+            self.bcast_offers(new_offer_ids)
+                .await
+                .map_err(|e| log::warn!("Failed to bcast. Error: {}", e))?;
+        }
 
         let end = Instant::now();
         timing!("market.offers.incoming.time", start, end);
@@ -375,23 +382,21 @@ impl Discovery {
         }
 
         let offer_unsubscribe_handler = self.inner.offer_unsubscribe_handler.clone();
-        let _unsubscribed_offer_ids = offer_unsubscribe_handler.call(caller.clone(), msg).await?;
+        let unsubscribed_offer_ids = offer_unsubscribe_handler.call(caller.clone(), msg).await?;
 
-        // I'm ceasing rebroadcast to reduce net traffic. It should be restored when we have P2P net
+        if !unsubscribed_offer_ids.is_empty() {
+            log::debug!(
+                "Propagating {}/{} unsubscribed Offers received from [{}].",
+                unsubscribed_offer_ids.len(),
+                num_received_ids,
+                &caller,
+            );
 
-        // if !unsubscribed_offer_ids.is_empty() {
-        //     log::debug!(
-        //         "Propagating {}/{} unsubscribed Offers received from [{}].",
-        //         unsubscribed_offer_ids.len(),
-        //         num_received_ids,
-        //         &caller,
-        //     );
-        //
-        //     // No need to retry broadcasting, since we send cyclic broadcasts.
-        //     if let Err(error) = self.bcast_unsubscribes(unsubscribed_offer_ids).await {
-        //         log::error!("Error propagating unsubscribed Offers further: {}", error,);
-        //     }
-        // }
+            // No need to retry broadcasting, since we send cyclic broadcasts.
+            if let Err(error) = self.bcast_unsubscribes(unsubscribed_offer_ids).await {
+                log::error!("Error propagating unsubscribed Offers further: {}", error,);
+            }
+        }
         let end = Instant::now();
         timing!("market.offers.unsubscribes.incoming.time", start, end);
         Ok(())

--- a/core/market/src/protocol/discovery/message.rs
+++ b/core/market/src/protocol/discovery/message.rs
@@ -76,6 +76,6 @@ impl BroadcastMessage for UnsubscribedOffersBcast {
     const TOPIC: &'static str = concat!(
         "market-protocol-discovery-",
         PROTOCOL_VERSION!(),
-        "market-protocol-discovery-mk1-offers-unsubscribe"
+        "-offers-unsubscribe"
     );
 }

--- a/core/market/src/testing/mock_node.rs
+++ b/core/market/src/testing/mock_node.rs
@@ -79,15 +79,15 @@ impl MockNodeKind {
         match self {
             MockNodeKind::Market(market) => {
                 market.bind_gsb(&public, &local).await?;
-                market.matcher.discovery.lazy_bind_gsb().await?;
+                market.matcher.discovery.bind_gsb_broadcast().await?;
             }
             MockNodeKind::Matcher { matcher, .. } => {
                 matcher.bind_gsb(&public, &local).await?;
-                matcher.discovery.lazy_bind_gsb().await?;
+                matcher.discovery.bind_gsb_broadcast().await?;
             }
             MockNodeKind::Discovery(discovery) => {
                 discovery.bind_gsb(&public, &local).await?;
-                discovery.lazy_bind_gsb().await?;
+                discovery.bind_gsb_broadcast().await?;
             }
             MockNodeKind::Negotiation {
                 provider,


### PR DESCRIPTION
Don't merge until the final decision, because we must still care a little bit about central NET behavior

resolves: https://github.com/golemfactory/ya-relay/issues/15

