### PR TITLE
Proposal: fix str literal parsing

### DIFF
--- a/core/market/resolver/src/resolver/properties.rs
+++ b/core/market/resolver/src/resolver/properties.rs
@@ -16,8 +16,7 @@ type d128 = BigDecimal;
 // #region PropertyValue
 #[derive(Debug, Clone, PartialEq)]
 pub enum PropertyValue<'a> {
-    Str(&'a str),   // Str
-    String(String), // String
+    Str(&'a str), // Str
     Boolean(bool),
     //Int(i32),
     //Long(i64),
@@ -57,7 +56,6 @@ impl<'a> PropertyValue<'a> {
                 Ok(result) => &result == value,
                 _ => false,
             }, // ignore parsing error, assume false
-            PropertyValue::String(value) => PropertyValue::str_equal_with_wildcard(other, value),
         }
     }
 
@@ -83,7 +81,6 @@ impl<'a> PropertyValue<'a> {
             }, // ignore parsing error, assume false
             PropertyValue::List(_) => false,             // operator meaningless for List
             PropertyValue::Boolean(_) => false,          // operator meaningless for bool
-            PropertyValue::String(value) => value.as_str() < other,
         }
     }
 
@@ -109,7 +106,6 @@ impl<'a> PropertyValue<'a> {
             }, // ignore parsing error, assume false
             PropertyValue::List(_) => false,              // operator meaningless for List
             PropertyValue::Boolean(_) => false,           // operator meaningless for bool
-            PropertyValue::String(value) => value.as_str() <= other,
         }
     }
 
@@ -135,7 +131,6 @@ impl<'a> PropertyValue<'a> {
             }, // ignore parsing error, assume false
             PropertyValue::List(_) => false,             // operator meaningless for List
             PropertyValue::Boolean(_) => false,          // operator meaningless for bool
-            PropertyValue::String(value) => value.as_str() > other,
         }
     }
 
@@ -161,7 +156,6 @@ impl<'a> PropertyValue<'a> {
             }, // ignore parsing error, assume false
             PropertyValue::List(_) => false,              // operator meaningless for List
             PropertyValue::Boolean(_) => false,           // operator meaningless for bool
-            PropertyValue::String(value) => value.as_str() >= other,
         }
     }
 
@@ -314,7 +308,6 @@ impl<'a> PropertyValue<'a> {
                         .collect(),
                 ))
             }
-            Literal::String(val) => Ok(PropertyValue::String(val)),
         }
     }
 

--- a/core/market/resolver/tests/prop-parser.rs
+++ b/core/market/resolver/tests/prop-parser.rs
@@ -100,17 +100,29 @@ fn parse_prop_ref_as_list_syntax_error2() {
 #[test]
 fn parse_prop_value_from_literal_string() {
     assert_eq!(
-        parse_prop_value_literal("\"dblah\""),
+        parse_prop_value_literal(r#""dblah""#),
         Ok(Literal::Str("dblah"))
     );
 }
 
 #[test]
-fn parse_prop_value_from_literal_string_with_escaped_quotes() {
+fn parse_prop_value_from_literal_string_with_quotes() {
     assert_eq!(
-        parse_prop_value_literal("\"\\\"king\\\" \\\"node\\\"\""),
-        Ok(Literal::String(String::from("\"king\" \"node\"")))
+        parse_prop_value_literal(r#""one \"two\" \tthree\n""#),
+        Ok(Literal::Str(r#"one \"two\" \tthree\n"#))
     );
+}
+
+#[test]
+fn parse_prop() {
+    assert_eq!(
+        parse_prop_value_literal(
+            r#""hash:sha3:aabb:http://repo.some.network:8000/some-image-ddee0011.gvmi\n""#
+        ),
+        Ok(Literal::Str(
+            r#"hash:sha3:aabb:http://repo.some.network:8000/some-image-ddee0011.gvmi\n"#
+        ))
+    )
 }
 
 #[test]


### PR DESCRIPTION
Removes the `Literal::String` variant as the string is no longer automatically unescaped from quotes.
The parser should not be responsible for unescaping the contents of a str literal.

Limits the acceptable set of special characters to `\" \n \t \0 \\`

Fixes #1817 