### PR TITLE
Payment batching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -730,7 +730,7 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 [[package]]
 name = "bellman_ce"
 version = "0.3.2"
-source = "git+https://github.com/matter-labs/bellman?branch=beta#48441155ec7006bf7bfac553b5fb7d466d7fcd00"
+source = "git+https://github.com/matter-labs/bellman?branch=beta#5809cc165db0a2e15be34c844fec568d8d6005bc"
 dependencies = [
  "bit-vec",
  "blake2s_const",
@@ -839,7 +839,7 @@ dependencies = [
 [[package]]
 name = "blake2s_const"
 version = "0.6.0"
-source = "git+https://github.com/matter-labs/bellman?branch=beta#48441155ec7006bf7bfac553b5fb7d466d7fcd00"
+source = "git+https://github.com/matter-labs/bellman?branch=beta#5809cc165db0a2e15be34c844fec568d8d6005bc"
 dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
@@ -1426,6 +1426,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle 2.4.0",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1637,15 +1647,6 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
-dependencies = [
- "generic-array 0.9.1",
-]
-
-[[package]]
-name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
@@ -1684,6 +1685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1705,12 +1715,12 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
- "redox_users 0.3.5",
+ "redox_users 0.4.0",
  "winapi 0.3.9",
 ]
 
@@ -2043,7 +2053,7 @@ dependencies = [
 [[package]]
 name = "franklin-crypto"
 version = "0.0.5"
-source = "git+https://github.com/matter-labs/franklin-crypto.git?branch=beta#4a706d93628980e036249e3b182b91af8797ce8c"
+source = "git+https://github.com/matter-labs/franklin-crypto.git?branch=beta#6e448d23161eacabb9465dc3181b7b15174cda2f"
 dependencies = [
  "bellman_ce",
  "bit-vec",
@@ -2051,9 +2061,9 @@ dependencies = [
  "blake2-rfc_bellman_edition",
  "blake2s_simd",
  "byteorder",
- "digest 0.7.6",
+ "digest 0.9.0",
  "hex",
- "hmac 0.7.1",
+ "hmac 0.11.0",
  "itertools 0.9.0",
  "num-bigint 0.3.2",
  "num-integer",
@@ -2062,7 +2072,7 @@ dependencies = [
  "rand 0.4.6",
  "serde",
  "serde_derive",
- "sha2 0.8.2",
+ "sha2 0.9.3",
  "splitmut",
  "tiny-keccak 1.5.0",
 ]
@@ -2237,15 +2247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d00328cedcac5e81c683e5620ca6a30756fc23027ebf9bff405c0e8da1fbb7e"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -2543,6 +2544,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
 dependencies = [
  "crypto-mac 0.10.1",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac 0.11.1",
  "digest 0.9.0",
 ]
 
@@ -5706,7 +5717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
- "dirs",
+ "dirs 1.0.5",
  "winapi 0.3.9",
 ]
 
@@ -7118,7 +7129,7 @@ dependencies = [
 
 [[package]]
 name = "ya-payment"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix-rt",
  "actix-web",
@@ -7128,6 +7139,7 @@ dependencies = [
  "chrono",
  "diesel",
  "diesel_migrations",
+ "dirs 4.0.0",
  "dotenv",
  "env_logger 0.7.1",
  "ethsign 0.7.3",

--- a/core/model/src/payment.rs
+++ b/core/model/src/payment.rs
@@ -52,6 +52,15 @@ pub mod local {
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct BatchPayment(pub SchedulePayment);
+
+    impl BatchPayment {
+        pub fn into_inner(self) -> SchedulePayment {
+            self.0
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
     pub struct SchedulePayment {
         pub title: PaymentTitle,
         pub payer_id: NodeId,
@@ -121,6 +130,12 @@ pub mod local {
                 }
             }
         }
+    }
+
+    impl RpcMessage for BatchPayment {
+        const ID: &'static str = "BatchPayment";
+        type Item = ();
+        type Error = GenericError;
     }
 
     impl RpcMessage for SchedulePayment {
@@ -326,6 +341,19 @@ pub mod local {
         fn sum<I: Iterator<Item = StatusNotes>>(iter: I) -> Self {
             iter.fold(Default::default(), |acc, item| acc + item)
         }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    pub struct GetAccount {
+        pub platform: String,
+        pub address: String,
+        pub mode: AccountMode,
+    }
+
+    impl RpcMessage for GetAccount {
+        const ID: &'static str = "GetAccount";
+        type Item = Option<Account>;
+        type Error = GenericError;
     }
 
     #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/core/payment-driver/base/src/driver.rs
+++ b/core/payment-driver/base/src/driver.rs
@@ -26,8 +26,8 @@ pub use ya_core_model::identity::{event::Event as IdentityEvent, Error as Identi
 pub trait PaymentDriver {
     async fn account_event(
         &self,
-        _db: DbExecutor,
-        _caller: String,
+        db: DbExecutor,
+        caller: String,
         msg: IdentityEvent,
     ) -> Result<(), IdentityError>;
 
@@ -48,6 +48,8 @@ pub trait PaymentDriver {
     async fn exit(&self, db: DbExecutor, caller: String, msg: Exit)
         -> Result<String, GenericError>;
 
+    async fn exit_fee(&self, msg: ExitFee) -> Result<FeeResult, GenericError>;
+
     // used by bus to bind service
     fn get_name(&self) -> String;
     fn get_default_network(&self) -> String;
@@ -64,6 +66,8 @@ pub trait PaymentDriver {
         caller: String,
         msg: Transfer,
     ) -> Result<String, GenericError>;
+
+    async fn transfer_fee(&self, msg: TransferFee) -> Result<FeeResult, GenericError>;
 
     async fn schedule_payment(
         &self,

--- a/core/payment-driver/dummy/src/service.rs
+++ b/core/payment-driver/dummy/src/service.rs
@@ -55,15 +55,13 @@ pub async fn register_in_payment_service() -> anyhow::Result<()> {
 async fn init(_db: (), _caller: String, msg: Init) -> Result<Ack, GenericError> {
     log::info!("init: {:?}", msg);
 
-    let address = msg.address();
-    let mode = msg.mode();
-
     let msg = payment_srv::RegisterAccount {
-        address,
+        address: msg.address(),
         driver: DRIVER_NAME.to_string(),
         network: NETWORK_NAME.to_string(),
         token: TOKEN_NAME.to_string(),
-        mode,
+        mode: msg.mode(),
+        batch: msg.batch(),
     };
     bus::service(payment_srv::BUS_ID)
         .send(msg)

--- a/core/payment-driver/erc20/src/driver.rs
+++ b/core/payment-driver/erc20/src/driver.rs
@@ -116,6 +116,11 @@ impl PaymentDriver for Erc20Driver {
         Ok("NOT_IMPLEMENTED".to_string())
     }
 
+    async fn exit_fee(&self, _: ExitFee) -> Result<FeeResult, GenericError> {
+        log::info!("EXIT_FEE = Not Implemented");
+        Err(GenericError::new("EXIT_FEE = Not Implemented"))
+    }
+
     async fn get_account_balance(
         &self,
         _db: DbExecutor,
@@ -163,6 +168,11 @@ impl PaymentDriver for Erc20Driver {
     ) -> Result<String, GenericError> {
         self.is_account_active(&msg.sender)?;
         cli::transfer(&self.dao, msg).await
+    }
+
+    async fn transfer_fee(&self, _msg: TransferFee) -> Result<FeeResult, GenericError> {
+        log::info!("transfer_fee = Not Implemented");
+        Err(GenericError::new("transfer_fee = Not Implemented"))
     }
 
     async fn schedule_payment(

--- a/core/payment-driver/erc20/src/driver/cli.rs
+++ b/core/payment-driver/erc20/src/driver/cli.rs
@@ -39,7 +39,15 @@ pub async fn init(driver: &Erc20Driver, msg: Init) -> Result<(), GenericError> {
 
     let network = network::network_like_to_network(msg.network());
     let token = network::get_network_token(network, msg.token());
-    bus::register_account(driver, &msg.address(), &network.to_string(), &token, mode).await?;
+    bus::register_account(
+        driver,
+        &msg.address(),
+        &network.to_string(),
+        &token,
+        mode,
+        msg.batch(),
+    )
+    .await?;
 
     log::info!(
         "Initialised payment account. mode={:?}, address={}, driver={}, network={}, token={}",

--- a/core/payment-driver/zksync/src/driver.rs
+++ b/core/payment-driver/zksync/src/driver.rs
@@ -206,6 +206,10 @@ impl PaymentDriver for ZksyncDriver {
         ))
     }
 
+    async fn exit_fee(&self, msg: ExitFee) -> Result<FeeResult, GenericError> {
+        Ok(wallet::exit_fee(&msg).await?)
+    }
+
     async fn get_account_balance(
         &self,
         _db: DbExecutor,
@@ -257,7 +261,7 @@ impl PaymentDriver for ZksyncDriver {
             DbNetwork::from_str(&network).map_err(GenericError::new)?,
             msg.token(),
         );
-        bus::register_account(self, &address, &network, &token, mode).await?;
+        bus::register_account(self, &address, &network, &token, mode, msg.batch()).await?;
 
         log::info!(
             "Initialised payment account. mode={:?}, address={}, driver={}, network={}, token={}",
@@ -317,6 +321,10 @@ To be able to use zkSync driver please send some GLM tokens and optionally ETH f
     ) -> Result<String, GenericError> {
         log::info!("TRANSFER = Not Implemented: {:?}", msg);
         Ok("NOT_IMPLEMENTED".to_string())
+    }
+
+    async fn transfer_fee(&self, _msg: TransferFee) -> Result<FeeResult, GenericError> {
+        Err(GenericError::new("NOT_IMPLEMENTED"))
     }
 
     async fn schedule_payment(

--- a/core/payment-driver/zksync/src/zksync/wallet.rs
+++ b/core/payment-driver/zksync/src/zksync/wallet.rs
@@ -9,6 +9,7 @@ use std::env;
 use std::str::FromStr;
 use zksync::operations::SyncTransactionHandle;
 use zksync::types::BlockStatus;
+use zksync::zksync_types::tx::ChangePubKeyType;
 use zksync::zksync_types::{
     tokens::ChangePubKeyFeeTypeArg, tx::TxHash, Address, Nonce, TxFeeTypes, H256,
 };
@@ -21,7 +22,7 @@ use zksync_eth_signer::EthereumSigner;
 // Workspace uses
 use ya_payment_driver::{
     db::models::Network,
-    model::{AccountMode, Enter, Exit, GenericError, Init, PaymentDetails},
+    model::{AccountMode, Enter, Exit, ExitFee, FeeResult, GenericError, Init, PaymentDetails},
     utils as base_utils,
 };
 
@@ -31,7 +32,6 @@ use crate::{
     zksync::{faucet, signer::YagnaEthSigner, utils},
     DEFAULT_NETWORK,
 };
-use zksync::zksync_types::tx::ChangePubKeyType;
 
 pub async fn account_balance(address: &str, network: Network) -> Result<BigDecimal, GenericError> {
     let pub_address = Address::from_str(&address[2..]).map_err(GenericError::new)?;
@@ -84,6 +84,23 @@ pub async fn fund(address: &str, network: Network) -> Result<(), GenericError> {
     Ok(())
 }
 
+pub async fn exit_fee(msg: &ExitFee) -> Result<FeeResult, GenericError> {
+    let network = msg
+        .network
+        .as_ref()
+        .map(AsRef::as_ref)
+        .unwrap_or(DEFAULT_NETWORK);
+    let network = Network::from_str(network).map_err(|e| GenericError::new(e))?;
+    let wallet = get_wallet(&msg.sender, network).await?;
+    let token = get_network_token(network, None);
+    let unlock_fee = get_unlock_fee(&wallet, &token).await?;
+    let withdraw_fee = get_withdraw_fee(&wallet, &token).await?;
+    Ok(FeeResult {
+        amount: utils::big_uint_to_big_dec(unlock_fee + withdraw_fee),
+        token,
+    })
+}
+
 pub async fn exit(msg: &Exit) -> Result<String, GenericError> {
     let network = msg.network().unwrap_or(DEFAULT_NETWORK.to_string());
     let network = Network::from_str(&network).map_err(|e| GenericError::new(e))?;
@@ -94,6 +111,16 @@ pub async fn exit(msg: &Exit) -> Result<String, GenericError> {
     let unlock_fee = get_unlock_fee(&wallet, &token).await?;
     let withdraw_fee = get_withdraw_fee(&wallet, &token).await?;
     let total_fee = unlock_fee + withdraw_fee;
+    if let Some(fee_limit_decimal) = msg.fee_limit() {
+        let fee_limit = utils::big_dec_to_big_uint(fee_limit_decimal.clone())?;
+        if total_fee > fee_limit {
+            return Err(GenericError::new(format!(
+                "minimum withdraw fees is {} {}",
+                utils::big_uint_to_big_dec(total_fee),
+                token
+            )));
+        }
+    }
     if balance < total_fee {
         return Err(GenericError::new(format!(
             "Not enough balance to exit. Minimum required balance to pay withdraw fees is {} {}",

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-payment"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
@@ -53,6 +53,7 @@ ya-zksync-driver = "0.2"
 ya-net = { version = "0.2", features = ["service"] }
 ya-sb-router = "0.4"
 
+dirs = "4.0"
 actix-rt = "1.0"
 
 rand = "0.7"

--- a/core/payment/examples/account_balance.rs
+++ b/core/payment/examples/account_balance.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
                 driver: account.driver,
                 network: Some(account.network),
                 token: Some(account.token),
-                after_timestamp: 0,
+                since: None,
             })
             .await??;
         log::info!("Balance: {:?}", payer_status.amount);

--- a/core/payment/examples/cancel_invoice.rs
+++ b/core/payment/examples/cancel_invoice.rs
@@ -33,7 +33,7 @@ async fn assert_requested_amount(
             driver: driver.to_string(),
             network: network.clone(),
             token: None,
-            after_timestamp: 0,
+            since: None,
         })
         .await??;
     assert_eq!(&payer_status.outgoing.requested.total_amount, amount);
@@ -44,7 +44,7 @@ async fn assert_requested_amount(
             driver: driver.to_string(),
             network: network.clone(),
             token: None,
-            after_timestamp: 0,
+            since: None,
         })
         .await??;
     assert_eq!(&payee_status.incoming.requested.total_amount, amount);

--- a/core/payment/examples/payment_api.rs
+++ b/core/payment/examples/payment_api.rs
@@ -265,6 +265,7 @@ async fn main() -> anyhow::Result<()> {
             args.network.clone(),
             None,
             AccountMode::RECV,
+            None,
         ))
         .await??;
 
@@ -281,6 +282,7 @@ async fn main() -> anyhow::Result<()> {
             args.network.clone(),
             None,
             AccountMode::SEND,
+            None,
         ))
         .await??;
 

--- a/core/payment/examples/resolve_invoices.rs
+++ b/core/payment/examples/resolve_invoices.rs
@@ -1,20 +1,8 @@
-use anyhow::Context;
-use bigdecimal::{BigDecimal, ToPrimitive, Zero};
-use chrono::{Duration, Utc};
-use num_bigint::ToBigInt;
-use std::borrow::BorrowMut;
-use std::collections::{btree_map, hash_map};
-use std::collections::{BTreeMap, HashMap};
 use structopt::StructOpt;
-use uuid::Uuid;
-use ya_client::model::payment as mpay;
-use ya_client_model::payment::DocumentStatus;
+
 use ya_core_model::driver::{driver_bus_id, SchedulePayment};
-use ya_core_model::net::NetApiError::NodeIdParseError;
-use ya_core_model::payment::local as pay;
-use ya_core_model::payment::public as ppay;
 use ya_core_model::NodeId;
-use ya_payment::dao::{AgreementDao, BatchDao, InvoiceDao, OrderDao};
+use ya_payment::dao::BatchDao;
 use ya_persistence::executor::DbExecutor;
 use ya_service_bus::typed as bus;
 
@@ -62,7 +50,7 @@ async fn main() -> anyhow::Result<()> {
     let db = {
         let database_url = format!(
             "file:{}/.local/share/yagna/payment.db",
-            std::env::home_dir().unwrap().display()
+            dirs::home_dir().unwrap().display()
         );
         let db = DbExecutor::new(database_url)?;
         db.apply_migration(ya_payment::migrations::run_with_output)?;
@@ -98,60 +86,12 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn list_dn(db: DbExecutor) -> anyhow::Result<()> {
-    for (id, amount, prev_id) in db
-        .as_dao::<BatchDao>()
-        .list_debit_notes(
-            "0xf7530cbcd3685a997b1e49974f68dbe94b1116be".parse()?,
-            "erc20-mumbai-tglm".to_string(),
-            chrono::Utc::now() + chrono::Duration::days(-30),
-        )
-        .await?
-    {
-        eprintln!("id={}, amount={}, prev_id={}", id, amount, prev_id);
-    }
-    Ok(())
-}
-
-struct Payment {
-    amount: BigDecimal,
-    delivers: HashMap<NodeId, Vec<Obligation>>,
-}
-
-#[derive(Debug, Clone)]
-enum Obligation {
-    Invoice {
-        id: String,
-        amount: BigDecimal,
-        agreement_id: String,
-    },
-}
-
-impl Payment {
-    fn new() -> Self {
-        Payment {
-            amount: BigDecimal::default(),
-            delivers: Default::default(),
-        }
-    }
-}
-
-#[derive(Debug)]
-struct Order {
-    payer_addr: NodeId,
-    payee_addr: NodeId,
-    payment_platform: String,
-    amount: BigDecimal,
-    payments: Vec<mpay::Payment>,
-    obligations: Vec<Obligation>,
-}
-
 async fn generate(
     db: DbExecutor,
     owner_id: NodeId,
     payment_platform: String,
-    dry_run: bool,
-    incremental: bool,
+    _dry_run: bool,
+    _incremental: bool,
 ) -> anyhow::Result<()> {
     let ts = chrono::Utc::now() + chrono::Duration::days(-7);
 
@@ -159,225 +99,6 @@ async fn generate(
         .as_dao::<BatchDao>()
         .resolve(owner_id, owner_id.to_string(), payment_platform, ts)
         .await?;
-    /*
-    let invoices = db
-        .as_dao::<InvoiceDao>()
-        .get_for_node_id(owner_id, Some(ts.naive_utc()), Some(1000))
-        .await?;
-
-    let mut payments = HashMap::<(NodeId, NodeId, String), Payment>::new();
-
-    let mut total_amount_i = BigDecimal::default();
-    for invoice in invoices
-        .into_iter()
-        .filter(|i| i.status == DocumentStatus::Accepted)
-        .filter(|i| i.payment_platform == payment_platform)
-        .filter(|i| i.recipient_id == owner_id)
-    {
-        let agreement = db
-            .as_dao::<AgreementDao>()
-            .get(invoice.agreement_id.clone(), invoice.recipient_id)
-            .await?
-            .context("agreement exists")?;
-        let amount_to_pay = agreement.total_amount_due.0 - agreement.total_amount_paid.0;
-        if amount_to_pay < BigDecimal::from(0u32) {
-            continue;
-        }
-        //assert_eq!(amount_to_pay, invoice.amount);
-        let obligation = Obligation::Invoice {
-            id: invoice.invoice_id,
-            amount: amount_to_pay.clone(),
-            agreement_id: invoice.agreement_id,
-        };
-        total_amount_i += &amount_to_pay;
-        match payments.entry((
-            invoice.payer_addr.parse()?,
-            invoice.payee_addr.parse()?,
-            invoice.payment_platform,
-        )) {
-            hash_map::Entry::Occupied(mut e) => {
-                let mut payment = e.get_mut();
-                payment.amount += &amount_to_pay;
-                match payment.delivers.entry(invoice.issuer_id) {
-                    hash_map::Entry::Occupied(mut e) => {
-                        e.get_mut().push(obligation);
-                    }
-                    hash_map::Entry::Vacant(e) => {
-                        e.insert(vec![obligation]);
-                    }
-                }
-            }
-            hash_map::Entry::Vacant(e) => {
-                let mut payment = Payment::new();
-                payment.amount = amount_to_pay.clone();
-                let r = payment.delivers.insert(invoice.issuer_id, vec![obligation]);
-                assert!(r.is_none());
-                e.insert(payment);
-            }
-        }
-    }
-    let mut total_amount = BigDecimal::default();
-
-    #[derive(Hash, Eq, PartialEq)]
-    struct Key {
-        payer_addr: NodeId,
-        payment_platform: String,
-    }
-
-    struct Item {
-        items: HashMap<String, (BigDecimal, HashMap<NodeId, String>)>,
-    }
-
-    let mut px: HashMap<Key, Item> = Default::default();
-    let ten = BigDecimal::from(10u64);
-    let mut presision = BigDecimal::from(1u64);
-    for _ in 0..18 {
-        presision *= &ten;
-    }
-
-    let mut sqls = Vec::new();
-    let mut prev_amount_map = HashMap::<(NodeId, String), _>::new();
-    let zero = BigDecimal::default();
-    for ((payer_addr, payee_addr, payment_platform), payment) in payments {
-        let key = (owner_id, payment_platform.clone());
-        if !prev_amount_map.contains_key(&key) {
-            prev_amount_map.insert(
-                key.clone(),
-                db.as_dao::<OrderDao>()
-                    .get_batch_items(owner_id, payment_platform.clone())
-                    .await?,
-            );
-        }
-        let prev_amount = prev_amount_map.get(&key).unwrap();
-
-        let payment_id = Uuid::new_v4().to_string();
-        let mut payment_amount = if incremental {
-            &payment.amount
-                - prev_amount
-                    .get(&(payer_addr.to_string(), payee_addr.to_string()))
-                    .unwrap_or(&zero)
-        } else {
-            payment.amount.clone()
-        };
-        if payment_amount < zero {
-            payment_amount = zero.clone();
-        }
-        let mut order = Order {
-            payer_addr,
-            payee_addr,
-            payment_platform: payment_platform.clone(),
-            obligations: Default::default(),
-            payments: Default::default(),
-            amount: payment_amount.clone(),
-        };
-
-        match px.entry(Key {
-            payer_addr,
-            payment_platform: payment_platform.clone(),
-        }) {
-            hash_map::Entry::Occupied(mut e) => (),
-            hash_map::Entry::Vacant(e) => {
-                e.insert(Item {
-                    items: Default::default(),
-                });
-            }
-        };
-
-        let item = px
-            .get_mut(&Key {
-                payer_addr,
-                payment_platform: payment_platform.clone(),
-            })
-            .unwrap();
-
-        total_amount += &payment_amount;
-
-        let sql_line = format!(
-            r#"
-        INSERT INTO payment (order_id, amount, gas, sender, recipient, payment_due_date, status, tx_id, network)
-        VALUES ('{}', '{}', '0000000000000000000000000000000000000000000000000000000000000000', '{}', '{}', '2021-08-27 23:19:32.577052800', 99, null, 1);"#,
-            Uuid::new_v4(),
-            format!(
-                "{:064x}",
-                (&payment_amount * &presision).round(0).to_bigint().unwrap()
-            ),
-            owner_id,
-            payee_addr
-        );
-        if payment_amount > zero {
-            sqls.push(sql_line);
-        }
-
-        eprintln!("\n\n{}/{}/{}\n", payment_platform, payer_addr, payee_addr);
-        eprintln!("  :: amount {} // {}", &payment_amount, &payment.amount);
-        for (peer, obligations) in payment.delivers {
-            let mut payment_template = mpay::Payment {
-                payment_id: payment_id.clone(),
-                payer_id: payer_addr,
-                payee_id: payee_addr,
-                payer_addr: payer_addr.to_string(),
-                payee_addr: payee_addr.to_string(),
-                payment_platform: payment_platform.clone(),
-                amount: payment_amount.clone(),
-                timestamp: chrono::Utc::now(),
-                agreement_payments: vec![],
-                activity_payments: vec![],
-                details: "".to_string(),
-            };
-
-            eprintln!("  :: peer {} invoices {}", peer, obligations.len());
-            for obligation in obligations {
-                order.obligations.push(obligation.clone());
-                match obligation {
-                    Obligation::Invoice {
-                        id,
-                        amount,
-                        agreement_id,
-                    } => {
-                        payment_template
-                            .agreement_payments
-                            .push(mpay::AgreementPayment {
-                                agreement_id: agreement_id.to_string(),
-                                amount: amount.clone(),
-                                allocation_id: None,
-                            });
-                    }
-                }
-            }
-            let _ = match item.items.entry(payee_addr.to_string()) {
-                hash_map::Entry::Occupied(mut e) => e
-                    .get_mut()
-                    .1
-                    .insert(peer, serde_json::to_string_pretty(&payment_template)?),
-                hash_map::Entry::Vacant(e) => e
-                    .insert((payment_amount.clone(), Default::default()))
-                    .1
-                    .insert(peer, serde_json::to_string_pretty(&payment_template)?),
-            };
-            order.payments.push(payment_template);
-        }
-        //eprintln!("order={:?}", order);
-    }
-
-    for sql in sqls {
-        eprintln!("{}", sql);
-    }
-
-    if !dry_run {
-        /*for (k, v) in px {
-            let id = db
-                .as_dao::<BatchDao>()
-                .new_batch_order(
-                    owner_id,
-                    k.payer_addr.to_string(),
-                    k.payment_platform,
-                    v.items,
-                )
-                .await?;
-            eprintln!("order={}", id);
-        }
-        todo!()
-    }*/*/
 
     eprintln!("order={:?}", order_id);
     Ok(())

--- a/core/payment/examples/resolve_invoices.rs
+++ b/core/payment/examples/resolve_invoices.rs
@@ -1,0 +1,422 @@
+use anyhow::Context;
+use bigdecimal::{BigDecimal, ToPrimitive, Zero};
+use chrono::{Duration, Utc};
+use num_bigint::ToBigInt;
+use std::borrow::BorrowMut;
+use std::collections::{btree_map, hash_map};
+use std::collections::{BTreeMap, HashMap};
+use structopt::StructOpt;
+use uuid::Uuid;
+use ya_client::model::payment as mpay;
+use ya_client_model::payment::DocumentStatus;
+use ya_core_model::driver::{driver_bus_id, SchedulePayment};
+use ya_core_model::net::NetApiError::NodeIdParseError;
+use ya_core_model::payment::local as pay;
+use ya_core_model::payment::public as ppay;
+use ya_core_model::NodeId;
+use ya_payment::dao::{AgreementDao, BatchDao, InvoiceDao, OrderDao};
+use ya_persistence::executor::DbExecutor;
+use ya_service_bus::typed as bus;
+
+#[derive(StructOpt)]
+struct Args {
+    #[structopt(subcommand)]
+    command: Command,
+}
+
+#[derive(StructOpt)]
+enum Command {
+    Generate {
+        #[structopt(long, short = "n")]
+        dry_run: bool,
+        #[structopt(long)]
+        incremental: bool,
+        #[structopt(long, default_value = "0x206bfe4f439a83b65a5b9c2c3b1cc6cb49054cc4")]
+        owner: NodeId,
+        #[structopt(long, default_value = "erc20-mumbai-tglm")]
+        payment_platform: String,
+    },
+    SendPayments {
+        #[structopt(long)]
+        order_id: String,
+    },
+    Run {
+        #[structopt(long)]
+        owner: NodeId,
+        #[structopt(long)]
+        payment_platform: String,
+        #[structopt(long)]
+        interval: Option<humantime::Duration>,
+    },
+}
+
+#[actix_rt::main]
+async fn main() -> anyhow::Result<()> {
+    std::env::set_var("RUST_LOG", "debug");
+    env_logger::init();
+
+    let args = Args::from_args_safe()?;
+
+    log::info!("test1");
+
+    let db = {
+        let database_url = format!(
+            "file:{}/.local/share/yagna/payment.db",
+            std::env::home_dir().unwrap().display()
+        );
+        let db = DbExecutor::new(database_url)?;
+        db.apply_migration(ya_payment::migrations::run_with_output)?;
+        db
+    };
+
+    match args.command {
+        Command::Generate {
+            dry_run,
+            payment_platform,
+            owner,
+            incremental,
+        } => generate(db, owner, payment_platform, dry_run, incremental).await?,
+        Command::SendPayments { order_id } => send_payments(db, order_id).await?,
+        Command::Run {
+            owner,
+            payment_platform,
+            interval,
+        } => {
+            if let Some(duration) = interval {
+                loop {
+                    tokio::time::delay_for(duration.into()).await;
+                    log::info!("sending payments for {} {}", owner, payment_platform);
+                    if let Err(e) = run(db.clone(), owner, payment_platform.clone()).await {
+                        log::error!("failed to process order: {:?}", e);
+                    }
+                }
+            } else {
+                run(db, owner, payment_platform).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn list_dn(db: DbExecutor) -> anyhow::Result<()> {
+    for (id, amount, prev_id) in db
+        .as_dao::<BatchDao>()
+        .list_debit_notes(
+            "0xf7530cbcd3685a997b1e49974f68dbe94b1116be".parse()?,
+            "erc20-mumbai-tglm".to_string(),
+            chrono::Utc::now() + chrono::Duration::days(-30),
+        )
+        .await?
+    {
+        eprintln!("id={}, amount={}, prev_id={}", id, amount, prev_id);
+    }
+    Ok(())
+}
+
+struct Payment {
+    amount: BigDecimal,
+    delivers: HashMap<NodeId, Vec<Obligation>>,
+}
+
+#[derive(Debug, Clone)]
+enum Obligation {
+    Invoice {
+        id: String,
+        amount: BigDecimal,
+        agreement_id: String,
+    },
+}
+
+impl Payment {
+    fn new() -> Self {
+        Payment {
+            amount: BigDecimal::default(),
+            delivers: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Order {
+    payer_addr: NodeId,
+    payee_addr: NodeId,
+    payment_platform: String,
+    amount: BigDecimal,
+    payments: Vec<mpay::Payment>,
+    obligations: Vec<Obligation>,
+}
+
+async fn generate(
+    db: DbExecutor,
+    owner_id: NodeId,
+    payment_platform: String,
+    dry_run: bool,
+    incremental: bool,
+) -> anyhow::Result<()> {
+    let ts = chrono::Utc::now() + chrono::Duration::days(-7);
+
+    let order_id = db
+        .as_dao::<BatchDao>()
+        .resolve(owner_id, owner_id.to_string(), payment_platform, ts)
+        .await?;
+    /*
+    let invoices = db
+        .as_dao::<InvoiceDao>()
+        .get_for_node_id(owner_id, Some(ts.naive_utc()), Some(1000))
+        .await?;
+
+    let mut payments = HashMap::<(NodeId, NodeId, String), Payment>::new();
+
+    let mut total_amount_i = BigDecimal::default();
+    for invoice in invoices
+        .into_iter()
+        .filter(|i| i.status == DocumentStatus::Accepted)
+        .filter(|i| i.payment_platform == payment_platform)
+        .filter(|i| i.recipient_id == owner_id)
+    {
+        let agreement = db
+            .as_dao::<AgreementDao>()
+            .get(invoice.agreement_id.clone(), invoice.recipient_id)
+            .await?
+            .context("agreement exists")?;
+        let amount_to_pay = agreement.total_amount_due.0 - agreement.total_amount_paid.0;
+        if amount_to_pay < BigDecimal::from(0u32) {
+            continue;
+        }
+        //assert_eq!(amount_to_pay, invoice.amount);
+        let obligation = Obligation::Invoice {
+            id: invoice.invoice_id,
+            amount: amount_to_pay.clone(),
+            agreement_id: invoice.agreement_id,
+        };
+        total_amount_i += &amount_to_pay;
+        match payments.entry((
+            invoice.payer_addr.parse()?,
+            invoice.payee_addr.parse()?,
+            invoice.payment_platform,
+        )) {
+            hash_map::Entry::Occupied(mut e) => {
+                let mut payment = e.get_mut();
+                payment.amount += &amount_to_pay;
+                match payment.delivers.entry(invoice.issuer_id) {
+                    hash_map::Entry::Occupied(mut e) => {
+                        e.get_mut().push(obligation);
+                    }
+                    hash_map::Entry::Vacant(e) => {
+                        e.insert(vec![obligation]);
+                    }
+                }
+            }
+            hash_map::Entry::Vacant(e) => {
+                let mut payment = Payment::new();
+                payment.amount = amount_to_pay.clone();
+                let r = payment.delivers.insert(invoice.issuer_id, vec![obligation]);
+                assert!(r.is_none());
+                e.insert(payment);
+            }
+        }
+    }
+    let mut total_amount = BigDecimal::default();
+
+    #[derive(Hash, Eq, PartialEq)]
+    struct Key {
+        payer_addr: NodeId,
+        payment_platform: String,
+    }
+
+    struct Item {
+        items: HashMap<String, (BigDecimal, HashMap<NodeId, String>)>,
+    }
+
+    let mut px: HashMap<Key, Item> = Default::default();
+    let ten = BigDecimal::from(10u64);
+    let mut presision = BigDecimal::from(1u64);
+    for _ in 0..18 {
+        presision *= &ten;
+    }
+
+    let mut sqls = Vec::new();
+    let mut prev_amount_map = HashMap::<(NodeId, String), _>::new();
+    let zero = BigDecimal::default();
+    for ((payer_addr, payee_addr, payment_platform), payment) in payments {
+        let key = (owner_id, payment_platform.clone());
+        if !prev_amount_map.contains_key(&key) {
+            prev_amount_map.insert(
+                key.clone(),
+                db.as_dao::<OrderDao>()
+                    .get_batch_items(owner_id, payment_platform.clone())
+                    .await?,
+            );
+        }
+        let prev_amount = prev_amount_map.get(&key).unwrap();
+
+        let payment_id = Uuid::new_v4().to_string();
+        let mut payment_amount = if incremental {
+            &payment.amount
+                - prev_amount
+                    .get(&(payer_addr.to_string(), payee_addr.to_string()))
+                    .unwrap_or(&zero)
+        } else {
+            payment.amount.clone()
+        };
+        if payment_amount < zero {
+            payment_amount = zero.clone();
+        }
+        let mut order = Order {
+            payer_addr,
+            payee_addr,
+            payment_platform: payment_platform.clone(),
+            obligations: Default::default(),
+            payments: Default::default(),
+            amount: payment_amount.clone(),
+        };
+
+        match px.entry(Key {
+            payer_addr,
+            payment_platform: payment_platform.clone(),
+        }) {
+            hash_map::Entry::Occupied(mut e) => (),
+            hash_map::Entry::Vacant(e) => {
+                e.insert(Item {
+                    items: Default::default(),
+                });
+            }
+        };
+
+        let item = px
+            .get_mut(&Key {
+                payer_addr,
+                payment_platform: payment_platform.clone(),
+            })
+            .unwrap();
+
+        total_amount += &payment_amount;
+
+        let sql_line = format!(
+            r#"
+        INSERT INTO payment (order_id, amount, gas, sender, recipient, payment_due_date, status, tx_id, network)
+        VALUES ('{}', '{}', '0000000000000000000000000000000000000000000000000000000000000000', '{}', '{}', '2021-08-27 23:19:32.577052800', 99, null, 1);"#,
+            Uuid::new_v4(),
+            format!(
+                "{:064x}",
+                (&payment_amount * &presision).round(0).to_bigint().unwrap()
+            ),
+            owner_id,
+            payee_addr
+        );
+        if payment_amount > zero {
+            sqls.push(sql_line);
+        }
+
+        eprintln!("\n\n{}/{}/{}\n", payment_platform, payer_addr, payee_addr);
+        eprintln!("  :: amount {} // {}", &payment_amount, &payment.amount);
+        for (peer, obligations) in payment.delivers {
+            let mut payment_template = mpay::Payment {
+                payment_id: payment_id.clone(),
+                payer_id: payer_addr,
+                payee_id: payee_addr,
+                payer_addr: payer_addr.to_string(),
+                payee_addr: payee_addr.to_string(),
+                payment_platform: payment_platform.clone(),
+                amount: payment_amount.clone(),
+                timestamp: chrono::Utc::now(),
+                agreement_payments: vec![],
+                activity_payments: vec![],
+                details: "".to_string(),
+            };
+
+            eprintln!("  :: peer {} invoices {}", peer, obligations.len());
+            for obligation in obligations {
+                order.obligations.push(obligation.clone());
+                match obligation {
+                    Obligation::Invoice {
+                        id,
+                        amount,
+                        agreement_id,
+                    } => {
+                        payment_template
+                            .agreement_payments
+                            .push(mpay::AgreementPayment {
+                                agreement_id: agreement_id.to_string(),
+                                amount: amount.clone(),
+                                allocation_id: None,
+                            });
+                    }
+                }
+            }
+            let _ = match item.items.entry(payee_addr.to_string()) {
+                hash_map::Entry::Occupied(mut e) => e
+                    .get_mut()
+                    .1
+                    .insert(peer, serde_json::to_string_pretty(&payment_template)?),
+                hash_map::Entry::Vacant(e) => e
+                    .insert((payment_amount.clone(), Default::default()))
+                    .1
+                    .insert(peer, serde_json::to_string_pretty(&payment_template)?),
+            };
+            order.payments.push(payment_template);
+        }
+        //eprintln!("order={:?}", order);
+    }
+
+    for sql in sqls {
+        eprintln!("{}", sql);
+    }
+
+    if !dry_run {
+        /*for (k, v) in px {
+            let id = db
+                .as_dao::<BatchDao>()
+                .new_batch_order(
+                    owner_id,
+                    k.payer_addr.to_string(),
+                    k.payment_platform,
+                    v.items,
+                )
+                .await?;
+            eprintln!("order={}", id);
+        }
+        todo!()
+    }*/*/
+
+    eprintln!("order={:?}", order_id);
+    Ok(())
+}
+
+async fn send_payments(db: DbExecutor, order_id: String) -> anyhow::Result<()> {
+    let (order, items) = db
+        .as_dao::<BatchDao>()
+        .get_unsent_batch_items(order_id.clone())
+        .await?;
+    eprintln!("got {} orders", items.len());
+    let bus_id = driver_bus_id("erc20");
+    for item in items {
+        eprintln!("sending: {:?}", &item);
+        let payment_order_id = bus::service(&bus_id)
+            .call(SchedulePayment::new(
+                item.amount.0,
+                order.payer_addr.clone(),
+                item.payee_addr.clone(),
+                order.platform.clone(),
+                chrono::Utc::now(),
+            ))
+            .await??;
+        db.as_dao::<BatchDao>()
+            .batch_order_item_send(order_id.clone(), item.payee_addr, payment_order_id)
+            .await?;
+    }
+    Ok(())
+}
+
+async fn run(db: DbExecutor, owner_id: NodeId, payment_platform: String) -> anyhow::Result<()> {
+    let ts = chrono::Utc::now() + chrono::Duration::days(-15);
+
+    if let Some(order_id) = db
+        .as_dao::<BatchDao>()
+        .resolve(owner_id, owner_id.to_string(), payment_platform, ts)
+        .await?
+    {
+        send_payments(db, order_id).await?;
+    }
+    Ok(())
+}

--- a/core/payment/examples/validate_allocation.rs
+++ b/core/payment/examples/validate_allocation.rs
@@ -20,7 +20,7 @@ async fn get_requestor_balance_and_platform() -> anyhow::Result<(BigDecimal, Str
                     driver: account.driver,
                     network: Some(account.network),
                     token: Some(account.token),
-                    after_timestamp: 0,
+                    since: None,
                 })
                 .await??;
             return Ok((status.amount, account.platform));

--- a/core/payment/migrations/2021-08-17-152257_timestamps/down.sql
+++ b/core/payment/migrations/2021-08-17-152257_timestamps/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/core/payment/migrations/2021-08-17-152257_timestamps/up.sql
+++ b/core/payment/migrations/2021-08-17-152257_timestamps/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+ALTER TABLE pay_agreement ADD created_ts DATETIME;
+
+ALTER TABLE pay_agreement ADD updated_ts DATETIME;

--- a/core/payment/migrations/2021-09-08-121012_extended_order/down.sql
+++ b/core/payment/migrations/2021-09-08-121012_extended_order/down.sql
@@ -1,0 +1,6 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE PAY_BATCH_ORDER_ITEM_PAYMENT;
+
+DROP TABLE PAY_BATCH_ORDER_ITEM;
+
+DROP TABLE PAY_BATCH_ORDER;

--- a/core/payment/migrations/2021-09-08-121012_extended_order/up.sql
+++ b/core/payment/migrations/2021-09-08-121012_extended_order/up.sql
@@ -1,0 +1,36 @@
+-- Your SQL goes here
+CREATE TABLE pay_batch_order(
+    id              VARCHAR (50) NOT NULL,
+    ts              DATETIME NOT NULL DEFAULT(STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW')),
+    owner_id        VARCHAR(50) NOT NULL,
+    payer_addr      VARCHAR(50) NOT NULL,
+    platform        VARCHAR(50) NOT NULL,
+    total_amount    REAL,
+    paid            BOOLEAN NOT NULL DEFAULT FALSE,
+
+    CONSTRAINT PAY_BATCH_ORDER_PK PRIMARY KEY(id)
+);
+
+CREATE TABLE pay_batch_order_item(
+    id              VARCHAR (50) NOT NULL,
+    payee_addr      VARCHAR(50) NOT NULL,
+    amount          VARCHAR(32) NOT NULL,
+    driver_order_id VARCHAR(50),
+    paid            BOOLEAN NOT NULL DEFAULT FALSE,
+
+    CONSTRAINT PAY_BATCH_ORDER_ITEM_PK PRIMARY KEY (id, payee_addr),
+    CONSTRAINT PAY_BATCH_ORDER_ITEM_FK1 FOREIGN KEY (id) REFERENCES pay_batch_order(id)
+);
+
+CREATE TABLE pay_batch_order_item_payment(
+    id              VARCHAR (50) NOT NULL,
+    payee_addr      VARCHAR(50) NOT NULL,
+    payee_id        VARCHAR(50) NOT NULL,
+    json            TEXT NOT NULL,
+
+    CONSTRAINT PAY_BATCH_ORDER_ITEM_PAYMENT_PK PRIMARY KEY (id, payee_addr, payee_id),
+    CONSTRAINT PAY_BATCH_ORDER_ITEM_PAYMENT_FK1 FOREIGN KEY (id, payee_addr) REFERENCES pay_batch_order_item(id, payee_addr),
+    CONSTRAINT PAY_BATCH_ORDER_ITEM_PAYMENT_FK2 FOREIGN KEY (id) REFERENCES pay_batch_order(ID)
+);
+
+

--- a/core/payment/migrations/2022-02-10-122354_batch_deadline/down.sql
+++ b/core/payment/migrations/2022-02-10-122354_batch_deadline/down.sql
@@ -1,0 +1,25 @@
+CREATE TABLE pay_batch_order_item_tmp(
+    id              VARCHAR (50) NOT NULL,
+    payee_addr      VARCHAR(50) NOT NULL,
+    amount          VARCHAR(32) NOT NULL,
+    driver_order_id VARCHAR(50),
+    paid            BOOLEAN NOT NULL DEFAULT FALSE,
+
+    CONSTRAINT PAY_BATCH_ORDER_ITEM_PK PRIMARY KEY (id, payee_addr),
+    CONSTRAINT PAY_BATCH_ORDER_ITEM_FK1 FOREIGN KEY (id) REFERENCES pay_batch_order(id)
+);
+
+INSERT INTO pay_batch_order_tmp(id, payee_addr, amount, driver_order_id, paid)
+SELECT id, payee_addr, amount, driver_order_id, (
+  CASE
+      WHEN status = "PENDING" THEN FALSE
+      ELSE TRUE
+  END
+) FROM pay_batch_order_item;
+
+DROP TABLE pay_batch_order_item_status;
+DROP TABLE pay_batch_order_item;
+
+ALTER TABLE pay_batch_order_item_tmp RENAME TO pay_batch_order_item;
+
+DROP INDEX pay_batch_order_triplet_idx;

--- a/core/payment/migrations/2022-02-10-122354_batch_deadline/up.sql
+++ b/core/payment/migrations/2022-02-10-122354_batch_deadline/up.sql
@@ -1,0 +1,33 @@
+CREATE TABLE pay_batch_order_item_status(
+    status VARCHAR(50) NOT NULL PRIMARY KEY
+);
+
+INSERT INTO pay_batch_order_item_status(status) VALUES('PENDING');
+INSERT INTO pay_batch_order_item_status(status) VALUES('SENT');
+INSERT INTO pay_batch_order_item_status(status) VALUES('PAID');
+
+CREATE TABLE pay_batch_order_item_tmp (
+    id                  VARCHAR(50) NOT NULL,
+    payee_addr          VARCHAR(50) NOT NULL,
+    amount              VARCHAR(32) NOT NULL,
+    driver_order_id     VARCHAR(50),
+    status              VARCHAR(50) NOT NULL DEFAULT "PENDING",
+    payment_due_date    DATETIME,
+
+    CONSTRAINT PAY_BATCH_ORDER_ITEM_PK  PRIMARY KEY (id, payee_addr),
+    CONSTRAINT PAY_BATCH_ORDER_ITEM_FK1 FOREIGN KEY (id) REFERENCES pay_batch_order (id)
+    CONSTRAINT PAY_BATCH_ORDER_ITEM_FK2 FOREIGN KEY (status) REFERENCES pay_batch_order_item_status (status)
+);
+
+INSERT INTO pay_batch_order_item_tmp(id, payee_addr, amount, driver_order_id, status)
+SELECT id, payee_addr, amount, driver_order_id, (
+  CASE
+    WHEN paid IS TRUE THEN "PAID"
+    ELSE "PENDING"
+  END
+) FROM pay_batch_order_item;
+
+DROP TABLE pay_batch_order_item;
+ALTER TABLE pay_batch_order_item_tmp RENAME TO pay_batch_order_item;
+
+CREATE INDEX IF NOT EXISTS pay_batch_order_triplet_idx on pay_batch_order (owner_id, payer_addr, platform);

--- a/core/payment/src/accounts.rs
+++ b/core/payment/src/accounts.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::path::{Path, PathBuf};
+
 use tokio::fs;
-use ya_core_model::driver::{driver_bus_id, AccountMode, Init};
+use ya_core_model::driver::{driver_bus_id, AccountMode, BatchMode, Init};
 use ya_core_model::identity;
 use ya_service_bus::typed as bus;
 
@@ -14,6 +15,13 @@ fn accounts_path(data_dir: &Path) -> PathBuf {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub(crate) enum SendMode {
+    Simple(bool),
+    Batch(BatchMode),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Account {
     pub driver: String,
     pub address: String,
@@ -21,14 +29,19 @@ pub(crate) struct Account {
     pub network: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
-    pub send: bool,
+    pub send: SendMode,
     pub receive: bool,
 }
 
 pub(crate) async fn init_account(account: Account) -> anyhow::Result<()> {
     log::debug!("Initializing payment account {:?}...", account);
     let mut mode = AccountMode::NONE;
-    mode.set(AccountMode::SEND, account.send);
+    let (send, batch) = match account.send {
+        SendMode::Simple(v) => (v, None),
+        SendMode::Batch(mode) => (true, Some(mode)),
+    };
+
+    mode.set(AccountMode::SEND, send);
     mode.set(AccountMode::RECV, account.receive);
     bus::service(driver_bus_id(account.driver))
         .call(Init::new(
@@ -36,6 +49,7 @@ pub(crate) async fn init_account(account: Account) -> anyhow::Result<()> {
             account.network,
             account.token,
             mode,
+            batch,
         ))
         .await??;
     log::debug!("Account initialized.");
@@ -84,7 +98,7 @@ pub async fn save_default_account(data_dir: &Path, drivers: Vec<String>) -> anyh
             address: default_node_id.to_string(),
             network: None, // Use default
             token: None,   // Use default
-            send: false,
+            send: SendMode::Batch(BatchMode::Manual {}),
             receive: true,
         })
         .collect();

--- a/core/payment/src/accounts.rs
+++ b/core/payment/src/accounts.rs
@@ -21,6 +21,12 @@ pub(crate) enum SendMode {
     Batch(BatchMode),
 }
 
+impl Default for SendMode {
+    fn default() -> Self {
+        Self::Batch(BatchMode::default())
+    }
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Account {
     pub driver: String,
@@ -98,7 +104,7 @@ pub async fn save_default_account(data_dir: &Path, drivers: Vec<String>) -> anyh
             address: default_node_id.to_string(),
             network: None, // Use default
             token: None,   // Use default
-            send: SendMode::Batch(BatchMode::Manual {}),
+            send: SendMode::default(),
             receive: true,
         })
         .collect();

--- a/core/payment/src/api/debit_notes.rs
+++ b/core/payment/src/api/debit_notes.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 // Workspace uses
 use metrics::{counter, timing};
 use ya_client_model::payment::*;
-use ya_core_model::payment::local::{SchedulePayment, BUS_ID as LOCAL_SERVICE};
+// use ya_core_model::payment::local::{SchedulePayment, BUS_ID as LOCAL_SERVICE};
 use ya_core_model::payment::public::{
     AcceptDebitNote, AcceptRejectError, SendDebitNote, SendError, BUS_ID as PUBLIC_SERVICE,
 };
@@ -17,7 +17,7 @@ use ya_persistence::executor::DbExecutor;
 use ya_persistence::types::Role;
 use ya_service_api_web::middleware::Identity;
 use ya_service_bus::timeout::IntoTimeoutFuture;
-use ya_service_bus::{typed as bus, RpcEndpoint};
+// use ya_service_bus::{typed as bus, RpcEndpoint};
 
 // Local uses
 use crate::dao::*;
@@ -337,8 +337,8 @@ async fn accept_debit_note(
     let result = async move {
         let issuer_id = debit_note.issuer_id;
         let accept_msg = AcceptDebitNote::new(debit_note_id.clone(), acceptance, issuer_id);
-        let schedule_msg =
-            SchedulePayment::from_debit_note(debit_note, allocation_id, amount_to_pay);
+        //let schedule_msg =
+        //    SchedulePayment::from_debit_note(debit_note, allocation_id, amount_to_pay);
         match async move {
             log::trace!(
                 "Sending AcceptDebitNote [{}] to [{}]",
@@ -350,12 +350,15 @@ async fn accept_debit_note(
                 .service(PUBLIC_SERVICE)
                 .call(accept_msg)
                 .await??;
-            if let Some(msg) = schedule_msg {
-                log::trace!("Calling SchedulePayment [{}] locally", debit_note_id);
-                bus::service(LOCAL_SERVICE).send(msg).await??;
-            }
+            // if let Some(msg) = schedule_msg {
+            //     log::trace!("Calling SchedulePayment [{}] locally", debit_note_id);
+            //     bus::service(LOCAL_SERVICE).send(msg).await??;
+            // }
             log::trace!("Accepting Debit Note [{}] in DB", debit_note_id);
-            dao.accept(debit_note_id.clone(), node_id).await?;
+            // dao.accept(debit_note_id.clone(), node_id).await?;
+            db.as_dao::<DebitNoteDao>()
+                .accept(debit_note_id.clone(), node_id)
+                .await?;
             log::trace!("Debit Note accepted successfully for [{}]", debit_note_id);
             Ok(())
         }

--- a/core/payment/src/api/debit_notes.rs
+++ b/core/payment/src/api/debit_notes.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 // Workspace uses
 use metrics::{counter, timing};
 use ya_client_model::payment::*;
-// use ya_core_model::payment::local::{SchedulePayment, BUS_ID as LOCAL_SERVICE};
+use ya_core_model::payment::local::{BatchPayment, SchedulePayment, BUS_ID as LOCAL_SERVICE};
 use ya_core_model::payment::public::{
     AcceptDebitNote, AcceptRejectError, SendDebitNote, SendError, BUS_ID as PUBLIC_SERVICE,
 };
@@ -17,7 +17,7 @@ use ya_persistence::executor::DbExecutor;
 use ya_persistence::types::Role;
 use ya_service_api_web::middleware::Identity;
 use ya_service_bus::timeout::IntoTimeoutFuture;
-// use ya_service_bus::{typed as bus, RpcEndpoint};
+use ya_service_bus::{typed as bus, RpcEndpoint};
 
 // Local uses
 use crate::dao::*;
@@ -337,8 +337,9 @@ async fn accept_debit_note(
     let result = async move {
         let issuer_id = debit_note.issuer_id;
         let accept_msg = AcceptDebitNote::new(debit_note_id.clone(), acceptance, issuer_id);
-        //let schedule_msg =
-        //    SchedulePayment::from_debit_note(debit_note, allocation_id, amount_to_pay);
+        let schedule_msg =
+            SchedulePayment::from_debit_note(debit_note, allocation_id, amount_to_pay);
+
         match async move {
             log::trace!(
                 "Sending AcceptDebitNote [{}] to [{}]",
@@ -350,12 +351,13 @@ async fn accept_debit_note(
                 .service(PUBLIC_SERVICE)
                 .call(accept_msg)
                 .await??;
-            // if let Some(msg) = schedule_msg {
-            //     log::trace!("Calling SchedulePayment [{}] locally", debit_note_id);
-            //     bus::service(LOCAL_SERVICE).send(msg).await??;
-            // }
+            if let Some(msg) = schedule_msg {
+                log::trace!("Calling BatchPayment [{}] locally", debit_note_id);
+                bus::service(LOCAL_SERVICE)
+                    .send(BatchPayment(msg))
+                    .await??;
+            }
             log::trace!("Accepting Debit Note [{}] in DB", debit_note_id);
-            // dao.accept(debit_note_id.clone(), node_id).await?;
             db.as_dao::<DebitNoteDao>()
                 .accept(debit_note_id.clone(), node_id)
                 .await?;

--- a/core/payment/src/api/debit_notes.rs
+++ b/core/payment/src/api/debit_notes.rs
@@ -351,17 +351,18 @@ async fn accept_debit_note(
                 .service(PUBLIC_SERVICE)
                 .call(accept_msg)
                 .await??;
+            log::trace!("Accepting Debit Note [{}] in DB", debit_note_id);
+            db.as_dao::<DebitNoteDao>()
+                .accept(debit_note_id.clone(), node_id)
+                .await?;
+            log::trace!("Debit Note accepted successfully for [{}]", debit_note_id);
+
             if let Some(msg) = schedule_msg {
                 log::trace!("Calling BatchPayment [{}] locally", debit_note_id);
                 bus::service(LOCAL_SERVICE)
                     .send(BatchPayment(msg))
                     .await??;
             }
-            log::trace!("Accepting Debit Note [{}] in DB", debit_note_id);
-            db.as_dao::<DebitNoteDao>()
-                .accept(debit_note_id.clone(), node_id)
-                .await?;
-            log::trace!("Debit Note accepted successfully for [{}]", debit_note_id);
             Ok(())
         }
         .timeout(Some(timeout))

--- a/core/payment/src/api/invoices.rs
+++ b/core/payment/src/api/invoices.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 // Workspace uses
 use metrics::{counter, timing};
 use ya_client_model::payment::*;
-use ya_core_model::payment::local::{SchedulePayment, BUS_ID as LOCAL_SERVICE};
+// use ya_core_model::payment::local::{SchedulePayment, BUS_ID as LOCAL_SERVICE};
 use ya_core_model::payment::public::{
     AcceptInvoice, AcceptRejectError, CancelError, CancelInvoice, SendError, SendInvoice,
     BUS_ID as PUBLIC_SERVICE,
@@ -18,7 +18,7 @@ use ya_persistence::executor::DbExecutor;
 use ya_persistence::types::Role;
 use ya_service_api_web::middleware::Identity;
 use ya_service_bus::timeout::IntoTimeoutFuture;
-use ya_service_bus::{typed as bus, RpcEndpoint};
+// use ya_service_bus::{typed as bus, RpcEndpoint};
 
 // Local uses
 use crate::dao::*;
@@ -403,7 +403,7 @@ async fn accept_invoice(
     let result = async move {
         let issuer_id = invoice.issuer_id;
         let accept_msg = AcceptInvoice::new(invoice_id.clone(), acceptance, issuer_id);
-        let schedule_msg = SchedulePayment::from_invoice(invoice, allocation_id, amount_to_pay);
+        //let schedule_msg = SchedulePayment::from_invoice(invoice, allocation_id, amount_to_pay);
         match async move {
             log::debug!("Sending AcceptInvoice [{}] to [{}]", invoice_id, issuer_id);
             ya_net::from(node_id)
@@ -411,12 +411,18 @@ async fn accept_invoice(
                 .service(PUBLIC_SERVICE)
                 .call(accept_msg)
                 .await??;
-            if let Some(msg) = schedule_msg {
-                log::trace!("Calling SchedulePayment [{}] locally", invoice_id);
-                bus::service(LOCAL_SERVICE).send(msg).await??;
-            }
+            // if let Some(msg) = schedule_msg {
+            //     log::trace!("Calling SchedulePayment [{}] locally", invoice_id);
+            //     bus::service(LOCAL_SERVICE).send(msg).await??;
+            // }
             log::trace!("Accepting Invoice [{}] in DB", invoice_id);
-            dao.accept(invoice_id.clone(), node_id).await?;
+            // dao.accept(invoice_id.clone(), node_id).await?;
+            db.as_dao::<AllocationDao>()
+                .spend_from_allocation(allocation_id, amount_to_pay)
+                .await?;
+            db.as_dao::<InvoiceDao>()
+                .accept(invoice_id.clone(), node_id)
+                .await?;
             log::trace!("Invoice accepted successfully for [{}]", invoice_id);
             Ok(())
         }

--- a/core/payment/src/batch.rs
+++ b/core/payment/src/batch.rs
@@ -1,0 +1,259 @@
+use actix_rt::Arbiter;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use chrono::{DateTime, Duration, Utc};
+use futures::future::{AbortHandle, Abortable, LocalBoxFuture};
+use futures::FutureExt;
+use tokio::sync::RwLock;
+use ya_client_model::NodeId;
+
+use ya_core_model::driver;
+use ya_core_model::driver::{AccountMode, BatchMode};
+use ya_core_model::payment::local as pay;
+use ya_persistence::executor::DbExecutor;
+use ya_service_bus::typed as bus;
+
+use crate::dao::BatchDao;
+use crate::error::processor::SchedulePaymentError;
+use crate::models::batch::{DbBatchOrder, DbBatchOrderItem};
+use crate::processor::AccountDetails;
+
+lazy_static::lazy_static! {
+    /// Maximum time required to process the payment
+    static ref DEFAULT_PAYMENT_PROCESSING_TIME: Duration = Duration::seconds(60);
+}
+
+#[derive(Clone)]
+pub struct BatchScheduler {
+    db: DbExecutor,
+    inner: Arc<RwLock<Inner>>,
+}
+
+struct Inner {
+    handle: Option<AbortHandle>,
+    scheduled_at: DateTime<Utc>,
+    since: DateTime<Utc>,
+    history: HashSet<(NodeId, String, String)>,
+}
+
+impl Default for Inner {
+    fn default() -> Self {
+        Self {
+            handle: None,
+            scheduled_at: Utc::now() + chrono::Duration::days(3650),
+            since: DateTime::<Utc>::from(SystemTime::UNIX_EPOCH),
+            history: Default::default(),
+        }
+    }
+}
+
+impl BatchScheduler {
+    pub fn new(db: DbExecutor) -> Self {
+        let inner = Default::default();
+        Self { db, inner }
+    }
+
+    pub async fn add_payment(
+        &self,
+        account: AccountDetails,
+        msg: pay::SchedulePayment,
+    ) -> Result<(), SchedulePaymentError> {
+        let now = Utc::now();
+        let since;
+        {
+            let mut inner = self.inner.write().await;
+            inner.history.insert((
+                msg.payer_id,
+                msg.payer_addr.clone(),
+                msg.payment_platform.clone(),
+            ));
+            since = inner.since;
+        };
+
+        let mut at = msg.due_date - processing_time_needed(&account);
+        at = if at <= now { now } else { at };
+        let mut due_date = msg.due_date;
+        due_date = if due_date <= now { now } else { due_date };
+
+        let latest = collect_payments(
+            self.db.clone(),
+            msg.payer_id,
+            msg.payer_addr,
+            msg.payment_platform,
+            since,
+            now,
+        )
+        .await
+        .map_err(|e| SchedulePaymentError::Batch(e.to_string()))?;
+
+        let mut inner = self.inner.write().await;
+        inner.since = latest;
+
+        if inner.scheduled_at > at || inner.scheduled_at < now {
+            let (h, reg) = AbortHandle::new_pair();
+            inner.handle.take().map(|h| h.abort());
+            inner.handle.replace(h);
+            inner.scheduled_at = at;
+
+            log::info!("Batch payment is scheduled at {}", at);
+
+            let send_at = send_payments_at(self.db.clone(), at, Some(due_date));
+            Arbiter::spawn(Abortable::new(send_at, reg).then(|r| async move { () }));
+        } else {
+            log::debug!("Batch payment schedule unchanged: {}", inner.scheduled_at);
+        }
+
+        Ok(())
+    }
+
+    pub fn shutdown<'a>(&self) -> LocalBoxFuture<'a, ()> {
+        let db = self.db.clone();
+        let inner = self.inner.clone();
+        async move {
+            let now = Utc::now();
+            let (since, history) = {
+                let mut inner = inner.write().await;
+                inner.handle.take().map(|h| h.abort());
+                (
+                    inner.since,
+                    std::mem::replace(&mut inner.history, Default::default()),
+                )
+            };
+
+            for (id, addr, platform) in history {
+                if let Err(e) = collect_payments(db.clone(), id, addr, platform, since, now).await {
+                    log::warn!("Unable to collect payments: {}", e);
+                }
+            }
+
+            log::info!("Executing all remaining batch payments");
+            send_payments_at(db, Utc::now(), None).await;
+        }
+        .boxed_local()
+    }
+}
+
+async fn collect_payments(
+    db: DbExecutor,
+    payer_id: NodeId,
+    payer_addr: String,
+    payment_platform: String,
+    since: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> Result<DateTime<Utc>, SchedulePaymentError> {
+    log::debug!(
+        "Collecting batch for {} ({}) since {}",
+        payer_addr,
+        payment_platform,
+        since
+    );
+
+    let now = Utc::now();
+    let (_, date) = db
+        .as_dao::<BatchDao>()
+        .batch(payer_id, payer_addr, payment_platform, since, now)
+        .await?;
+
+    Ok(date)
+}
+
+async fn send_payments_at(db: DbExecutor, at: DateTime<Utc>, due_date: Option<DateTime<Utc>>) {
+    let mut delay = std::time::Duration::from_secs(0);
+    let now = Utc::now();
+
+    if at > now {
+        if let Ok(d) = (at - now).to_std() {
+            delay = d;
+        }
+    }
+
+    log::debug!("Executing next batch payment in {}s", delay.as_secs());
+
+    tokio::time::delay_for(delay).await;
+    if let Err(e) = send_payments(db, due_date).await {
+        log::warn!("Unable to send batch payments: {}", e);
+    }
+}
+
+async fn send_payments(
+    db: DbExecutor,
+    due_date: Option<DateTime<Utc>>,
+) -> Result<(), SchedulePaymentError> {
+    let entries = db
+        .as_dao::<BatchDao>()
+        .get_unsent_batch_orders(due_date)
+        .await?;
+
+    if entries.is_empty() {
+        log::info!("No batch payments to send");
+        return Ok(());
+    }
+
+    log::info!("Sending {} batch payment(s)", entries.len());
+
+    for (item, order) in entries {
+        let amount = order.total_amount.unwrap_or(0.);
+        let payee = item.payee_addr.clone();
+        let platform = order.platform.clone();
+
+        if let Err(err) = send_payment(db.clone(), item, order).await {
+            log::warn!(
+                "Batch payment of {} to {} ({}) failed: {}",
+                amount,
+                payee,
+                platform,
+                err
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn send_payment(
+    db: DbExecutor,
+    item: DbBatchOrderItem,
+    order: DbBatchOrder,
+) -> Result<(), SchedulePaymentError> {
+    let account = bus::service(pay::BUS_ID)
+        .call(pay::GetAccount {
+            platform: order.platform.clone(),
+            address: order.payer_addr.clone(),
+            mode: AccountMode::SEND,
+        })
+        .await
+        .map_err(|_| SchedulePaymentError::Batch("payment service is not available".to_string()))?
+        .map_err(|e| SchedulePaymentError::Batch(e.to_string()))?
+        .ok_or_else(|| SchedulePaymentError::Batch("payment account not found".to_string()))?;
+
+    let bus_id = driver::driver_bus_id(&account.driver);
+    let driver_order_id = bus::service(&bus_id)
+        .call(driver::SchedulePayment::new(
+            item.amount.0,
+            order.payer_addr.clone(),
+            item.payee_addr.clone(),
+            order.platform.clone(),
+            chrono::Utc::now(),
+        ))
+        .await??;
+
+    db.as_dao::<BatchDao>()
+        .batch_order_item_send(order.id, item.payee_addr, driver_order_id)
+        .await?;
+    Ok(())
+}
+
+fn processing_time_needed(account: &AccountDetails) -> chrono::Duration {
+    account
+        .batch
+        .as_ref()
+        .map(|b| match b {
+            BatchMode::Auto {
+                max_processing_time,
+            } => Duration::seconds(*max_processing_time as i64),
+            _ => *DEFAULT_PAYMENT_PROCESSING_TIME,
+        })
+        .unwrap_or(*DEFAULT_PAYMENT_PROCESSING_TIME)
+}

--- a/core/payment/src/dao.rs
+++ b/core/payment/src/dao.rs
@@ -1,6 +1,7 @@
 mod activity;
 mod agreement;
 mod allocation;
+mod batch;
 mod debit_note;
 mod debit_note_event;
 mod invoice;
@@ -11,6 +12,7 @@ mod payment;
 pub use self::activity::ActivityDao;
 pub use self::agreement::AgreementDao;
 pub use self::allocation::AllocationDao;
+pub use self::batch::BatchDao;
 pub use self::debit_note::DebitNoteDao;
 pub use self::debit_note_event::DebitNoteEventDao;
 pub use self::invoice::InvoiceDao;

--- a/core/payment/src/dao/activity.rs
+++ b/core/payment/src/dao/activity.rs
@@ -81,6 +81,7 @@ pub fn increase_amount_paid(
     conn: &ConnType,
 ) -> DbResult<()> {
     assert!(amount > &BigDecimal::zero().into()); // TODO: Remove when payment service is production-ready.
+
     let (total_amount_paid, agreement_id, role): (BigDecimalField, String, Role) =
         dsl::pay_activity
             .find((activity_id, owner_id))
@@ -114,6 +115,8 @@ pub fn increase_amount_paid(
             )?;
         }
     }
+
+    agreement::increase_amount_paid(&agreement_id, owner_id, amount, conn)?;
 
     Ok(())
 }

--- a/core/payment/src/dao/agreement.rs
+++ b/core/payment/src/dao/agreement.rs
@@ -5,10 +5,11 @@ use crate::schema::pay_activity::dsl as activity_dsl;
 use crate::schema::pay_agreement::dsl;
 use crate::schema::pay_invoice::dsl as invoice_dsl;
 use bigdecimal::{BigDecimal, Zero};
-use chrono::NaiveDateTime;
+use chrono::{DateTime, Utc};
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};
+use std::collections::HashMap;
 use ya_client_model::market::Agreement;
-use ya_client_model::payment::{DocumentStatus, InvoiceEventType};
+use ya_client_model::payment::{DocumentStatus, Invoice, InvoiceEventType};
 use ya_client_model::NodeId;
 use ya_core_model::payment::local::{StatValue, StatusNotes};
 use ya_persistence::executor::{
@@ -27,8 +28,12 @@ pub fn increase_amount_due(
         .find((agreement_id, owner_id))
         .first(conn)?;
     let total_amount_due = &agreement.total_amount_due + amount;
+    let updated_ts = chrono::Utc::now().naive_utc();
     diesel::update(&agreement)
-        .set(dsl::total_amount_due.eq(total_amount_due))
+        .set((
+            dsl::total_amount_due.eq(total_amount_due),
+            dsl::updated_ts.eq(updated_ts),
+        ))
         .execute(conn)?;
     Ok(())
 }
@@ -45,8 +50,12 @@ pub fn set_amount_due(
     if total_amount_due < &agreement.total_amount_due {
         return Err(DbError::Query(format!("Requested amount for agreement cannot be lowered. Current amount requested: {} Amount on invoice: {}", agreement.total_amount_due, total_amount_due)));
     }
+    let updated_ts = chrono::Utc::now().naive_utc();
     diesel::update(&agreement)
-        .set(dsl::total_amount_due.eq(total_amount_due))
+        .set((
+            dsl::total_amount_due.eq(total_amount_due),
+            dsl::updated_ts.eq(updated_ts),
+        ))
         .execute(conn)?;
     Ok(())
 }
@@ -66,8 +75,12 @@ pub fn compute_amount_due(
         .select(activity_dsl::total_amount_due)
         .load(conn)?;
     let total_amount_due: BigDecimalField = activity_amounts.sum().into();
+    let updated_ts = chrono::Utc::now().naive_utc();
     diesel::update(&agreement)
-        .set(dsl::total_amount_due.eq(total_amount_due))
+        .set((
+            dsl::total_amount_due.eq(total_amount_due),
+            dsl::updated_ts.eq(updated_ts),
+        ))
         .execute(conn)?;
     Ok(())
 }
@@ -83,8 +96,12 @@ pub fn increase_amount_accepted(
         .find((agreement_id, owner_id))
         .first(conn)?;
     let total_amount_accepted = &agreement.total_amount_accepted + amount;
+    let updated_ts = chrono::Utc::now().naive_utc();
     diesel::update(&agreement)
-        .set(dsl::total_amount_accepted.eq(total_amount_accepted))
+        .set((
+            dsl::total_amount_accepted.eq(total_amount_accepted),
+            dsl::updated_ts.eq(updated_ts),
+        ))
         .execute(conn)?;
     Ok(())
 }
@@ -101,8 +118,12 @@ pub fn increase_amount_scheduled(
         .first(conn)?;
     let total_amount_scheduled: BigDecimalField =
         (&agreement.total_amount_scheduled.0 + amount).into();
+    let updated_ts = chrono::Utc::now().naive_utc();
     diesel::update(&agreement)
-        .set(dsl::total_amount_scheduled.eq(total_amount_scheduled))
+        .set((
+            dsl::total_amount_scheduled.eq(total_amount_scheduled),
+            dsl::updated_ts.eq(updated_ts),
+        ))
         .execute(conn)?;
     Ok(())
 }
@@ -117,8 +138,12 @@ pub fn set_amount_accepted(
         .find((agreement_id, owner_id))
         .first(conn)?;
     assert!(total_amount_accepted >= &agreement.total_amount_accepted); // TODO: Remove when payment service is production-ready.
+    let updated_ts = chrono::Utc::now().naive_utc();
     diesel::update(&agreement)
-        .set(dsl::total_amount_accepted.eq(total_amount_accepted))
+        .set((
+            dsl::total_amount_accepted.eq(total_amount_accepted),
+            dsl::updated_ts.eq(updated_ts),
+        ))
         .execute(conn)?;
     Ok(())
 }
@@ -135,8 +160,12 @@ pub fn increase_amount_paid(
         .select(dsl::total_amount_paid)
         .first(conn)?;
     let total_amount_paid = &total_amount_paid + amount;
+    let updated_ts = chrono::Utc::now().naive_utc();
     diesel::update(dsl::pay_agreement.find((agreement_id, owner_id)))
-        .set(dsl::total_amount_paid.eq(&total_amount_paid))
+        .set((
+            dsl::total_amount_paid.eq(&total_amount_paid),
+            dsl::updated_ts.eq(updated_ts),
+        ))
         .execute(conn)?;
 
     let invoice_query: Option<(String, Role)> = invoice_dsl::pay_invoice
@@ -238,23 +267,28 @@ impl<'a> AgreementDao<'a> {
         &self,
         platform: String,
         payee_addr: String,
-        after_timestamp: NaiveDateTime,
+        since: Option<DateTime<Utc>>,
     ) -> DbResult<StatusNotes> {
         readonly_transaction(self.pool, move |conn| {
-            let agreements: Vec<ReadObj> = dsl::pay_agreement
+            let last_days = chrono::Utc::now() - chrono::Duration::days(1);
+            let invoices: Vec<Invoice> =
+                crate::dao::invoice::get_for_payee(conn, &payee_addr, Some(last_days.naive_utc()))?;
+
+            let query = dsl::pay_agreement
                 .filter(dsl::role.eq(Role::Provider))
                 .filter(dsl::payment_platform.eq(platform))
-                .filter(dsl::payee_addr.eq(payee_addr))
-                .filter(diesel::dsl::exists(
-                    invoice_dsl::pay_invoice
-                        .filter(invoice_dsl::agreement_id.eq(dsl::id))
-                        .filter(invoice_dsl::timestamp.gt(after_timestamp))
-                        .limit(1)
-                        .select(invoice_dsl::id),
-                ))
-                .select(crate::schema::pay_agreement::all_columns)
-                .get_results(conn)?;
-            Ok(make_summary(agreements))
+                .filter(dsl::payee_addr.eq(payee_addr));
+
+            let agreements: Vec<crate::models::agreement::ReadObj> = if let Some(last_days) = since
+            {
+                query
+                    .filter(dsl::created_ts.ge(last_days.naive_utc()))
+                    .get_results(conn)?
+            } else {
+                query.get_results(conn)?
+            };
+
+            Ok(make_summary2(agreements, invoices))
         })
         .await
     }
@@ -264,22 +298,20 @@ impl<'a> AgreementDao<'a> {
         &self,
         platform: String,
         payer_addr: String,
-        after_timestamp: NaiveDateTime,
+        since: Option<DateTime<Utc>>,
     ) -> DbResult<StatusNotes> {
         readonly_transaction(self.pool, move |conn| {
-            let agreements: Vec<ReadObj> = dsl::pay_agreement
+            let query = dsl::pay_agreement
                 .filter(dsl::role.eq(Role::Requestor))
                 .filter(dsl::payment_platform.eq(platform))
-                .filter(dsl::payer_addr.eq(payer_addr))
-                .filter(diesel::dsl::exists(
-                    invoice_dsl::pay_invoice
-                        .filter(invoice_dsl::agreement_id.eq(dsl::id))
-                        .filter(invoice_dsl::timestamp.gt(after_timestamp))
-                        .limit(1)
-                        .select(invoice_dsl::id),
-                ))
-                .select(crate::schema::pay_agreement::all_columns)
-                .get_results(conn)?;
+                .filter(dsl::payer_addr.eq(payer_addr));
+            let agreements: Vec<ReadObj> = if let Some(since) = since {
+                query
+                    .filter(dsl::created_ts.ge(since.naive_utc()))
+                    .get_results(conn)?
+            } else {
+                query.get_results(conn)?
+            };
             Ok(make_summary(agreements))
         })
         .await
@@ -293,6 +325,63 @@ fn make_summary(agreements: Vec<ReadObj>) -> StatusNotes {
             requested: StatValue::new(agreement.total_amount_due),
             accepted: StatValue::new(agreement.total_amount_accepted),
             confirmed: StatValue::new(agreement.total_amount_paid),
+            overdue: None,
+        })
+        .sum()
+}
+
+fn make_summary2(
+    agreements: Vec<crate::models::agreement::ReadObj>,
+    invoices: Vec<Invoice>,
+) -> StatusNotes {
+    let invoice_map: HashMap<String, Invoice> = invoices
+        .into_iter()
+        .map(|invoice| (invoice.agreement_id.clone(), invoice))
+        .collect();
+
+    fn is_overdue(
+        agreement: &crate::models::agreement::ReadObj,
+        invoice: Option<&Invoice>,
+    ) -> bool {
+        if let Some(invoice) = invoice {
+            match invoice.status {
+                DocumentStatus::Settled => false,
+                DocumentStatus::Accepted => {
+                    chrono::Utc::now() - invoice.payment_due_date > chrono::Duration::hours(1)
+                }
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
+
+    agreements
+        .into_iter()
+        .map(|agreement| {
+            let is_overdue = is_overdue(&agreement, invoice_map.get(&agreement.id));
+            let confirmed = agreement.total_amount_paid;
+            let requested = if is_overdue {
+                confirmed.clone()
+            } else {
+                agreement.total_amount_due
+            };
+            let accepted = if is_overdue {
+                confirmed.clone()
+            } else {
+                agreement.total_amount_accepted.clone()
+            };
+            let overdue = if is_overdue {
+                agreement.total_amount_accepted
+            } else {
+                Default::default()
+            };
+            StatusNotes {
+                requested: StatValue::new(requested),
+                accepted: StatValue::new(accepted),
+                confirmed: StatValue::new(confirmed),
+                overdue: Some(StatValue::new(overdue)),
+            }
         })
         .sum()
 }

--- a/core/payment/src/dao/allocation.rs
+++ b/core/payment/src/dao/allocation.rs
@@ -63,6 +63,17 @@ impl<'c> AllocationDao<'c> {
         .await
     }
 
+    pub async fn spend_from_allocation(
+        &self,
+        allocation_id: String,
+        amount: BigDecimal,
+    ) -> DbResult<()> {
+        do_with_transaction(self.pool, move |conn| {
+            spend_from_allocation(&allocation_id, &amount.into(), conn)
+        })
+        .await
+    }
+
     pub async fn get(
         &self,
         allocation_id: String,

--- a/core/payment/src/dao/batch.rs
+++ b/core/payment/src/dao/batch.rs
@@ -1,0 +1,467 @@
+use std::collections::HashMap;
+
+use bigdecimal::{BigDecimal, ToPrimitive};
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use diesel::sql_types::{Text, Timestamp};
+
+use uuid::Uuid;
+use ya_client_model::payment::DocumentStatus;
+
+use ya_core_model::NodeId;
+use ya_persistence::executor::{
+    do_with_transaction, readonly_transaction, AsDao, ConnType, PoolType,
+};
+use ya_persistence::types::BigDecimalField;
+
+use crate::error::{DbError, DbResult};
+use crate::models::batch::*;
+use crate::schema::pay_batch_order_item::dsl as oidsl;
+
+pub struct BatchDao<'c> {
+    pool: &'c PoolType,
+}
+
+impl<'c> AsDao<'c> for BatchDao<'c> {
+    fn as_dao(pool: &'c PoolType) -> Self {
+        Self { pool }
+    }
+}
+
+pub fn resolve_invoices(
+    conn: &ConnType,
+    owner_id: NodeId,
+    payer_addr: &str,
+    platform: &str,
+    since: DateTime<Utc>,
+) -> DbResult<Option<String>> {
+    use crate::schema::pay_agreement::dsl as pa;
+    use crate::schema::pay_invoice::dsl as iv;
+    use std::collections::hash_map;
+
+    let invoices = iv::pay_invoice
+        .inner_join(
+            pa::pay_agreement.on(pa::id
+                .eq(iv::agreement_id)
+                .and(pa::owner_id.eq(iv::owner_id))),
+        )
+        .filter(iv::owner_id.eq(owner_id))
+        .filter(iv::role.eq("R"))
+        .filter(pa::payer_addr.eq(payer_addr))
+        .filter(pa::payment_platform.eq(platform))
+        .filter(iv::timestamp.gt(since.naive_utc()))
+        .filter(iv::status.eq("ACCEPTED"))
+        .select((
+            pa::id,
+            pa::peer_id,
+            pa::payee_addr,
+            pa::total_amount_accepted,
+            pa::total_amount_scheduled,
+            iv::id,
+            iv::amount,
+        ))
+        .load::<(
+            String,
+            NodeId,
+            String,
+            BigDecimalField,
+            BigDecimalField,
+            String,
+            BigDecimalField,
+        )>(conn)?;
+    log::info!("found [{}] invoices", invoices.len());
+
+    let mut total_amount = BigDecimal::default();
+    let zero = BigDecimal::from(0u32);
+    let mut payments = HashMap::<String, BatchPayment>::new();
+    for (
+        agreement_id,
+        peer_id,
+        payee_addr,
+        total_amount_accepted,
+        total_amount_scheduled,
+        invoice_id,
+        invoice_amount,
+    ) in invoices
+    {
+        let amount_to_pay = total_amount_accepted.0 - total_amount_scheduled.0;
+        log::info!(
+            "[{}] to pay {} - {}",
+            invoice_id,
+            amount_to_pay,
+            agreement_id
+        );
+        if amount_to_pay <= zero {
+            super::invoice::update_status(&invoice_id, &owner_id, &DocumentStatus::Settled, conn)?;
+            continue;
+        }
+
+        total_amount += &amount_to_pay;
+
+        let obligation = BatchPaymentObligation::Invoice {
+            id: invoice_id,
+            amount: amount_to_pay.clone(),
+            agreement_id: agreement_id.clone(),
+        };
+
+        match payments.entry(payee_addr.clone()) {
+            hash_map::Entry::Occupied(mut e) => {
+                let payment = e.get_mut();
+                payment.amount += &amount_to_pay;
+                match payment.peer_obligation.entry(peer_id) {
+                    hash_map::Entry::Occupied(mut e) => e.get_mut().push(obligation),
+                    hash_map::Entry::Vacant(e) => {
+                        e.insert(vec![obligation]);
+                    }
+                }
+            }
+            hash_map::Entry::Vacant(e) => {
+                let mut peer_obligation = HashMap::new();
+                peer_obligation.insert(peer_id, vec![obligation]);
+                let amount = amount_to_pay.clone();
+                e.insert(BatchPayment {
+                    amount,
+                    peer_obligation,
+                });
+            }
+        }
+        log::debug!(
+            "increase_amount_scheduled agreement_id={} by {}",
+            agreement_id,
+            amount_to_pay
+        );
+        super::agreement::increase_amount_scheduled(
+            &agreement_id,
+            &owner_id,
+            &amount_to_pay,
+            conn,
+        )?;
+    }
+    {
+        table! {
+            sql_activity (id, owner_id) {
+                id -> Text,
+                owner_id -> Text,
+                role -> Text,
+                peer_id -> Text,
+                payee_addr -> Text,
+                agreement_id -> Text,
+                total_amount_due -> Text,
+                total_amount_accepted -> Text,
+                total_amount_scheduled -> Text,
+                total_amount_paid -> Text,
+            }
+        }
+
+        #[derive(QueryableByName)]
+        #[table_name = "sql_activity"]
+        struct Activity {
+            id: String,
+            peer_id: NodeId,
+            payee_addr: String,
+            total_amount_accepted: BigDecimalField,
+            total_amount_scheduled: BigDecimalField,
+            agreement_id: String,
+        }
+
+        let v : Vec<Activity> = diesel::sql_query(r#"
+                SELECT a.id, pa.peer_id, pa.payee_addr, a.total_amount_accepted, a.total_amount_scheduled, pa.id agreement_id
+                FROM pay_activity a join pay_agreement pa on a.owner_id = pa.owner_id and a.agreement_id = pa.id and a.role = pa.role
+                where a.role='R' and a.total_amount_accepted > 0
+                and cast(a.total_amount_scheduled as float) < cast(a.total_amount_accepted as float)
+                and not exists (select 1 from pay_invoice where agreement_id = a.agreement_id and owner_id = a.owner_id and role = 'R')
+                and pa.updated_ts > ? and pa.payment_platform = ? and pa.owner_id = ?
+            "#)
+            .bind::<Timestamp, _>(since.naive_utc())
+            .bind::<Text, _>(&platform)
+            .bind::<Text, _>(owner_id)
+            .load::<Activity>(conn)?;
+
+        log::info!("{} activites found", v.len());
+        for a in v {
+            let amount_to_pay = a.total_amount_accepted.0 - a.total_amount_scheduled.0;
+            if amount_to_pay < zero {
+                continue;
+            }
+            total_amount += &amount_to_pay;
+            super::activity::increase_amount_scheduled(&a.id, &owner_id, &amount_to_pay, conn)?;
+
+            let obligation = BatchPaymentObligation::DebitNote {
+                amount: amount_to_pay.clone(),
+                agreement_id: a.agreement_id.clone(),
+                activity_id: a.id,
+            };
+
+            match payments.entry(a.payee_addr.clone()) {
+                hash_map::Entry::Occupied(mut e) => {
+                    let payment = e.get_mut();
+                    payment.amount += &amount_to_pay;
+                    match payment.peer_obligation.entry(a.peer_id) {
+                        hash_map::Entry::Occupied(mut e) => e.get_mut().push(obligation),
+                        hash_map::Entry::Vacant(e) => {
+                            e.insert(vec![obligation]);
+                        }
+                    }
+                }
+                hash_map::Entry::Vacant(e) => {
+                    let mut peer_obligation = HashMap::new();
+                    peer_obligation.insert(a.peer_id, vec![obligation]);
+                    let amount = amount_to_pay.clone();
+                    e.insert(BatchPayment {
+                        amount,
+                        peer_obligation,
+                    });
+                }
+            }
+        }
+    }
+
+    if total_amount == zero {
+        return Ok(None);
+    }
+
+    let order_id = Uuid::new_v4().to_string();
+    {
+        use crate::schema::pay_batch_order::dsl as odsl;
+
+        let _ = diesel::insert_into(odsl::pay_batch_order)
+            .values((
+                odsl::id.eq(&order_id),
+                odsl::owner_id.eq(owner_id),
+                odsl::payer_addr.eq(&payer_addr),
+                odsl::platform.eq(&platform),
+                odsl::total_amount.eq(total_amount.to_f32()),
+            ))
+            .execute(conn)?;
+    }
+    {
+        for (payee_addr, payment) in payments {
+            diesel::insert_into(oidsl::pay_batch_order_item)
+                .values((
+                    oidsl::id.eq(&order_id),
+                    oidsl::payee_addr.eq(&payee_addr),
+                    oidsl::amount.eq(BigDecimalField(payment.amount.clone())),
+                ))
+                .execute(conn)?;
+            for (payee_id, obligations) in payment.peer_obligation {
+                let json = serde_json::to_string(&obligations)?;
+                use crate::schema::pay_batch_order_item_payment::dsl;
+
+                diesel::insert_into(dsl::pay_batch_order_item_payment)
+                    .values((
+                        dsl::id.eq(&order_id),
+                        dsl::payee_addr.eq(&payee_addr),
+                        dsl::payee_id.eq(payee_id),
+                        dsl::json.eq(json),
+                    ))
+                    .execute(conn)?;
+            }
+        }
+    }
+    Ok(Some(order_id))
+}
+
+pub fn get_batch_orders(
+    conn: &ConnType,
+    ids: &[String],
+    platform: &str,
+) -> DbResult<Vec<DbBatchOrderItem>> {
+    let batch_orders: Vec<DbBatchOrderItem> = oidsl::pay_batch_order_item
+        .filter(oidsl::driver_order_id.eq_any(ids))
+        .load(conn)?;
+
+    Ok(batch_orders)
+}
+
+impl<'c> BatchDao<'c> {
+    pub async fn resolve(
+        &self,
+        owner_id: NodeId,
+        payer_addr: String,
+        platform: String,
+        since: DateTime<Utc>,
+    ) -> DbResult<Option<String>> {
+        do_with_transaction(self.pool, move |conn| {
+            resolve_invoices(conn, owner_id, &payer_addr, &platform, since)
+        })
+        .await
+    }
+    pub async fn list_debit_notes(
+        &self,
+        owner_id: NodeId,
+        payment_platform: String,
+        since: DateTime<Utc>,
+    ) -> DbResult<Vec<(String, BigDecimalField, BigDecimalField)>> {
+        use crate::schema::pay_activity;
+
+        #[derive(QueryableByName)]
+        #[table_name = "pay_activity"]
+        struct Activity {
+            id: String,
+            total_amount_accepted: BigDecimalField,
+            total_amount_scheduled: BigDecimalField,
+        }
+
+        do_with_transaction(self.pool, move |conn| {
+            let v : Vec<Activity> = diesel::sql_query(r#"
+                SELECT a.id, a.total_amount_accepted, a.total_amount_scheduled
+                 FROM pay_activity a join pay_agreement pa on a.owner_id = pa.owner_id and a.agreement_id = pa.id and a.role = pa.role
+                where a.role='R' and a.total_amount_accepted > 0
+                and cast(a.total_amount_scheduled as float) < cast(a.total_amount_accepted as float)
+                and not exists (select 1 from pay_invoice where agreement_id = a.agreement_id and owner_id = a.owner_id and role = 'R')
+                and pa.updated_ts > ? and pa.payment_platform = ? and pa.owner_id = ?
+            "#)
+                .bind::<Timestamp, _>(since.naive_utc())
+                .bind::<Text, _>(&payment_platform)
+                .bind::<Text, _>(owner_id)
+                .load::<Activity>(conn)?;
+            Ok(v.into_iter().map(|a| (a.id, a.total_amount_accepted, a.total_amount_scheduled)).collect())
+        }).await
+    }
+
+    pub async fn get_batch_order(&self, order_id: String) -> DbResult<DbBatchOrder> {
+        readonly_transaction(self.pool, move |conn| {
+            use crate::schema::pay_batch_order::dsl as odsl;
+
+            Ok(odsl::pay_batch_order
+                .filter(odsl::id.eq(order_id))
+                .get_result(conn)?)
+        })
+        .await
+    }
+
+    pub async fn get_batch_order_payments(
+        &self,
+        order_id: String,
+        payee_addr: String,
+    ) -> DbResult<BatchPayment> {
+        readonly_transaction(self.pool, |conn| {
+            use crate::schema::pay_batch_order_item::dsl as di;
+            use crate::schema::pay_batch_order_item_payment::dsl as d;
+
+            let (amount,) = di::pay_batch_order_item
+                .filter(di::id.eq(&order_id).and(di::payee_addr.eq(&payee_addr)))
+                .select((di::amount,))
+                .get_result::<(BigDecimalField,)>(conn)?;
+
+            let mut peer_obligation = HashMap::<NodeId, Vec<BatchPaymentObligation>>::new();
+
+            for (payee_id, json) in d::pay_batch_order_item_payment
+                .filter(d::id.eq(order_id).and(d::payee_addr.eq(payee_addr)))
+                .select((d::payee_id, d::json))
+                .load::<(NodeId, String)>(conn)?
+            {
+                let obligations =
+                    serde_json::from_str(&json).map_err(|e| DbError::Integrity(e.to_string()))?;
+                peer_obligation.insert(payee_id, obligations);
+            }
+
+            Ok(BatchPayment {
+                amount: amount.0,
+                peer_obligation,
+            })
+        })
+        .await
+    }
+
+    pub async fn get_unsent_batch_items(
+        &self,
+        order_id: String,
+    ) -> DbResult<(DbBatchOrder, Vec<DbBatchOrderItem>)> {
+        readonly_transaction(self.pool, move |conn| {
+            use crate::schema::pay_batch_order::dsl as odsl;
+
+            let order: DbBatchOrder = odsl::pay_batch_order
+                .filter(odsl::id.eq(&order_id))
+                .get_result(conn)?;
+            let items: Vec<DbBatchOrderItem> = oidsl::pay_batch_order_item
+                .filter(oidsl::id.eq(&order_id))
+                .filter(oidsl::driver_order_id.is_null())
+                .filter(oidsl::paid.eq(false))
+                .load(conn)?;
+            Ok((order, items))
+        })
+        .await
+    }
+
+    pub async fn batch_order_item_send(
+        &self,
+        order_id: String,
+        payee_addr: String,
+        driver_order_id: String,
+    ) -> DbResult<usize> {
+        do_with_transaction(self.pool, |conn| {
+            Ok(diesel::update(oidsl::pay_batch_order_item)
+                .filter(oidsl::id.eq(order_id).and(oidsl::payee_addr.eq(payee_addr)))
+                .set(oidsl::driver_order_id.eq(driver_order_id))
+                .execute(conn)?)
+        })
+        .await
+    }
+
+    pub async fn batch_order_item_paid(
+        &self,
+        order_id: String,
+        payee_addr: String,
+        confirmation: Vec<u8>,
+    ) -> DbResult<usize> {
+        do_with_transaction(self.pool, move |conn| {
+            use crate::schema::pay_batch_order::dsl as odsl;
+            use crate::schema::pay_batch_order_item_payment::dsl as d;
+            let order: DbBatchOrder = odsl::pay_batch_order
+                .filter(odsl::id.eq(&order_id))
+                .get_result(conn)?;
+
+            let v = diesel::update(oidsl::pay_batch_order_item)
+                .filter(
+                    oidsl::id
+                        .eq(&order_id)
+                        .and(oidsl::payee_addr.eq(&payee_addr))
+                        .and(oidsl::paid.eq(false)),
+                )
+                .set(oidsl::paid.eq(true))
+                .execute(conn)?;
+            if v > 0 {
+                for (payee_id, json) in d::pay_batch_order_item_payment
+                    .filter(d::id.eq(&order_id).and(d::payee_addr.eq(&payee_addr)))
+                    .select((d::payee_id, d::json))
+                    .load::<(NodeId, String)>(conn)?
+                {
+                    let obligations: Vec<BatchPaymentObligation> = serde_json::from_str(&json)
+                        .map_err(|e| DbError::Integrity(e.to_string()))?;
+                    for obligation in obligations {
+                        match obligation {
+                            BatchPaymentObligation::Invoice {
+                                id,
+                                amount,
+                                agreement_id,
+                            } => {
+                                super::agreement::increase_amount_paid(
+                                    &agreement_id,
+                                    &order.owner_id,
+                                    &BigDecimalField(amount),
+                                    conn,
+                                )?;
+                            }
+                            BatchPaymentObligation::DebitNote {
+                                amount,
+                                agreement_id,
+                                activity_id,
+                            } => {
+                                super::activity::increase_amount_paid(
+                                    &activity_id,
+                                    &order.owner_id,
+                                    &BigDecimalField(amount),
+                                    conn,
+                                )?;
+                            }
+                        }
+                    }
+                }
+            }
+
+            Ok(v)
+        })
+        .await
+    }
+}

--- a/core/payment/src/dao/batch.rs
+++ b/core/payment/src/dao/batch.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use bigdecimal::{BigDecimal, ToPrimitive, Zero};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, TimeZone, Utc};
 use diesel::prelude::*;
 use diesel::sql_types::{Text, Timestamp};
 use uuid::Uuid;
@@ -15,7 +15,39 @@ use ya_persistence::types::BigDecimalField;
 
 use crate::error::{DbError, DbResult};
 use crate::models::batch::*;
+use crate::schema::pay_batch_order::dsl;
 use crate::schema::pay_batch_order_item::dsl as oidsl;
+use crate::schema::pay_batch_order_item_payment::dsl as pdsl;
+use crate::schema::pay_debit_note::dsl as dndsl;
+use crate::schema::pay_order::dsl as odsl;
+
+table! {
+    sql_activity (id, owner_id) {
+        id -> Text,
+        owner_id -> Text,
+        role -> Text,
+        peer_id -> Text,
+        payee_addr -> Text,
+        agreement_id -> Text,
+        total_amount_due -> Text,
+        total_amount_accepted -> Text,
+        total_amount_scheduled -> Text,
+        total_amount_paid -> Text,
+        updated_ts -> Nullable<Timestamp>,
+    }
+}
+
+#[derive(QueryableByName)]
+#[table_name = "sql_activity"]
+struct Activity {
+    id: String,
+    peer_id: NodeId,
+    payee_addr: String,
+    total_amount_accepted: BigDecimalField,
+    total_amount_scheduled: BigDecimalField,
+    agreement_id: String,
+    updated_ts: Option<NaiveDateTime>,
+}
 
 pub struct BatchDao<'c> {
     pool: &'c PoolType,
@@ -34,69 +66,208 @@ pub fn resolve_invoices(
     platform: &str,
     since: DateTime<Utc>,
 ) -> DbResult<Option<String>> {
-    let (payments, total_amount) =
-        resolve_new_payments(conn, owner_id, payer_addr, platform, since)?;
-
+    let (payments, total_amount, _) =
+        collect_pending_payments(conn, owner_id, payer_addr, platform, since)?;
     if total_amount.is_zero() {
         return Ok(None);
     }
-
-    let order_id = Uuid::new_v4().to_string();
-    {
-        use crate::schema::pay_batch_order::dsl as odsl;
-
-        let _ = diesel::insert_into(odsl::pay_batch_order)
-            .values((
-                odsl::id.eq(&order_id),
-                odsl::owner_id.eq(owner_id),
-                odsl::payer_addr.eq(&payer_addr),
-                odsl::platform.eq(&platform),
-                odsl::total_amount.eq(total_amount.to_f32()),
-            ))
-            .execute(conn)?;
-    }
-    {
-        for (payee_addr, payment) in payments {
-            diesel::insert_into(oidsl::pay_batch_order_item)
-                .values((
-                    oidsl::id.eq(&order_id),
-                    oidsl::payee_addr.eq(&payee_addr),
-                    oidsl::amount.eq(BigDecimalField(payment.amount.clone())),
-                ))
-                .execute(conn)?;
-
-            for (payee_id, obligations) in payment.peer_obligation {
-                for obligation in obligations.iter() {
-                    increase_amount_scheduled(conn, &owner_id, &obligation)?;
-                }
-
-                let json = serde_json::to_string(&obligations)?;
-                use crate::schema::pay_batch_order_item_payment::dsl;
-
-                diesel::insert_into(dsl::pay_batch_order_item_payment)
-                    .values((
-                        dsl::id.eq(&order_id),
-                        dsl::payee_addr.eq(&payee_addr),
-                        dsl::payee_id.eq(payee_id),
-                        dsl::json.eq(json),
-                    ))
-                    .execute(conn)?;
-            }
-        }
-    }
-    Ok(Some(order_id))
+    create_order(conn, owner_id, payer_addr, platform, payments, total_amount).map(Some)
 }
 
-fn resolve_new_payments(
+pub fn batch_payments(
     conn: &ConnType,
     owner_id: NodeId,
     payer_addr: &str,
     platform: &str,
     since: DateTime<Utc>,
-) -> DbResult<(HashMap<String, BatchPayment>, BigDecimal)> {
+    now: DateTime<Utc>,
+) -> DbResult<(HashSet<String>, DateTime<Utc>)> {
+    let mut orders = Default::default();
+    let (payments, total_amount, latest_entry) =
+        collect_pending_payments(conn, owner_id, payer_addr, platform, since)?;
+
+    if total_amount.is_zero() {
+        return Ok((orders, Utc.from_utc_datetime(&latest_entry)));
+    }
+
+    log::debug!("Collected {} pending payments", payments.len());
+
+    for (payee_addr, mut payment) in payments {
+        let existing: Option<(
+            String,
+            Option<f32>,
+            BigDecimalField,
+            Option<NaiveDateTime>,
+            NodeId,
+            String,
+        )> = oidsl::pay_batch_order_item
+            .inner_join(dsl::pay_batch_order)
+            .inner_join(
+                pdsl::pay_batch_order_item_payment.on(pdsl::id
+                    .eq(dsl::id)
+                    .and(pdsl::payee_addr.eq(oidsl::payee_addr))),
+            )
+            .filter(oidsl::status.eq(DbBatchOrderItemStatus::Pending))
+            .filter(oidsl::payee_addr.eq(&payee_addr))
+            .filter(oidsl::payment_due_date.nullable().ge(now.naive_utc()))
+            .filter(dsl::owner_id.eq(owner_id))
+            .filter(dsl::payer_addr.eq(payer_addr))
+            .filter(dsl::platform.eq(platform))
+            .select((
+                dsl::id,
+                dsl::total_amount,
+                oidsl::amount,
+                oidsl::payment_due_date,
+                pdsl::payee_id,
+                pdsl::json,
+            ))
+            .order_by(oidsl::payment_due_date.desc())
+            .first(conn)
+            .optional()?;
+
+        let sub_amount = payment.amount.clone();
+
+        match existing {
+            Some((order_id, total_amount, payment_amount, payment_due_date, payee_id, json)) => {
+                log::debug!(
+                    "Adding a payment of {} to {} ({}) to an existing batch: {}",
+                    sub_amount,
+                    payee_addr,
+                    platform,
+                    order_id
+                );
+
+                let mut vec: Vec<BatchPaymentObligation> = serde_json::from_str(&json)?;
+                let obligations = payment.peer_obligation.entry(payee_id).or_default();
+                vec.extend(obligations.drain(..));
+                let json = serde_json::to_string(&vec)?;
+
+                let current_due_date = payment.payment_due_dates.get(&payee_addr).cloned();
+                let payment_due_date = payment_due_date
+                    .min(current_due_date)
+                    .or(payment_due_date)
+                    .or(current_due_date);
+
+                let total_amount = total_amount.unwrap_or(0.)
+                    + sub_amount.to_f32().ok_or_else(|| {
+                        DbError::Integrity(format!("Invalid amount: {}", sub_amount))
+                    })?;
+
+                diesel::update(dsl::pay_batch_order)
+                    .filter(dsl::id.eq(&order_id))
+                    .set(dsl::total_amount.eq(total_amount))
+                    .execute(conn)?;
+
+                diesel::update(oidsl::pay_batch_order_item)
+                    .filter(oidsl::id.eq(&order_id))
+                    .set((
+                        oidsl::amount.eq(BigDecimalField(payment_amount.0 + sub_amount)),
+                        oidsl::payment_due_date.eq(payment_due_date),
+                    ))
+                    .execute(conn)?;
+
+                diesel::update(pdsl::pay_batch_order_item_payment)
+                    .filter(pdsl::id.eq(&order_id))
+                    .set(pdsl::json.eq(json))
+                    .execute(conn)?;
+
+                orders.insert(order_id);
+            }
+            None => {
+                log::debug!(
+                    "Adding a payment of {} to {} ({}) to a new batch",
+                    sub_amount,
+                    payee_addr,
+                    platform,
+                );
+
+                let sub_payments = HashMap::from([(payee_addr.to_string(), payment)]);
+                let order_id = create_order(
+                    conn,
+                    owner_id,
+                    payer_addr,
+                    platform,
+                    sub_payments,
+                    sub_amount,
+                )?;
+
+                orders.insert(order_id);
+            }
+        }
+    }
+
+    Ok((orders, Utc.from_utc_datetime(&latest_entry)))
+}
+
+pub fn get_batch_orders(
+    conn: &ConnType,
+    ids: &[String],
+    platform: &str,
+) -> DbResult<Vec<DbBatchOrderItem>> {
+    let batch_orders: Vec<DbBatchOrderItem> = oidsl::pay_batch_order_item
+        .filter(oidsl::driver_order_id.eq_any(ids))
+        .load(conn)?;
+
+    Ok(batch_orders)
+}
+
+fn create_order(
+    conn: &ConnType,
+    owner_id: NodeId,
+    payer_addr: &str,
+    platform: &str,
+    payments: HashMap<String, BatchPayment>,
+    total_amount: BigDecimal,
+) -> DbResult<String> {
+    let order_id = Uuid::new_v4().to_string();
+
+    let _ = diesel::insert_into(dsl::pay_batch_order)
+        .values((
+            dsl::id.eq(&order_id),
+            dsl::owner_id.eq(owner_id),
+            dsl::payer_addr.eq(&payer_addr),
+            dsl::platform.eq(&platform),
+            dsl::total_amount.eq(total_amount.to_f32()),
+        ))
+        .execute(conn)?;
+
+    for (payee_addr, payment) in payments {
+        diesel::insert_into(oidsl::pay_batch_order_item)
+            .values((
+                oidsl::id.eq(&order_id),
+                oidsl::payee_addr.eq(&payee_addr),
+                oidsl::amount.eq(BigDecimalField(payment.amount.clone())),
+                oidsl::payment_due_date.eq(payment.payment_due_dates.get(&payee_addr)),
+            ))
+            .execute(conn)?;
+
+        for (payee_id, obligations) in payment.peer_obligation {
+            let json = serde_json::to_string(&obligations)?;
+            diesel::insert_into(pdsl::pay_batch_order_item_payment)
+                .values((
+                    pdsl::id.eq(&order_id),
+                    pdsl::payee_addr.eq(&payee_addr),
+                    pdsl::payee_id.eq(payee_id),
+                    pdsl::json.eq(json),
+                ))
+                .execute(conn)?;
+        }
+    }
+
+    Ok(order_id)
+}
+
+fn collect_pending_payments(
+    conn: &ConnType,
+    owner_id: NodeId,
+    payer_addr: &str,
+    platform: &str,
+    since: DateTime<Utc>,
+) -> DbResult<(HashMap<String, BatchPayment>, BigDecimal, NaiveDateTime)> {
     use crate::schema::pay_agreement::dsl as pa;
     use crate::schema::pay_invoice::dsl as iv;
 
+    let since = since.naive_utc();
     let invoices = iv::pay_invoice
         .inner_join(
             pa::pay_agreement.on(pa::id
@@ -107,7 +278,7 @@ fn resolve_new_payments(
         .filter(iv::role.eq("R"))
         .filter(pa::payer_addr.eq(payer_addr))
         .filter(pa::payment_platform.eq(platform))
-        .filter(iv::timestamp.gt(since.naive_utc()))
+        .filter(iv::timestamp.gt(since))
         .filter(iv::status.eq("ACCEPTED"))
         .select((
             pa::id,
@@ -117,6 +288,8 @@ fn resolve_new_payments(
             pa::total_amount_scheduled,
             iv::id,
             iv::amount,
+            iv::timestamp,
+            iv::payment_due_date,
         ))
         .load::<(
             String,
@@ -126,12 +299,16 @@ fn resolve_new_payments(
             BigDecimalField,
             String,
             BigDecimalField,
+            NaiveDateTime,
+            NaiveDateTime,
         )>(conn)?;
-    log::info!("found [{}] invoices", invoices.len());
+    log::info!("{} invoices found", invoices.len());
 
-    let mut total_amount = BigDecimal::default();
     let zero = BigDecimal::from(0u32);
     let mut payments = HashMap::<String, BatchPayment>::new();
+    let mut total_amount = BigDecimal::default();
+    let mut latest_entry = since;
+
     for (
         agreement_id,
         peer_id,
@@ -140,65 +317,52 @@ fn resolve_new_payments(
         total_amount_scheduled,
         invoice_id,
         invoice_amount,
+        invoice_timestamp,
+        invoice_payment_due_date,
     ) in invoices
     {
         let amount = total_amount_accepted.0 - total_amount_scheduled.0;
         log::info!("[{}] to pay {} - {}", invoice_id, amount, agreement_id);
-
         if amount <= zero {
             super::invoice::update_status(&invoice_id, &owner_id, &DocumentStatus::Settled, conn)?;
             continue;
         }
+
         total_amount += &amount;
+        let batch = payments.entry(payee_addr.clone()).or_default();
+        batch.amount += &amount;
 
-        let batch_payment = payments.entry(payee_addr.clone()).or_default();
-        batch_payment.amount += &amount;
-
-        let obligations = batch_payment.peer_obligation.entry(peer_id).or_default();
-        obligations.push(BatchPaymentObligation::Invoice {
+        let obligations = batch.peer_obligation.entry(peer_id).or_default();
+        let obligation = BatchPaymentObligation::Invoice {
             id: invoice_id,
             amount,
             agreement_id: agreement_id.clone(),
-        });
+        };
+        increase_amount_scheduled(conn, &owner_id, &obligation)?;
+        obligations.push(obligation);
+
+        let current_due_date = batch.payment_due_dates.get(&payee_addr).cloned();
+        let payment_due_date = current_due_date
+            .min(Some(invoice_payment_due_date))
+            .unwrap_or(invoice_payment_due_date);
+        batch
+            .payment_due_dates
+            .insert(payee_addr.to_string(), payment_due_date);
+
+        latest_entry = latest_entry.max(invoice_timestamp);
     }
     {
-        table! {
-            sql_activity (id, owner_id) {
-                id -> Text,
-                owner_id -> Text,
-                role -> Text,
-                peer_id -> Text,
-                payee_addr -> Text,
-                agreement_id -> Text,
-                total_amount_due -> Text,
-                total_amount_accepted -> Text,
-                total_amount_scheduled -> Text,
-                total_amount_paid -> Text,
-            }
-        }
-
-        #[derive(QueryableByName)]
-        #[table_name = "sql_activity"]
-        struct Activity {
-            id: String,
-            peer_id: NodeId,
-            payee_addr: String,
-            total_amount_accepted: BigDecimalField,
-            total_amount_scheduled: BigDecimalField,
-            agreement_id: String,
-        }
-
         let v : Vec<Activity> = diesel::sql_query(r#"
-                SELECT a.id, pa.peer_id, pa.payee_addr, a.total_amount_accepted, a.total_amount_scheduled, pa.id agreement_id
+                SELECT a.id, pa.peer_id, pa.payee_addr, a.total_amount_accepted, a.total_amount_scheduled, pa.id agreement_id, pa.updated_ts
                 FROM pay_activity a join pay_agreement pa on a.owner_id = pa.owner_id and a.agreement_id = pa.id and a.role = pa.role
                 where a.role='R' and a.total_amount_accepted > 0
                 and cast(a.total_amount_scheduled as float) < cast(a.total_amount_accepted as float)
                 and not exists (select 1 from pay_invoice where agreement_id = a.agreement_id and owner_id = a.owner_id and role = 'R')
                 and pa.updated_ts > ? and pa.payment_platform = ? and pa.owner_id = ?
             "#)
-            .bind::<Timestamp, _>(since.naive_utc())
+            .bind::<Timestamp, _>(since)
             .bind::<Text, _>(&platform)
-            .bind::<Text, _>(owner_id)
+            .bind::<Text, _>(&owner_id)
             .load::<Activity>(conn)?;
 
         log::info!("{} activites found", v.len());
@@ -208,21 +372,57 @@ fn resolve_new_payments(
             if amount < zero {
                 continue;
             }
+
             total_amount += &amount;
+            let batch = payments.entry(a.payee_addr.clone()).or_default();
+            batch.amount += &amount;
 
-            let batch_payment = payments.entry(a.payee_addr.clone()).or_default();
-            batch_payment.amount += &amount;
-
-            let obligations = batch_payment.peer_obligation.entry(a.peer_id).or_default();
-            obligations.push(BatchPaymentObligation::DebitNote {
+            let obligations = batch.peer_obligation.entry(a.peer_id).or_default();
+            let obligation = BatchPaymentObligation::DebitNote {
                 amount,
                 agreement_id: a.agreement_id.clone(),
-                activity_id: a.id,
-            });
+                activity_id: a.id.clone(),
+            };
+            increase_amount_scheduled(conn, &owner_id, &obligation)?;
+            obligations.push(obligation);
+
+            let dn_due_date: Option<NaiveDateTime> = dndsl::pay_debit_note
+                .filter(dndsl::owner_id.eq(&owner_id))
+                .filter(dndsl::activity_id.eq(&a.id))
+                .filter(dndsl::role.eq("R"))
+                .filter(dndsl::timestamp.gt(since))
+                .filter(dndsl::status.eq_any(vec!["RECEIVED", "ACCEPTED"]))
+                .filter(diesel::dsl::not(diesel::dsl::exists(
+                    odsl::pay_order
+                        .filter(odsl::debit_note_id.eq(dndsl::id.nullable()))
+                        .filter(odsl::payee_addr.eq(&a.payee_addr))
+                        .select(odsl::id),
+                )))
+                .select(dndsl::payment_due_date)
+                .order_by(dndsl::payment_due_date.asc())
+                .first(conn)
+                .optional()?
+                .flatten();
+
+            let current_due_date = batch.payment_due_dates.get(&a.payee_addr).cloned();
+            let payment_due_date = current_due_date
+                .min(dn_due_date)
+                .or(current_due_date)
+                .or(dn_due_date);
+            if let Some(due_date) = payment_due_date {
+                batch
+                    .payment_due_dates
+                    .insert(a.payee_addr.to_string(), due_date);
+            }
+
+            latest_entry = a
+                .updated_ts
+                .map(|d| latest_entry.max(d))
+                .unwrap_or(latest_entry);
         }
     }
 
-    Ok((payments, total_amount))
+    Ok((payments, total_amount, latest_entry))
 }
 
 fn increase_amount_scheduled(
@@ -254,21 +454,45 @@ fn increase_amount_scheduled(
                 agreement_id,
                 amount
             );
-            super::activity::increase_amount_scheduled(&activity_id, owner_id, amount, conn)
+            super::activity::increase_amount_scheduled(activity_id, owner_id, amount, conn)
         }
     }
 }
 
-pub fn get_batch_orders(
+fn increase_amount_paid(
     conn: &ConnType,
-    ids: &[String],
-    platform: &str,
-) -> DbResult<Vec<DbBatchOrderItem>> {
-    let batch_orders: Vec<DbBatchOrderItem> = oidsl::pay_batch_order_item
-        .filter(oidsl::driver_order_id.eq_any(ids))
-        .load(conn)?;
-
-    Ok(batch_orders)
+    owner_id: &NodeId,
+    obligation: &BatchPaymentObligation,
+) -> DbResult<()> {
+    match obligation {
+        BatchPaymentObligation::Invoice {
+            id,
+            amount,
+            agreement_id,
+        } => {
+            log::debug!(
+                "increase_amount_paid agreement_id={} by {}",
+                agreement_id,
+                amount
+            );
+            let amount = BigDecimalField(amount.clone());
+            super::agreement::increase_amount_paid(agreement_id, owner_id, &amount, conn)
+        }
+        BatchPaymentObligation::DebitNote {
+            amount,
+            agreement_id,
+            activity_id,
+        } => {
+            log::debug!(
+                "increase_amount_paid activity_id={} agreement_id={} by {}",
+                activity_id,
+                agreement_id,
+                amount
+            );
+            let amount = BigDecimalField(amount.clone());
+            super::activity::increase_amount_paid(activity_id, owner_id, &amount, conn)
+        }
+    }
 }
 
 impl<'c> BatchDao<'c> {
@@ -281,6 +505,20 @@ impl<'c> BatchDao<'c> {
     ) -> DbResult<Option<String>> {
         do_with_transaction(self.pool, move |conn| {
             resolve_invoices(conn, owner_id, &payer_addr, &platform, since)
+        })
+        .await
+    }
+
+    pub async fn batch(
+        &self,
+        owner_id: NodeId,
+        payer_addr: String,
+        platform: String,
+        since: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> DbResult<(HashSet<String>, DateTime<Utc>)> {
+        do_with_transaction(self.pool, move |conn| {
+            batch_payments(conn, owner_id, &payer_addr, &platform, since, now)
         })
         .await
     }
@@ -358,6 +596,7 @@ impl<'c> BatchDao<'c> {
             Ok(BatchPayment {
                 amount: amount.0,
                 peer_obligation,
+                payment_due_dates: Default::default(),
             })
         })
         .await
@@ -376,9 +615,48 @@ impl<'c> BatchDao<'c> {
             let items: Vec<DbBatchOrderItem> = oidsl::pay_batch_order_item
                 .filter(oidsl::id.eq(&order_id))
                 .filter(oidsl::driver_order_id.is_null())
-                .filter(oidsl::paid.eq(false))
+                .filter(oidsl::status.eq(DbBatchOrderItemStatus::Pending))
                 .load(conn)?;
             Ok((order, items))
+        })
+        .await
+    }
+
+    pub async fn get_unsent_batch_orders(
+        &self,
+        due_date: Option<DateTime<Utc>>,
+    ) -> DbResult<Vec<(DbBatchOrderItem, DbBatchOrder)>> {
+        readonly_transaction(self.pool, move |conn| {
+            let mut query = oidsl::pay_batch_order_item
+                .inner_join(dsl::pay_batch_order)
+                .filter(oidsl::status.eq(DbBatchOrderItemStatus::Pending))
+                .into_boxed();
+
+            if let Some(due_date) = due_date {
+                query = query.filter(oidsl::payment_due_date.le(due_date.naive_utc()));
+            }
+
+            Ok(query.order_by(oidsl::payment_due_date.asc()).load(conn)?)
+        })
+        .await
+    }
+
+    pub async fn get_next_unsent_due_date(
+        &self,
+        order_id: String,
+        since: DateTime<Utc>,
+        until: DateTime<Utc>,
+    ) -> DbResult<Option<DateTime<Utc>>> {
+        readonly_transaction(self.pool, move |conn| {
+            Ok(oidsl::pay_batch_order_item
+                .inner_join(dsl::pay_batch_order)
+                .filter(oidsl::status.eq(DbBatchOrderItemStatus::Pending))
+                .select(oidsl::payment_due_date)
+                .order_by(oidsl::payment_due_date.asc())
+                .first(conn)
+                .optional()?
+                .flatten()
+                .map(|d| Utc.from_utc_datetime(&d)))
         })
         .await
     }
@@ -391,8 +669,12 @@ impl<'c> BatchDao<'c> {
     ) -> DbResult<usize> {
         do_with_transaction(self.pool, |conn| {
             Ok(diesel::update(oidsl::pay_batch_order_item)
-                .filter(oidsl::id.eq(order_id).and(oidsl::payee_addr.eq(payee_addr)))
-                .set(oidsl::driver_order_id.eq(driver_order_id))
+                .filter(oidsl::id.eq(order_id))
+                .filter(oidsl::payee_addr.eq(payee_addr))
+                .set((
+                    oidsl::driver_order_id.eq(driver_order_id),
+                    oidsl::status.eq(DbBatchOrderItemStatus::Sent),
+                ))
                 .execute(conn)?)
         })
         .await
@@ -416,9 +698,9 @@ impl<'c> BatchDao<'c> {
                     oidsl::id
                         .eq(&order_id)
                         .and(oidsl::payee_addr.eq(&payee_addr))
-                        .and(oidsl::paid.eq(false)),
+                        .and(oidsl::status.eq(DbBatchOrderItemStatus::Sent)),
                 )
-                .set(oidsl::paid.eq(true))
+                .set(oidsl::status.eq(DbBatchOrderItemStatus::Paid))
                 .execute(conn)?;
             if v > 0 {
                 for (payee_id, json) in d::pay_batch_order_item_payment
@@ -429,33 +711,7 @@ impl<'c> BatchDao<'c> {
                     let obligations: Vec<BatchPaymentObligation> = serde_json::from_str(&json)
                         .map_err(|e| DbError::Integrity(e.to_string()))?;
                     for obligation in obligations {
-                        match obligation {
-                            BatchPaymentObligation::Invoice {
-                                id,
-                                amount,
-                                agreement_id,
-                                ..
-                            } => {
-                                super::agreement::increase_amount_paid(
-                                    &agreement_id,
-                                    &order.owner_id,
-                                    &BigDecimalField(amount),
-                                    conn,
-                                )?;
-                            }
-                            BatchPaymentObligation::DebitNote {
-                                amount,
-                                agreement_id,
-                                activity_id,
-                            } => {
-                                super::activity::increase_amount_paid(
-                                    &activity_id,
-                                    &order.owner_id,
-                                    &BigDecimalField(amount),
-                                    conn,
-                                )?;
-                            }
-                        }
+                        increase_amount_paid(conn, &order.owner_id, &obligation)?;
                     }
                 }
             }

--- a/core/payment/src/dao/batch.rs
+++ b/core/payment/src/dao/batch.rs
@@ -130,7 +130,7 @@ pub fn batch_payments(
         match existing {
             Some((order_id, total_amount, payment_amount, payment_due_date, payee_id, json)) => {
                 log::debug!(
-                    "Adding a payment of {} to {} ({}) to an existing batch: {}",
+                    "Adding payment of {} to {} ({}) to an existing batch: {}",
                     sub_amount,
                     payee_addr,
                     platform,
@@ -175,7 +175,7 @@ pub fn batch_payments(
             }
             None => {
                 log::debug!(
-                    "Adding a payment of {} to {} ({}) to a new batch",
+                    "Adding payment of {} to {} ({}) to a new batch",
                     sub_amount,
                     payee_addr,
                     platform,
@@ -365,7 +365,7 @@ fn collect_pending_payments(
             .bind::<Text, _>(&owner_id)
             .load::<Activity>(conn)?;
 
-        log::info!("{} activites found", v.len());
+        log::info!("{} debit notes found", v.len());
 
         for a in v {
             let amount = a.total_amount_accepted.0 - a.total_amount_scheduled.0;

--- a/core/payment/src/dao/invoice.rs
+++ b/core/payment/src/dao/invoice.rs
@@ -353,3 +353,26 @@ fn join_invoices_with_activities(
         })
         .collect()
 }
+
+pub fn get_for_payee(
+    conn: &ConnType,
+    payee: &str,
+    after_timestamp: Option<NaiveDateTime>,
+) -> DbResult<Vec<Invoice>> {
+    let mut query = query!().into_boxed();
+
+    if let Some(date) = after_timestamp {
+        query = query.filter(dsl::timestamp.gt(date))
+    }
+
+    let invoices = query.load(conn)?;
+    let activities = activity_dsl::pay_invoice_x_activity
+        .inner_join(
+            dsl::pay_invoice.on(activity_dsl::owner_id
+                .eq(dsl::owner_id)
+                .and(activity_dsl::invoice_id.eq(dsl::id))),
+        )
+        .select(crate::schema::pay_invoice_x_activity::all_columns)
+        .load(conn)?;
+    join_invoices_with_activities(invoices, activities)
+}

--- a/core/payment/src/dao/order.rs
+++ b/core/payment/src/dao/order.rs
@@ -1,17 +1,24 @@
-use crate::dao::{activity, agreement, allocation};
-use crate::error::DbResult;
-use crate::models::order::{ReadObj, WriteObj};
-use crate::schema::pay_debit_note::dsl as debit_note_dsl;
-use crate::schema::pay_invoice::dsl as invoice_dsl;
-use crate::schema::pay_order::dsl;
-use diesel::{
-    self, BoolExpressionMethods, ExpressionMethods, JoinOnDsl, NullableExpressionMethods, QueryDsl,
-    RunQueryDsl,
-};
+use std::collections::HashMap;
+
+use bigdecimal::BigDecimal;
+use diesel::prelude::*;
+
 use ya_core_model::payment::local::{
     DebitNotePayment, InvoicePayment, PaymentTitle, SchedulePayment,
 };
+use ya_core_model::NodeId;
 use ya_persistence::executor::{do_with_transaction, readonly_transaction, AsDao, PoolType};
+
+use crate::dao::{activity, agreement, allocation};
+use crate::error::{DbError, DbResult};
+use crate::models::batch::DbBatchOrderItem;
+use crate::models::order::{ReadObj, WriteObj};
+use crate::schema::pay_batch_order::dsl as odsl;
+use crate::schema::pay_batch_order_item::dsl as oidsl;
+use crate::schema::pay_debit_note::dsl as debit_note_dsl;
+use crate::schema::pay_invoice::dsl as invoice_dsl;
+
+use crate::schema::pay_order::dsl;
 
 pub struct OrderDao<'c> {
     pool: &'c PoolType,
@@ -87,6 +94,81 @@ impl<'c> OrderDao<'c> {
                 ))
                 .load(conn)?;
             Ok(orders)
+        })
+        .await
+    }
+
+    pub async fn get_orders(
+        &self,
+        ids: Vec<String>,
+        driver: String,
+    ) -> DbResult<(Vec<ReadObj>, Vec<DbBatchOrderItem>)> {
+        readonly_transaction(self.pool, move |conn| {
+            let orders = dsl::pay_order
+                .left_join(
+                    invoice_dsl::pay_invoice.on(dsl::invoice_id
+                        .eq(invoice_dsl::id.nullable())
+                        .and(dsl::payer_id.eq(invoice_dsl::owner_id))),
+                )
+                .left_join(
+                    debit_note_dsl::pay_debit_note.on(dsl::debit_note_id
+                        .eq(debit_note_dsl::id.nullable())
+                        .and(dsl::payer_id.eq(debit_note_dsl::owner_id))),
+                )
+                .filter(dsl::id.eq_any(&ids))
+                .filter(dsl::driver.eq(&driver))
+                .select((
+                    dsl::id,
+                    dsl::driver,
+                    dsl::amount,
+                    dsl::payee_id,
+                    dsl::payer_id,
+                    dsl::payee_addr,
+                    dsl::payer_addr,
+                    dsl::payment_platform,
+                    dsl::invoice_id,
+                    dsl::debit_note_id,
+                    dsl::allocation_id,
+                    dsl::is_paid,
+                    invoice_dsl::agreement_id.nullable(),
+                    debit_note_dsl::activity_id.nullable(),
+                ))
+                .load(conn)?;
+
+            let batch_orders = super::batch::get_batch_orders(conn, &ids, &driver)?;
+
+            Ok((orders, batch_orders))
+        })
+        .await
+    }
+
+    pub async fn get_batch_items(
+        &self,
+        owner_id: NodeId,
+        platform: String,
+    ) -> DbResult<HashMap<(String, String), BigDecimal>> {
+        readonly_transaction(self.pool, move |conn| {
+            let data: Vec<(String, String, String, bool)> = odsl::pay_batch_order
+                .filter(
+                    odsl::platform
+                        .eq(&platform)
+                        .and(odsl::owner_id.eq(owner_id)),
+                )
+                .inner_join(oidsl::pay_batch_order_item)
+                .select((
+                    odsl::payer_addr,
+                    oidsl::payee_addr,
+                    oidsl::amount,
+                    oidsl::paid,
+                ))
+                .load(conn)?;
+
+            data
+                .into_iter()
+                .map(|(payer_addr, payee_addr, amount, paid)| -> Result<((String, String), BigDecimal), DbError> {
+                    Ok(((payer_addr, payee_addr), amount.parse().map_err(|e : bigdecimal::ParseBigDecimalError| DbError::Integrity(e.to_string()))?))
+                })
+                .collect()
         })
         .await
     }

--- a/core/payment/src/error.rs
+++ b/core/payment/src/error.rs
@@ -150,6 +150,8 @@ pub mod processor {
         Driver(#[from] ya_core_model::driver::GenericError),
         #[error("Database error: {0}")]
         Database(#[from] DbError),
+        #[error("Batch error: {0}")]
+        Batch(String),
         #[error("Payment service is shutting down")]
         Shutdown,
     }

--- a/core/payment/src/lib.rs
+++ b/core/payment/src/lib.rs
@@ -13,6 +13,7 @@ extern crate diesel;
 
 pub mod accounts;
 pub mod api;
+mod batch;
 mod cli;
 pub mod dao;
 pub mod error;

--- a/core/payment/src/models.rs
+++ b/core/payment/src/models.rs
@@ -1,6 +1,7 @@
 pub mod activity;
 pub mod agreement;
 pub mod allocation;
+pub mod batch;
 pub mod debit_note;
 pub mod debit_note_event;
 pub mod invoice;

--- a/core/payment/src/models/agreement.rs
+++ b/core/payment/src/models/agreement.rs
@@ -1,5 +1,6 @@
 use crate::schema::pay_agreement;
 use crate::DEFAULT_PAYMENT_PLATFORM;
+use chrono::{NaiveDateTime, Timelike, Utc};
 use serde_json::Value;
 use ya_agreement_utils::agreement::{expand, TypedPointer};
 use ya_client_model::market::Agreement;
@@ -22,6 +23,8 @@ pub struct WriteObj {
     pub total_amount_scheduled: BigDecimalField,
     pub total_amount_paid: BigDecimalField,
     pub app_session_id: Option<String>,
+    pub created_ts: Option<NaiveDateTime>,
+    pub updated_ts: Option<NaiveDateTime>,
 }
 
 impl WriteObj {
@@ -52,6 +55,10 @@ impl WriteObj {
             .map(ToOwned::to_owned)
             .unwrap_or(requestor_id.to_string().to_lowercase());
 
+        let now = Utc::now();
+        let created_ts = Some(now.naive_utc()).and_then(|v| v.with_nanosecond(0));
+        let updated_ts = created_ts.clone();
+
         Self {
             id: agreement.agreement_id,
             owner_id,
@@ -65,6 +72,8 @@ impl WriteObj {
             total_amount_scheduled: Default::default(),
             total_amount_paid: Default::default(),
             app_session_id: agreement.app_session_id,
+            created_ts,
+            updated_ts,
         }
     }
 }

--- a/core/payment/src/models/batch.rs
+++ b/core/payment/src/models/batch.rs
@@ -1,0 +1,65 @@
+use std::collections::HashMap;
+
+use bigdecimal::BigDecimal;
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+
+use ya_core_model::NodeId;
+use ya_persistence::types::BigDecimalField;
+
+use crate::schema::*;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BatchPaymentObligation {
+    Invoice {
+        id: String,
+        amount: BigDecimal,
+        agreement_id: String,
+    },
+    DebitNote {
+        amount: BigDecimal,
+        agreement_id: String,
+        activity_id: String,
+    },
+}
+
+pub struct BatchItem {
+    pub payee_addr: String,
+    pub payments: Vec<BatchPayment>,
+}
+
+pub struct BatchPayment {
+    pub amount: BigDecimal,
+    pub peer_obligation: HashMap<NodeId, Vec<BatchPaymentObligation>>,
+}
+
+#[derive(Queryable, Debug, Identifiable, Insertable)]
+#[table_name = "pay_batch_order"]
+pub struct DbBatchOrder {
+    pub id: String,
+    pub ts: NaiveDateTime,
+    pub owner_id: NodeId,
+    pub payer_addr: String,
+    pub platform: String,
+    pub total_amount: Option<f32>,
+    pub paid: bool,
+}
+
+#[derive(Queryable, Debug, Identifiable, Insertable)]
+#[table_name = "pay_batch_order_item"]
+pub struct DbBatchOrderItem {
+    pub id: String,
+    pub payee_addr: String,
+    pub amount: BigDecimalField,
+    pub driver_order_id: Option<String>,
+    pub paid: bool,
+}
+
+#[derive(Queryable, Debug, Identifiable, Insertable)]
+#[table_name = "pay_batch_order_item_payment"]
+pub struct DbBatchOrderItemPayment {
+    pub id: String,
+    pub payee_addr: String,
+    pub payee_id: NodeId,
+    pub json: String,
+}

--- a/core/payment/src/models/batch.rs
+++ b/core/payment/src/models/batch.rs
@@ -1,7 +1,12 @@
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use bigdecimal::BigDecimal;
 use chrono::NaiveDateTime;
+use diesel::backend::Backend;
+use diesel::deserialize::FromSql;
+use diesel::serialize::{Output, ToSql};
+use diesel::sql_types::Text;
 use serde::{Deserialize, Serialize};
 
 use ya_core_model::NodeId;
@@ -28,9 +33,11 @@ pub struct BatchItem {
     pub payments: Vec<BatchPayment>,
 }
 
+#[derive(Default)]
 pub struct BatchPayment {
     pub amount: BigDecimal,
     pub peer_obligation: HashMap<NodeId, Vec<BatchPaymentObligation>>,
+    pub payment_due_dates: HashMap<String, NaiveDateTime>,
 }
 
 #[derive(Queryable, Debug, Identifiable, Insertable)]
@@ -52,7 +59,8 @@ pub struct DbBatchOrderItem {
     pub payee_addr: String,
     pub amount: BigDecimalField,
     pub driver_order_id: Option<String>,
-    pub paid: bool,
+    pub status: DbBatchOrderItemStatus,
+    pub payment_due_date: Option<NaiveDateTime>,
 }
 
 #[derive(Queryable, Debug, Identifiable, Insertable)]
@@ -62,4 +70,60 @@ pub struct DbBatchOrderItemPayment {
     pub payee_addr: String,
     pub payee_id: NodeId,
     pub json: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, AsExpression, FromSqlRow)]
+#[sql_type = "Text"]
+pub enum DbBatchOrderItemStatus {
+    Pending,
+    Sent,
+    Paid,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("Invalid batch order item status string: {0}")]
+pub struct StatusParseError(pub String);
+
+impl ToString for DbBatchOrderItemStatus {
+    fn to_string(&self) -> String {
+        match self {
+            Self::Pending => "PENDING",
+            Self::Sent => "SENT",
+            Self::Paid => "PAID",
+        }
+        .to_string()
+    }
+}
+
+impl FromStr for DbBatchOrderItemStatus {
+    type Err = StatusParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "PENDING" => Self::Pending,
+            "SENT" => Self::Sent,
+            "PAID" => Self::Paid,
+            _ => return Err(StatusParseError(s.to_string())),
+        })
+    }
+}
+
+impl<DB: Backend> ToSql<Text, DB> for DbBatchOrderItemStatus
+where
+    String: ToSql<Text, DB>,
+{
+    fn to_sql<W: std::io::Write>(&self, out: &mut Output<W, DB>) -> diesel::serialize::Result {
+        self.to_string().to_sql(out)
+    }
+}
+
+impl<DB> FromSql<Text, DB> for DbBatchOrderItemStatus
+where
+    String: FromSql<Text, DB>,
+    DB: Backend,
+{
+    fn from_sql(bytes: Option<&DB::RawValue>) -> diesel::deserialize::Result<Self> {
+        let s = String::from_sql(bytes)?;
+        Ok(Self::from_str(&s)?)
+    }
 }

--- a/core/payment/src/models/order.rs
+++ b/core/payment/src/models/order.rs
@@ -1,4 +1,5 @@
-use crate::schema::pay_order;
+use crate::schema::*;
+
 use ya_client_model::NodeId;
 use ya_core_model::payment::local::{PaymentTitle, SchedulePayment};
 use ya_persistence::types::BigDecimalField;

--- a/core/payment/src/processor.rs
+++ b/core/payment/src/processor.rs
@@ -1,21 +1,24 @@
-use crate::dao::{ActivityDao, AgreementDao, AllocationDao, OrderDao, PaymentDao};
+use crate::dao::{ActivityDao, AgreementDao, AllocationDao, BatchDao, OrderDao, PaymentDao};
 use crate::error::processor::{
     AccountNotRegistered, GetStatusError, NotifyPaymentError, OrderValidationError,
     SchedulePaymentError, ValidateAllocationError, VerifyPaymentError,
 };
+use crate::models::batch::BatchPaymentObligation;
 use crate::models::order::ReadObj as DbOrder;
 use actix_web::rt::Arbiter;
 use bigdecimal::{BigDecimal, Zero};
+use chrono::Utc;
 use futures::FutureExt;
 use metrics::counter;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::time::Duration;
+
 use ya_client_model::payment::{
     Account, ActivityPayment, AgreementPayment, DriverDetails, Network, Payment,
 };
 use ya_core_model::driver::{
-    self, driver_bus_id, AccountMode, PaymentConfirmation, PaymentDetails, ShutDown,
+    self, driver_bus_id, AccountMode, BatchMode, PaymentConfirmation, PaymentDetails, ShutDown,
     ValidateAllocation,
 };
 use ya_core_model::payment::local::{
@@ -71,6 +74,7 @@ struct AccountDetails {
     pub network: String,
     pub token: String,
     pub mode: AccountMode,
+    pub batch: Option<BatchMode>,
 }
 
 #[derive(Clone, Default)]
@@ -174,6 +178,7 @@ impl DriverRegistry {
                     network: msg.network,
                     token: msg.token,
                     mode: msg.mode,
+                    batch: msg.batch,
                 });
             }
         };
@@ -351,90 +356,218 @@ impl PaymentProcessor {
         if msg.order_ids.is_empty() {
             return Err(OrderValidationError::new("order_ids is empty").into());
         }
-        let orders = self
+        let (orders, batch_orders) = self
             .db_executor
             .as_dao::<OrderDao>()
-            .get_many(msg.order_ids, driver.clone())
+            .get_orders(msg.order_ids, driver.clone())
             .await?;
-        validate_orders(
-            &orders,
-            &payment_platform,
-            &payer_addr,
-            &payee_addr,
-            &msg.amount,
-        )
-        .await?;
+        if !batch_orders.is_empty() {
+            for batch_order_item in batch_orders {
+                self.db_executor
+                    .as_dao::<BatchDao>()
+                    .batch_order_item_paid(
+                        batch_order_item.id.clone(),
+                        batch_order_item.payee_addr.clone(),
+                        msg.confirmation.confirmation.clone(),
+                    )
+                    .await?;
+                {
+                    let db_order = self
+                        .db_executor
+                        .as_dao::<BatchDao>()
+                        .get_batch_order(batch_order_item.id.clone())
+                        .await?;
 
-        let mut activity_payments = vec![];
-        let mut agreement_payments = vec![];
-        for order in orders.iter() {
-            let amount = order.amount.clone().into();
-            match (order.activity_id.clone(), order.agreement_id.clone()) {
-                (Some(activity_id), None) => activity_payments.push(ActivityPayment {
-                    activity_id,
-                    amount,
-                    allocation_id: Some(order.allocation_id.clone()),
-                }),
-                (None, Some(agreement_id)) => agreement_payments.push(AgreementPayment {
-                    agreement_id,
-                    amount,
-                    allocation_id: Some(order.allocation_id.clone()),
-                }),
-                _ => return NotifyPaymentError::invalid_order(&order),
+                    let confirmation = base64::encode(&msg.confirmation.confirmation);
+
+                    let payment = self
+                        .db_executor
+                        .as_dao::<BatchDao>()
+                        .get_batch_order_payments(
+                            batch_order_item.id.clone(),
+                            batch_order_item.payee_addr.clone(),
+                        )
+                        .await?;
+
+                    for (payee_id, obligations) in payment.peer_obligation {
+                        let payer_id = db_order.owner_id;
+                        let payer_addr = payer_addr.clone();
+                        let payee_addr = payee_addr.clone();
+                        let driver = driver.clone();
+                        let payment_platform = payment_platform.clone();
+                        let confirmation = confirmation.clone();
+                        let agreement_payments = obligations
+                            .iter()
+                            .filter_map(|obligation: &BatchPaymentObligation| match obligation {
+                                BatchPaymentObligation::Invoice {
+                                    id,
+                                    amount,
+                                    agreement_id,
+                                } => Some(AgreementPayment {
+                                    agreement_id: agreement_id.to_string(),
+                                    amount: amount.clone(),
+                                    allocation_id: None,
+                                }),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>();
+                        let activity_payments = obligations
+                            .iter()
+                            .filter_map(|obligation: &BatchPaymentObligation| match obligation {
+                                BatchPaymentObligation::DebitNote {
+                                    amount,
+                                    agreement_id,
+                                    activity_id,
+                                } => Some(ActivityPayment {
+                                    activity_id: activity_id.to_string(),
+                                    amount: amount.clone(),
+                                    allocation_id: None,
+                                }),
+                                _ => None,
+                            })
+                            .collect::<Vec<_>>();
+
+                        Arbiter::spawn(async move {
+                            let payment = Payment {
+                                payment_id: uuid::Uuid::new_v4().to_string(), // TODO: check this
+                                payer_id,
+                                payee_id,
+                                payer_addr: payer_addr.clone(),
+                                payee_addr: payee_addr.clone(),
+                                payment_platform,
+                                amount: Default::default(),
+                                timestamp: Utc::now(),
+                                agreement_payments,
+                                activity_payments,
+                                details: confirmation.clone(),
+                            };
+
+                            let signature = match driver_endpoint(&driver)
+                                .send(driver::SignPayment(payment.clone()))
+                                .await
+                            {
+                                Ok(Ok(v)) => v,
+                                Err(e) => {
+                                    log::error!(
+                                        "Failed to sign payment: {:?} ,err={:?}",
+                                        payment,
+                                        e
+                                    );
+                                    return;
+                                }
+                                Ok(Err(e)) => {
+                                    log::error!("Failed to sign payment: {:?} ,err={}", payment, e);
+                                    return;
+                                }
+                            };
+
+                            let msg = SendPayment::new(payment, signature);
+
+                            match ya_net::from(payer_id)
+                                .to(payee_id)
+                                .service(BUS_ID)
+                                .call(msg)
+                                .await
+                            {
+                                Ok(Ok(v)) => (),
+                                Err(e) => log::error!(
+                                    "failed to call payment to {}, err={:?}",
+                                    payee_id,
+                                    e
+                                ),
+                                Ok(Err(e)) => log::error!(
+                                    "failed to send payment to {}, err={:?}",
+                                    payee_id,
+                                    e
+                                ),
+                            }
+                        })
+                    }
+                    counter!("payment.amount.sent", ya_metrics::utils::cryptocurrency_to_u64(&msg.amount), "platform" => payment_platform.clone());
+                }
             }
         }
-
-        // FIXME: This is a hack. Payment orders realized by a single transaction are not guaranteed
-        //        to have the same payer and payee IDs. Fixing this requires a major redesign of the
-        //        data model. Payments can no longer by assigned to a single payer and payee.
-        let payer_id = orders.get(0).unwrap().payer_id;
-        let payee_id = orders.get(0).unwrap().payee_id;
-
-        let payment_dao: PaymentDao = self.db_executor.as_dao();
-        let payment_id = payment_dao
-            .create_new(
-                payer_id,
-                payee_id,
-                payer_addr,
-                payee_addr,
-                payment_platform.clone(),
-                msg.amount.clone(),
-                msg.confirmation.confirmation,
-                activity_payments,
-                agreement_payments,
+        if !orders.is_empty() {
+            validate_orders(
+                &orders,
+                &payment_platform,
+                &payer_addr,
+                &payee_addr,
+                &msg.amount,
             )
             .await?;
 
-        let mut payment = payment_dao.get(payment_id, payer_id).await?.unwrap();
-        // Allocation IDs are requestor's private matter and should not be sent to provider
-        for agreement_payment in payment.agreement_payments.iter_mut() {
-            agreement_payment.allocation_id = None;
+            let mut activity_payments = vec![];
+            let mut agreement_payments = vec![];
+            for order in orders.iter() {
+                let amount = order.amount.clone().into();
+                match (order.activity_id.clone(), order.agreement_id.clone()) {
+                    (Some(activity_id), None) => activity_payments.push(ActivityPayment {
+                        activity_id,
+                        amount,
+                        allocation_id: Some(order.allocation_id.clone()),
+                    }),
+                    (None, Some(agreement_id)) => agreement_payments.push(AgreementPayment {
+                        agreement_id,
+                        amount,
+                        allocation_id: Some(order.allocation_id.clone()),
+                    }),
+                    _ => return NotifyPaymentError::invalid_order(&order),
+                }
+            }
+
+            // FIXME: This is a hack. Payment orders realized by a single transaction are not guaranteed
+            //        to have the same payer and payee IDs. Fixing this requires a major redesign of the
+            //        data model. Payments can no longer by assigned to a single payer and payee.
+            let payer_id = orders.get(0).unwrap().payer_id;
+            let payee_id = orders.get(0).unwrap().payee_id;
+
+            let payment_dao: PaymentDao = self.db_executor.as_dao();
+            let payment_id = payment_dao
+                .create_new(
+                    payer_id,
+                    payee_id,
+                    payer_addr,
+                    payee_addr,
+                    payment_platform.clone(),
+                    msg.amount.clone(),
+                    msg.confirmation.confirmation,
+                    activity_payments,
+                    agreement_payments,
+                )
+                .await?;
+
+            let mut payment = payment_dao.get(payment_id, payer_id).await?.unwrap();
+            // Allocation IDs are requestor's private matter and should not be sent to provider
+            for agreement_payment in payment.agreement_payments.iter_mut() {
+                agreement_payment.allocation_id = None;
+            }
+            for activity_payment in payment.activity_payments.iter_mut() {
+                activity_payment.allocation_id = None;
+            }
+
+            let signature = driver_endpoint(&driver)
+                .send(driver::SignPayment(payment.clone()))
+                .await??;
+
+            counter!("payment.amount.sent", ya_metrics::utils::cryptocurrency_to_u64(&msg.amount), "platform" => payment_platform);
+            let msg = SendPayment::new(payment, signature);
+
+            // Spawning to avoid deadlock in a case that payee is the same node as payer
+            Arbiter::spawn(
+                ya_net::from(payer_id)
+                    .to(payee_id)
+                    .service(BUS_ID)
+                    .call(msg)
+                    .map(|res| match res {
+                        Ok(Ok(_)) => (),
+                        err => log::error!("Error sending payment message to provider: {:?}", err),
+                    }),
+            );
+            // TODO: Implement re-sending mechanism in case SendPayment fails
+
+            counter!("payment.invoices.requestor.paid", 1);
         }
-        for activity_payment in payment.activity_payments.iter_mut() {
-            activity_payment.allocation_id = None;
-        }
-
-        let signature = driver_endpoint(&driver)
-            .send(driver::SignPayment(payment.clone()))
-            .await??;
-
-        counter!("payment.amount.sent", ya_metrics::utils::cryptocurrency_to_u64(&msg.amount), "platform" => payment_platform);
-        let msg = SendPayment::new(payment, signature);
-
-        // Spawning to avoid deadlock in a case that payee is the same node as payer
-        Arbiter::spawn(
-            ya_net::from(payer_id)
-                .to(payee_id)
-                .service(BUS_ID)
-                .call(msg)
-                .map(|res| match res {
-                    Ok(Ok(_)) => (),
-                    err => log::error!("Error sending payment message to provider: {:?}", err),
-                }),
-        );
-        // TODO: Implement re-sending mechanism in case SendPayment fails
-
-        counter!("payment.invoices.requestor.paid", 1);
         Ok(())
     }
 

--- a/core/payment/src/processor.rs
+++ b/core/payment/src/processor.rs
@@ -433,6 +433,7 @@ impl PaymentProcessor {
                         let driver = driver.clone();
                         let payment_platform = payment_platform.clone();
                         let confirmation = confirmation.clone();
+                        let mut amount = BigDecimal::from(0u64);
 
                         let agreement_payments = obligations
                             .iter()
@@ -449,6 +450,7 @@ impl PaymentProcessor {
                                 _ => None,
                             })
                             .fold(HashMap::<String, AgreementPayment>::new(), |mut acc, p| {
+                                amount += p.amount.clone();
                                 match acc.get_mut(&p.agreement_id) {
                                     Some(entry) => {
                                         entry.amount += p.amount;
@@ -479,6 +481,7 @@ impl PaymentProcessor {
                                 _ => None,
                             })
                             .fold(HashMap::<String, ActivityPayment>::new(), |mut acc, p| {
+                                amount += p.amount.clone();
                                 match acc.get_mut(&p.activity_id) {
                                     Some(entry) => {
                                         entry.amount += p.amount;
@@ -500,7 +503,7 @@ impl PaymentProcessor {
                                 payer_addr: payer_addr.clone(),
                                 payee_addr: payee_addr.clone(),
                                 payment_platform,
-                                amount: Default::default(),
+                                amount,
                                 timestamp: Utc::now(),
                                 agreement_payments,
                                 activity_payments,

--- a/core/payment/src/schema.rs
+++ b/core/payment/src/schema.rs
@@ -84,7 +84,8 @@ table! {
         payee_addr -> Text,
         amount -> Text,
         driver_order_id -> Nullable<Text>,
-        paid -> Bool,
+        status -> Text,
+        payment_due_date -> Nullable<Timestamp>,
     }
 }
 

--- a/core/payment/src/schema.rs
+++ b/core/payment/src/schema.rs
@@ -35,6 +35,8 @@ table! {
         total_amount_scheduled -> Text,
         total_amount_paid -> Text,
         app_session_id -> Nullable<Text>,
+        created_ts -> Nullable<Timestamp>,
+        updated_ts -> Nullable<Timestamp>,
     }
 }
 
@@ -61,6 +63,37 @@ table! {
         timeout -> Nullable<Timestamp>,
         make_deposit -> Bool,
         released -> Bool,
+    }
+}
+
+table! {
+    pay_batch_order (id) {
+        id -> Text,
+        ts -> Timestamp,
+        owner_id -> Text,
+        payer_addr -> Text,
+        platform -> Text,
+        total_amount -> Nullable<Float>,
+        paid -> Bool,
+    }
+}
+
+table! {
+    pay_batch_order_item (id, payee_addr) {
+        id -> Text,
+        payee_addr -> Text,
+        amount -> Text,
+        driver_order_id -> Nullable<Text>,
+        paid -> Bool,
+    }
+}
+
+table! {
+    pay_batch_order_item_payment (id, payee_addr, payee_id) {
+        id -> Text,
+        payee_addr -> Text,
+        payee_id -> Text,
+        json -> Text,
     }
 }
 
@@ -189,6 +222,7 @@ table! {
 
 joinable!(pay_activity_payment -> pay_allocation (allocation_id));
 joinable!(pay_agreement_payment -> pay_allocation (allocation_id));
+joinable!(pay_batch_order_item -> pay_batch_order (id));
 joinable!(pay_debit_note -> pay_document_status (status));
 joinable!(pay_debit_note_event -> pay_event_type (event_type));
 joinable!(pay_invoice -> pay_document_status (status));
@@ -201,6 +235,9 @@ allow_tables_to_appear_in_same_query!(
     pay_agreement,
     pay_agreement_payment,
     pay_allocation,
+    pay_batch_order,
+    pay_batch_order_item,
+    pay_batch_order_item_payment,
     pay_debit_note,
     pay_debit_note_event,
     pay_debit_note_event_read,

--- a/core/payment/src/wallet.rs
+++ b/core/payment/src/wallet.rs
@@ -2,7 +2,7 @@
 use bigdecimal::BigDecimal;
 
 // Workspace uses
-use ya_core_model::driver::{driver_bus_id, Enter, Exit, Fund, Transfer};
+use ya_core_model::driver::{driver_bus_id, Enter, Exit, ExitFee, FeeResult, Fund, Transfer};
 use ya_service_bus::typed as bus;
 
 pub async fn fund(
@@ -37,9 +37,10 @@ pub async fn exit(
     driver: String,
     network: Option<String>,
     token: Option<String>,
+    fee_limit: Option<BigDecimal>,
 ) -> anyhow::Result<String> {
     let driver_id = driver_bus_id(driver);
-    let message = Exit::new(sender, to, amount, network, token);
+    let message = Exit::new(sender, to, amount, network, token, fee_limit);
     let tx_id = bus::service(driver_id).call(message).await??;
     Ok(tx_id)
 }
@@ -68,4 +69,24 @@ pub async fn transfer(
     );
     let tx_id = bus::service(driver_id).call(message).await??;
     Ok(tx_id)
+}
+
+pub async fn exit_fee(
+    sender: String,
+    to: Option<String>,
+    amount: Option<BigDecimal>,
+    driver: String,
+    network: Option<String>,
+    token: Option<String>,
+) -> anyhow::Result<FeeResult> {
+    let driver_id = driver_bus_id(driver);
+    Ok(bus::service(driver_id)
+        .call(ExitFee {
+            sender,
+            to,
+            amount,
+            network,
+            token,
+        })
+        .await??)
 }

--- a/goth_tests/domain/payments/goth-batch-config.yml
+++ b/goth_tests/domain/payments/goth-batch-config.yml
@@ -1,0 +1,43 @@
+docker-compose:
+  docker-dir: "../../assets/docker/"
+  build-environment:
+    # default
+  compose-log-patterns:
+    ethereum: ".*Wallets supplied."
+    zksync: ".*Running on http://.*:3030/.*"
+
+key-dir: "../../assets/keys"
+web-root: "../../assets/web-root"
+
+node-types:
+  - name: "Requestor"
+    class: "goth.runner.probe.RequestorProbe"
+    environment:
+      - "ERC20_SENDOUT_INTERVAL_SECS=1"
+      - "ERC20_CONFIRMATION_INTERVAL_SECS=1"
+      - "BATCH_DEFAULT_PROCESSING_TIME_SECS=3"
+
+  - name: "Provider"
+    class: "goth_tests.helpers.probe.ProviderProbe"
+    mount:
+      - read-only: "../../assets/provider/presets.json"
+        destination: "/root/.local/share/ya-provider/presets.json"
+      - read-only: "../../assets/provider/hardware.json"
+        destination: "/root/.local/share/ya-provider/hardware.json"
+    privileged-mode: True
+    environment:
+      - "IDLE_AGREEMENT_TIMEOUT=5s"
+      - "DEBIT_NOTE_ACCEPTANCE_DEADLINE=8s"
+      - "DEBIT_NOTE_INTERVAL=2s"
+      - "PAYMENT_TIMEOUT=30s"
+      - "ERC20_CONFIRMATION_INTERVAL_SECS=1"
+
+nodes:
+  - name: "requestor"
+    type: "Requestor"
+    payment-config: "erc20_batching"
+
+  - name: "provider-1"
+    type: "Provider"
+    use-proxy: True
+    payment-config: "erc20"

--- a/goth_tests/helpers/payment.py
+++ b/goth_tests/helpers/payment.py
@@ -17,6 +17,7 @@ logger = logging.getLogger("goth.tests.helpers.payment")
 async def pay_all(
     requestor: RequestorProbe,
     agreements: List[Tuple[str, ProviderProbe]],
+    await_payment: bool = True,
 ):
     """Pay for all Agreements."""
     for agreement_id, provider in agreements:
@@ -25,7 +26,8 @@ async def pay_all(
         assert all(inv.agreement_id == agreement_id for inv in invoices)
         # TODO:
         await requestor.pay_invoices(invoices)
-        await provider.wait_for_invoice_paid()
+        if await_payment:
+            await provider.wait_for_invoice_paid()
 
 
 async def accept_debit_notes(

--- a/goth_tests/poetry.lock
+++ b/goth_tests/poetry.lock
@@ -62,17 +62,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "21.3.0"
+version = "21.4.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
-tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
 name = "bcrypt"
@@ -157,7 +157,7 @@ python-versions = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.9"
+version = "2.0.12"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -203,11 +203,11 @@ test = ["pytest (>=3.6.0,!=3.9.0,!=3.9.1,!=3.9.2)", "pretend", "iso8601", "pytz"
 
 [[package]]
 name = "distro"
-version = "1.6.0"
+version = "1.7.0"
 description = "Distro - an OS platform information API"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "docker"
@@ -273,7 +273,7 @@ python-versions = "*"
 
 [[package]]
 name = "dpath"
-version = "2.0.5"
+version = "2.0.6"
 description = "Filesystem-like pathing and searching for dictionaries"
 category = "main"
 optional = false
@@ -337,30 +337,37 @@ dev = ["jsonref"]
 
 [[package]]
 name = "goth"
-version = "0.9.0"
+version = "0.10.0"
 description = "Golem Test Harness - integration testing framework"
 category = "main"
 optional = false
-python-versions = ">=3.8,<4.0"
+python-versions = "^3.8"
+develop = false
 
 [package.dependencies]
 aiohttp = "3.7.4"
-ansicolors = ">=1.1.0,<2.0.0"
-docker = ">=5.0,<6.0"
-docker-compose = ">=1.29,<2.0"
-dpath = ">=2.0,<3.0"
+ansicolors = "^1.1.0"
+docker = "^5.0"
+docker-compose = "^1.29"
+dpath = "^2.0"
 func_timeout = "4.3.5"
-ghapi = ">=0.1.16,<0.2.0"
-mitmproxy = ">=5.3,<6.0"
-pyyaml = ">=5.4,<6.0"
-transitions = ">=0.8,<0.9"
-typing_extensions = ">=3.10.0,<4.0.0"
-urllib3 = ">=1.26,<2.0"
-ya-aioclient = ">=0.6,<0.7"
+ghapi = "^0.1.16"
+mitmproxy = "^5.3"
+pyyaml = "^5.4"
+transitions = "^0.8"
+typing_extensions = "^3.10.0"
+urllib3 = "^1.26"
+ya-aioclient = "^0.6"
+
+[package.source]
+type = "git"
+url = "https://github.com/golemfactory/goth.git"
+reference = "mf/batch-payments"
+resolved_reference = "1557109b6971bf1ac3d0ad71de5c4bb4dd60f3e5"
 
 [[package]]
 name = "h11"
-version = "0.12.0"
+version = "0.13.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 category = "main"
 optional = false
@@ -525,11 +532,11 @@ python-versions = "*"
 
 [[package]]
 name = "multidict"
-version = "5.2.0"
+version = "6.0.2"
 description = "multidict implementation"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "mypy"
@@ -568,7 +575,7 @@ pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "paramiko"
-version = "2.9.1"
+version = "2.9.2"
 description = "SSH2 protocol library"
 category = "main"
 optional = false
@@ -696,15 +703,14 @@ test = ["mock (>=1.0.1)", "hypothesis (>=3.5.3)", "pytest (>=3.0.3)", "pytest-co
 
 [[package]]
 name = "pynacl"
-version = "1.4.0"
+version = "1.5.0"
 description = "Python binding to the Networking and Cryptography (NaCl) library"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 cffi = ">=1.4.1"
-six = "*"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
@@ -744,11 +750,11 @@ python-versions = "*"
 
 [[package]]
 name = "pyrsistent"
-version = "0.18.0"
+version = "0.18.1"
 description = "Persistent/Functional/Immutable data structures"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [[package]]
 name = "pytest"
@@ -825,7 +831,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
 name = "regex"
-version = "2021.11.10"
+version = "2022.1.18"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -833,7 +839,7 @@ python-versions = "*"
 
 [[package]]
 name = "requests"
-version = "2.26.0"
+version = "2.27.1"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
@@ -906,7 +912,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomlkit"
-version = "0.8.0"
+version = "0.9.2"
 description = "Style preserving TOML library"
 category = "dev"
 optional = false
@@ -953,7 +959,7 @@ python-versions = "*"
 
 [[package]]
 name = "urllib3"
-version = "1.26.7"
+version = "1.26.8"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -1042,7 +1048,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8.0"
-content-hash = "ec43d044ee3a22bb0948422cb6ad7031481e96820fa53b308c798cea7f925793"
+content-hash = "a30995eaebd1a948f8089b3fed70dacccb60241d96c60ece77885e37545e9f66"
 
 [metadata.files]
 aiohttp = [
@@ -1105,8 +1111,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-21.3.0-py2.py3-none-any.whl", hash = "sha256:8f7335278dedd26b58c38e006338242cc0977f06d51579b2b8b87b9b33bff66c"},
-    {file = "attrs-21.3.0.tar.gz", hash = "sha256:50f3c9b216dc9021042f71b392859a773b904ce1a029077f58f6598272432045"},
+    {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
+    {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
 bcrypt = [
     {file = "bcrypt-3.2.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c95d4cbebffafcdd28bd28bb4e25b31c50f6da605c81ffd9ad8a3d1b2ab7b1b6"},
@@ -1218,8 +1224,8 @@ chardet = [
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.9.tar.gz", hash = "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"},
-    {file = "charset_normalizer-2.0.9-py3-none-any.whl", hash = "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"},
+    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
 ]
 click = [
     {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
@@ -1254,8 +1260,8 @@ cryptography = [
     {file = "cryptography-3.2.1.tar.gz", hash = "sha256:d3d5e10be0cf2a12214ddee45c6bd203dab435e3d83b4560c03066eda600bfe3"},
 ]
 distro = [
-    {file = "distro-1.6.0-py2.py3-none-any.whl", hash = "sha256:c8713330ab31a034623a9515663ed87696700b55f04556b97c39cd261aa70dc7"},
-    {file = "distro-1.6.0.tar.gz", hash = "sha256:83f5e5a09f9c5f68f60173de572930effbcc0287bb84fdc4426cb4168c088424"},
+    {file = "distro-1.7.0-py3-none-any.whl", hash = "sha256:d596311d707e692c2160c37807f83e3820c5d539d5a83e87cfb6babd8ba3a06b"},
+    {file = "distro-1.7.0.tar.gz", hash = "sha256:151aeccf60c216402932b52e40ee477a939f8d58898927378a02abbe852c1c39"},
 ]
 docker = [
     {file = "docker-5.0.3-py2.py3-none-any.whl", hash = "sha256:7a79bb439e3df59d0a72621775d600bc8bc8b422d285824cb37103eab91d1ce0"},
@@ -1272,8 +1278,8 @@ docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},
 ]
 dpath = [
-    {file = "dpath-2.0.5-py3-none-any.whl", hash = "sha256:e7813fd8a9dd0d4c7cd4014533ce955eff712bcb2e8189be79bb893890a9db01"},
-    {file = "dpath-2.0.5.tar.gz", hash = "sha256:ef74321b01479653c812fee69c53922364614d266a8e804d22058c5c02e5674e"},
+    {file = "dpath-2.0.6-py3-none-any.whl", hash = "sha256:8c439bb1c3b3222427e9b8812701cd99a0ef3415ddbb7c03a2379f6989a03965"},
+    {file = "dpath-2.0.6.tar.gz", hash = "sha256:5a1ddae52233fbc8ef81b15fb85073a81126bb43698d3f3a1b6aaf561a46cdc0"},
 ]
 fastcore = [
     {file = "fastcore-1.3.27-py3-none-any.whl", hash = "sha256:03c6c93f2c769fdd611e32a7cc1433db5a82f67146d9e2f88e03107db203f6de"},
@@ -1290,13 +1296,10 @@ ghapi = [
     {file = "ghapi-0.1.19-py3-none-any.whl", hash = "sha256:6f18bc621b498e6c530c2fefea3bd7255860a4d2667de6b7a5301cd67057e959"},
     {file = "ghapi-0.1.19.tar.gz", hash = "sha256:d8d7012a6b275c1b691de9854504b11d6c41b36db7002992c2e2d51320f9758b"},
 ]
-goth = [
-    {file = "goth-0.9.0-py3-none-any.whl", hash = "sha256:1ab224c99a8c110ffa654150729cb942680171d64129fa6d859c196909feaa16"},
-    {file = "goth-0.9.0.tar.gz", hash = "sha256:e4952449bacb69fb5d6de33611a468fdb61ead0e663179f1cbd16ca9ec17fa0c"},
-]
+goth = []
 h11 = [
-    {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
-    {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
+    {file = "h11-0.13.0-py3-none-any.whl", hash = "sha256:8ddd78563b633ca55346c8cd41ec0af27d3c79931828beffb46ce70a379e7442"},
+    {file = "h11-0.13.0.tar.gz", hash = "sha256:70813c1135087a248a4d38cc0e1a0181ffab2188141a93eaf567940c3957ff06"},
 ]
 h2 = [
     {file = "h2-4.1.0-py3-none-any.whl", hash = "sha256:03a46bcf682256c95b5fd9e9a99c1323584c3eec6440d379b9903d709476bc6d"},
@@ -1416,78 +1419,65 @@ msgpack = [
     {file = "msgpack-1.0.3.tar.gz", hash = "sha256:51fdc7fb93615286428ee7758cecc2f374d5ff363bdd884c7ea622a7a327a81e"},
 ]
 multidict = [
-    {file = "multidict-5.2.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3822c5894c72e3b35aae9909bef66ec83e44522faf767c0ad39e0e2de11d3b55"},
-    {file = "multidict-5.2.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:28e6d883acd8674887d7edc896b91751dc2d8e87fbdca8359591a13872799e4e"},
-    {file = "multidict-5.2.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b61f85101ef08cbbc37846ac0e43f027f7844f3fade9b7f6dd087178caedeee7"},
-    {file = "multidict-5.2.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d9b668c065968c5979fe6b6fa6760bb6ab9aeb94b75b73c0a9c1acf6393ac3bf"},
-    {file = "multidict-5.2.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:517d75522b7b18a3385726b54a081afd425d4f41144a5399e5abd97ccafdf36b"},
-    {file = "multidict-5.2.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1b4ac3ba7a97b35a5ccf34f41b5a8642a01d1e55454b699e5e8e7a99b5a3acf5"},
-    {file = "multidict-5.2.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:df23c83398715b26ab09574217ca21e14694917a0c857e356fd39e1c64f8283f"},
-    {file = "multidict-5.2.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e58a9b5cc96e014ddf93c2227cbdeca94b56a7eb77300205d6e4001805391747"},
-    {file = "multidict-5.2.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f76440e480c3b2ca7f843ff8a48dc82446b86ed4930552d736c0bac507498a52"},
-    {file = "multidict-5.2.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:cfde464ca4af42a629648c0b0d79b8f295cf5b695412451716531d6916461628"},
-    {file = "multidict-5.2.0-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:0fed465af2e0eb6357ba95795d003ac0bdb546305cc2366b1fc8f0ad67cc3fda"},
-    {file = "multidict-5.2.0-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:b70913cbf2e14275013be98a06ef4b412329fe7b4f83d64eb70dce8269ed1e1a"},
-    {file = "multidict-5.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a5635bcf1b75f0f6ef3c8a1ad07b500104a971e38d3683167b9454cb6465ac86"},
-    {file = "multidict-5.2.0-cp310-cp310-win32.whl", hash = "sha256:77f0fb7200cc7dedda7a60912f2059086e29ff67cefbc58d2506638c1a9132d7"},
-    {file = "multidict-5.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:9416cf11bcd73c861267e88aea71e9fcc35302b3943e45e1dbb4317f91a4b34f"},
-    {file = "multidict-5.2.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fd77c8f3cba815aa69cb97ee2b2ef385c7c12ada9c734b0f3b32e26bb88bbf1d"},
-    {file = "multidict-5.2.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:98ec9aea6223adf46999f22e2c0ab6cf33f5914be604a404f658386a8f1fba37"},
-    {file = "multidict-5.2.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5283c0a00f48e8cafcecadebfa0ed1dac8b39e295c7248c44c665c16dc1138b"},
-    {file = "multidict-5.2.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5f79c19c6420962eb17c7e48878a03053b7ccd7b69f389d5831c0a4a7f1ac0a1"},
-    {file = "multidict-5.2.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e4a67f1080123de76e4e97a18d10350df6a7182e243312426d508712e99988d4"},
-    {file = "multidict-5.2.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:94b117e27efd8e08b4046c57461d5a114d26b40824995a2eb58372b94f9fca02"},
-    {file = "multidict-5.2.0-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:2e77282fd1d677c313ffcaddfec236bf23f273c4fba7cdf198108f5940ae10f5"},
-    {file = "multidict-5.2.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:116347c63ba049c1ea56e157fa8aa6edaf5e92925c9b64f3da7769bdfa012858"},
-    {file = "multidict-5.2.0-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:dc3a866cf6c13d59a01878cd806f219340f3e82eed514485e094321f24900677"},
-    {file = "multidict-5.2.0-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:ac42181292099d91217a82e3fa3ce0e0ddf3a74fd891b7c2b347a7f5aa0edded"},
-    {file = "multidict-5.2.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:f0bb0973f42ffcb5e3537548e0767079420aefd94ba990b61cf7bb8d47f4916d"},
-    {file = "multidict-5.2.0-cp36-cp36m-win32.whl", hash = "sha256:ea21d4d5104b4f840b91d9dc8cbc832aba9612121eaba503e54eaab1ad140eb9"},
-    {file = "multidict-5.2.0-cp36-cp36m-win_amd64.whl", hash = "sha256:e6453f3cbeb78440747096f239d282cc57a2997a16b5197c9bc839099e1633d0"},
-    {file = "multidict-5.2.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d3def943bfd5f1c47d51fd324df1e806d8da1f8e105cc7f1c76a1daf0f7e17b0"},
-    {file = "multidict-5.2.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:35591729668a303a02b06e8dba0eb8140c4a1bfd4c4b3209a436a02a5ac1de11"},
-    {file = "multidict-5.2.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8cacda0b679ebc25624d5de66c705bc53dcc7c6f02a7fb0f3ca5e227d80422"},
-    {file = "multidict-5.2.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:baf1856fab8212bf35230c019cde7c641887e3fc08cadd39d32a421a30151ea3"},
-    {file = "multidict-5.2.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a43616aec0f0d53c411582c451f5d3e1123a68cc7b3475d6f7d97a626f8ff90d"},
-    {file = "multidict-5.2.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:25cbd39a9029b409167aa0a20d8a17f502d43f2efebfe9e3ac019fe6796c59ac"},
-    {file = "multidict-5.2.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:0a2cbcfbea6dc776782a444db819c8b78afe4db597211298dd8b2222f73e9cd0"},
-    {file = "multidict-5.2.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:3d2d7d1fff8e09d99354c04c3fd5b560fb04639fd45926b34e27cfdec678a704"},
-    {file = "multidict-5.2.0-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:a37e9a68349f6abe24130846e2f1d2e38f7ddab30b81b754e5a1fde32f782b23"},
-    {file = "multidict-5.2.0-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:637c1896497ff19e1ee27c1c2c2ddaa9f2d134bbb5e0c52254361ea20486418d"},
-    {file = "multidict-5.2.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:9815765f9dcda04921ba467957be543423e5ec6a1136135d84f2ae092c50d87b"},
-    {file = "multidict-5.2.0-cp37-cp37m-win32.whl", hash = "sha256:8b911d74acdc1fe2941e59b4f1a278a330e9c34c6c8ca1ee21264c51ec9b67ef"},
-    {file = "multidict-5.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:380b868f55f63d048a25931a1632818f90e4be71d2081c2338fcf656d299949a"},
-    {file = "multidict-5.2.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e7d81ce5744757d2f05fc41896e3b2ae0458464b14b5a2c1e87a6a9d69aefaa8"},
-    {file = "multidict-5.2.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2d1d55cdf706ddc62822d394d1df53573d32a7a07d4f099470d3cb9323b721b6"},
-    {file = "multidict-5.2.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:a4771d0d0ac9d9fe9e24e33bed482a13dfc1256d008d101485fe460359476065"},
-    {file = "multidict-5.2.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da7d57ea65744d249427793c042094c4016789eb2562576fb831870f9c878d9e"},
-    {file = "multidict-5.2.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cdd68778f96216596218b4e8882944d24a634d984ee1a5a049b300377878fa7c"},
-    {file = "multidict-5.2.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ecc99bce8ee42dcad15848c7885197d26841cb24fa2ee6e89d23b8993c871c64"},
-    {file = "multidict-5.2.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:067150fad08e6f2dd91a650c7a49ba65085303fcc3decbd64a57dc13a2733031"},
-    {file = "multidict-5.2.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:78c106b2b506b4d895ddc801ff509f941119394b89c9115580014127414e6c2d"},
-    {file = "multidict-5.2.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e6c4fa1ec16e01e292315ba76eb1d012c025b99d22896bd14a66628b245e3e01"},
-    {file = "multidict-5.2.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:b227345e4186809d31f22087d0265655114af7cda442ecaf72246275865bebe4"},
-    {file = "multidict-5.2.0-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:06560fbdcf22c9387100979e65b26fba0816c162b888cb65b845d3def7a54c9b"},
-    {file = "multidict-5.2.0-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:7878b61c867fb2df7a95e44b316f88d5a3742390c99dfba6c557a21b30180cac"},
-    {file = "multidict-5.2.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:246145bff76cc4b19310f0ad28bd0769b940c2a49fc601b86bfd150cbd72bb22"},
-    {file = "multidict-5.2.0-cp38-cp38-win32.whl", hash = "sha256:c30ac9f562106cd9e8071c23949a067b10211917fdcb75b4718cf5775356a940"},
-    {file = "multidict-5.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:f19001e790013ed580abfde2a4465388950728861b52f0da73e8e8a9418533c0"},
-    {file = "multidict-5.2.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c1ff762e2ee126e6f1258650ac641e2b8e1f3d927a925aafcfde943b77a36d24"},
-    {file = "multidict-5.2.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bd6c9c50bf2ad3f0448edaa1a3b55b2e6866ef8feca5d8dbec10ec7c94371d21"},
-    {file = "multidict-5.2.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fc66d4016f6e50ed36fb39cd287a3878ffcebfa90008535c62e0e90a7ab713ae"},
-    {file = "multidict-5.2.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9acb76d5f3dd9421874923da2ed1e76041cb51b9337fd7f507edde1d86535d6"},
-    {file = "multidict-5.2.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dfc924a7e946dd3c6360e50e8f750d51e3ef5395c95dc054bc9eab0f70df4f9c"},
-    {file = "multidict-5.2.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:32fdba7333eb2351fee2596b756d730d62b5827d5e1ab2f84e6cbb287cc67fe0"},
-    {file = "multidict-5.2.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:b9aad49466b8d828b96b9e3630006234879c8d3e2b0a9d99219b3121bc5cdb17"},
-    {file = "multidict-5.2.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:93de39267c4c676c9ebb2057e98a8138bade0d806aad4d864322eee0803140a0"},
-    {file = "multidict-5.2.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:f9bef5cff994ca3026fcc90680e326d1a19df9841c5e3d224076407cc21471a1"},
-    {file = "multidict-5.2.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:5f841c4f14331fd1e36cbf3336ed7be2cb2a8f110ce40ea253e5573387db7621"},
-    {file = "multidict-5.2.0-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:38ba256ee9b310da6a1a0f013ef4e422fca30a685bcbec86a969bd520504e341"},
-    {file = "multidict-5.2.0-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:3bc3b1621b979621cee9f7b09f024ec76ec03cc365e638126a056317470bde1b"},
-    {file = "multidict-5.2.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6ee908c070020d682e9b42c8f621e8bb10c767d04416e2ebe44e37d0f44d9ad5"},
-    {file = "multidict-5.2.0-cp39-cp39-win32.whl", hash = "sha256:1c7976cd1c157fa7ba5456ae5d31ccdf1479680dc9b8d8aa28afabc370df42b8"},
-    {file = "multidict-5.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:c9631c642e08b9fff1c6255487e62971d8b8e821808ddd013d8ac058087591ac"},
-    {file = "multidict-5.2.0.tar.gz", hash = "sha256:0dd1c93edb444b33ba2274b66f63def8a327d607c6c790772f448a53b6ea59ce"},
+    {file = "multidict-6.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b9e95a740109c6047602f4db4da9949e6c5945cefbad34a1299775ddc9a62e2"},
+    {file = "multidict-6.0.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ac0e27844758d7177989ce406acc6a83c16ed4524ebc363c1f748cba184d89d3"},
+    {file = "multidict-6.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:041b81a5f6b38244b34dc18c7b6aba91f9cdaf854d9a39e5ff0b58e2b5773b9c"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5fdda29a3c7e76a064f2477c9aab1ba96fd94e02e386f1e665bca1807fc5386f"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3368bf2398b0e0fcbf46d85795adc4c259299fec50c1416d0f77c0a843a3eed9"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f4f052ee022928d34fe1f4d2bc743f32609fb79ed9c49a1710a5ad6b2198db20"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:225383a6603c086e6cef0f2f05564acb4f4d5f019a4e3e983f572b8530f70c88"},
+    {file = "multidict-6.0.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:50bd442726e288e884f7be9071016c15a8742eb689a593a0cac49ea093eef0a7"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:47e6a7e923e9cada7c139531feac59448f1f47727a79076c0b1ee80274cd8eee"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:0556a1d4ea2d949efe5fd76a09b4a82e3a4a30700553a6725535098d8d9fb672"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:626fe10ac87851f4cffecee161fc6f8f9853f0f6f1035b59337a51d29ff3b4f9"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:8064b7c6f0af936a741ea1efd18690bacfbae4078c0c385d7c3f611d11f0cf87"},
+    {file = "multidict-6.0.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2d36e929d7f6a16d4eb11b250719c39560dd70545356365b494249e2186bc389"},
+    {file = "multidict-6.0.2-cp310-cp310-win32.whl", hash = "sha256:fcb91630817aa8b9bc4a74023e4198480587269c272c58b3279875ed7235c293"},
+    {file = "multidict-6.0.2-cp310-cp310-win_amd64.whl", hash = "sha256:8cbf0132f3de7cc6c6ce00147cc78e6439ea736cee6bca4f068bcf892b0fd658"},
+    {file = "multidict-6.0.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:05f6949d6169878a03e607a21e3b862eaf8e356590e8bdae4227eedadacf6e51"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e2c2e459f7050aeb7c1b1276763364884595d47000c1cddb51764c0d8976e608"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d0509e469d48940147e1235d994cd849a8f8195e0bca65f8f5439c56e17872a3"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:514fe2b8d750d6cdb4712346a2c5084a80220821a3e91f3f71eec11cf8d28fd4"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:19adcfc2a7197cdc3987044e3f415168fc5dc1f720c932eb1ef4f71a2067e08b"},
+    {file = "multidict-6.0.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9d153e7f1f9ba0b23ad1568b3b9e17301e23b042c23870f9ee0522dc5cc79e8"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:aef9cc3d9c7d63d924adac329c33835e0243b5052a6dfcbf7732a921c6e918ba"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:4571f1beddff25f3e925eea34268422622963cd8dc395bb8778eb28418248e43"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:d48b8ee1d4068561ce8033d2c344cf5232cb29ee1a0206a7b828c79cbc5982b8"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:45183c96ddf61bf96d2684d9fbaf6f3564d86b34cb125761f9a0ef9e36c1d55b"},
+    {file = "multidict-6.0.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:75bdf08716edde767b09e76829db8c1e5ca9d8bb0a8d4bd94ae1eafe3dac5e15"},
+    {file = "multidict-6.0.2-cp37-cp37m-win32.whl", hash = "sha256:a45e1135cb07086833ce969555df39149680e5471c04dfd6a915abd2fc3f6dbc"},
+    {file = "multidict-6.0.2-cp37-cp37m-win_amd64.whl", hash = "sha256:6f3cdef8a247d1eafa649085812f8a310e728bdf3900ff6c434eafb2d443b23a"},
+    {file = "multidict-6.0.2-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:0327292e745a880459ef71be14e709aaea2f783f3537588fb4ed09b6c01bca60"},
+    {file = "multidict-6.0.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e875b6086e325bab7e680e4316d667fc0e5e174bb5611eb16b3ea121c8951b86"},
+    {file = "multidict-6.0.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:feea820722e69451743a3d56ad74948b68bf456984d63c1a92e8347b7b88452d"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc57c68cb9139c7cd6fc39f211b02198e69fb90ce4bc4a094cf5fe0d20fd8b0"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:497988d6b6ec6ed6f87030ec03280b696ca47dbf0648045e4e1d28b80346560d"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:89171b2c769e03a953d5969b2f272efa931426355b6c0cb508022976a17fd376"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:684133b1e1fe91eda8fa7447f137c9490a064c6b7f392aa857bba83a28cfb693"},
+    {file = "multidict-6.0.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd9fc9c4849a07f3635ccffa895d57abce554b467d611a5009ba4f39b78a8849"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e07c8e79d6e6fd37b42f3250dba122053fddb319e84b55dd3a8d6446e1a7ee49"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:4070613ea2227da2bfb2c35a6041e4371b0af6b0be57f424fe2318b42a748516"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:47fbeedbf94bed6547d3aa632075d804867a352d86688c04e606971595460227"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:5774d9218d77befa7b70d836004a768fb9aa4fdb53c97498f4d8d3f67bb9cfa9"},
+    {file = "multidict-6.0.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2957489cba47c2539a8eb7ab32ff49101439ccf78eab724c828c1a54ff3ff98d"},
+    {file = "multidict-6.0.2-cp38-cp38-win32.whl", hash = "sha256:e5b20e9599ba74391ca0cfbd7b328fcc20976823ba19bc573983a25b32e92b57"},
+    {file = "multidict-6.0.2-cp38-cp38-win_amd64.whl", hash = "sha256:8004dca28e15b86d1b1372515f32eb6f814bdf6f00952699bdeb541691091f96"},
+    {file = "multidict-6.0.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2e4a0785b84fb59e43c18a015ffc575ba93f7d1dbd272b4cdad9f5134b8a006c"},
+    {file = "multidict-6.0.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:6701bf8a5d03a43375909ac91b6980aea74b0f5402fbe9428fc3f6edf5d9677e"},
+    {file = "multidict-6.0.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a007b1638e148c3cfb6bf0bdc4f82776cef0ac487191d093cdc316905e504071"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:07a017cfa00c9890011628eab2503bee5872f27144936a52eaab449be5eaf032"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c207fff63adcdf5a485969131dc70e4b194327666b7e8a87a97fbc4fd80a53b2"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:373ba9d1d061c76462d74e7de1c0c8e267e9791ee8cfefcf6b0b2495762c370c"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfba7c6d5d7c9099ba21f84662b037a0ffd4a5e6b26ac07d19e423e6fdf965a9"},
+    {file = "multidict-6.0.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19d9bad105dfb34eb539c97b132057a4e709919ec4dd883ece5838bcbf262b80"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:de989b195c3d636ba000ee4281cd03bb1234635b124bf4cd89eeee9ca8fcb09d"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7c40b7bbece294ae3a87c1bc2abff0ff9beef41d14188cda94ada7bcea99b0fb"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:d16cce709ebfadc91278a1c005e3c17dd5f71f5098bfae1035149785ea6e9c68"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:a2c34a93e1d2aa35fbf1485e5010337c72c6791407d03aa5f4eed920343dd360"},
+    {file = "multidict-6.0.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:feba80698173761cddd814fa22e88b0661e98cb810f9f986c54aa34d281e4937"},
+    {file = "multidict-6.0.2-cp39-cp39-win32.whl", hash = "sha256:23b616fdc3c74c9fe01d76ce0d1ce872d2d396d8fa8e4899398ad64fb5aa214a"},
+    {file = "multidict-6.0.2-cp39-cp39-win_amd64.whl", hash = "sha256:4bae31803d708f6f15fd98be6a6ac0b6958fcf68fda3c77a048a4f9073704aae"},
+    {file = "multidict-6.0.2.tar.gz", hash = "sha256:5ff3bd75f38e4c43f1f470f2df7a4d430b821c4ce22be384e1459cb57d6bb013"},
 ]
 mypy = [
     {file = "mypy-0.782-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:2c6cde8aa3426c1682d35190b59b71f661237d74b053822ea3d748e2c9578a7c"},
@@ -1514,8 +1504,8 @@ packaging = [
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 paramiko = [
-    {file = "paramiko-2.9.1-py2.py3-none-any.whl", hash = "sha256:db5d3f19607941b1c90233588d60213c874392c4961c6297037da989c24f8070"},
-    {file = "paramiko-2.9.1.tar.gz", hash = "sha256:a1fdded3b55f61d23389e4fe52d9ae428960ac958d2edf50373faa5d8926edd0"},
+    {file = "paramiko-2.9.2-py2.py3-none-any.whl", hash = "sha256:04097dbd96871691cdb34c13db1883066b8a13a0df2afd4cb0a92221f51c2603"},
+    {file = "paramiko-2.9.2.tar.gz", hash = "sha256:944a9e5dbdd413ab6c7951ea46b0ab40713235a9c4c5ca81cfe45c6f14fa677b"},
 ]
 passlib = [
     {file = "passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1"},
@@ -1589,24 +1579,16 @@ pydivert = [
     {file = "pydivert-2.1.0.tar.gz", hash = "sha256:f0e150f4ff591b78e35f514e319561dadff7f24a82186a171dd4d465483de5b4"},
 ]
 pynacl = [
-    {file = "PyNaCl-1.4.0-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:ea6841bc3a76fa4942ce00f3bda7d436fda21e2d91602b9e21b7ca9ecab8f3ff"},
-    {file = "PyNaCl-1.4.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:d452a6746f0a7e11121e64625109bc4468fc3100452817001dbe018bb8b08514"},
-    {file = "PyNaCl-1.4.0-cp27-cp27m-win32.whl", hash = "sha256:2fe0fc5a2480361dcaf4e6e7cea00e078fcda07ba45f811b167e3f99e8cff574"},
-    {file = "PyNaCl-1.4.0-cp27-cp27m-win_amd64.whl", hash = "sha256:f8851ab9041756003119368c1e6cd0b9c631f46d686b3904b18c0139f4419f80"},
-    {file = "PyNaCl-1.4.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:7757ae33dae81c300487591c68790dfb5145c7d03324000433d9a2c141f82af7"},
-    {file = "PyNaCl-1.4.0-cp35-abi3-macosx_10_10_x86_64.whl", hash = "sha256:757250ddb3bff1eecd7e41e65f7f833a8405fede0194319f87899690624f2122"},
-    {file = "PyNaCl-1.4.0-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:30f9b96db44e09b3304f9ea95079b1b7316b2b4f3744fe3aaecccd95d547063d"},
-    {file = "PyNaCl-1.4.0-cp35-abi3-win32.whl", hash = "sha256:4e10569f8cbed81cb7526ae137049759d2a8d57726d52c1a000a3ce366779634"},
-    {file = "PyNaCl-1.4.0-cp35-abi3-win_amd64.whl", hash = "sha256:c914f78da4953b33d4685e3cdc7ce63401247a21425c16a39760e282075ac4a6"},
-    {file = "PyNaCl-1.4.0-cp35-cp35m-win32.whl", hash = "sha256:06cbb4d9b2c4bd3c8dc0d267416aaed79906e7b33f114ddbf0911969794b1cc4"},
-    {file = "PyNaCl-1.4.0-cp35-cp35m-win_amd64.whl", hash = "sha256:511d269ee845037b95c9781aa702f90ccc36036f95d0f31373a6a79bd8242e25"},
-    {file = "PyNaCl-1.4.0-cp36-cp36m-win32.whl", hash = "sha256:11335f09060af52c97137d4ac54285bcb7df0cef29014a1a4efe64ac065434c4"},
-    {file = "PyNaCl-1.4.0-cp36-cp36m-win_amd64.whl", hash = "sha256:cd401ccbc2a249a47a3a1724c2918fcd04be1f7b54eb2a5a71ff915db0ac51c6"},
-    {file = "PyNaCl-1.4.0-cp37-cp37m-win32.whl", hash = "sha256:8122ba5f2a2169ca5da936b2e5a511740ffb73979381b4229d9188f6dcb22f1f"},
-    {file = "PyNaCl-1.4.0-cp37-cp37m-win_amd64.whl", hash = "sha256:537a7ccbea22905a0ab36ea58577b39d1fa9b1884869d173b5cf111f006f689f"},
-    {file = "PyNaCl-1.4.0-cp38-cp38-win32.whl", hash = "sha256:9c4a7ea4fb81536c1b1f5cc44d54a296f96ae78c1ebd2311bd0b60be45a48d96"},
-    {file = "PyNaCl-1.4.0-cp38-cp38-win_amd64.whl", hash = "sha256:7c6092102219f59ff29788860ccb021e80fffd953920c4a8653889c029b2d420"},
-    {file = "PyNaCl-1.4.0.tar.gz", hash = "sha256:54e9a2c849c742006516ad56a88f5c74bf2ce92c9f67435187c3c5953b346505"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:401002a4aaa07c9414132aaed7f6836ff98f59277a234704ff66878c2ee4a0d1"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:52cb72a79269189d4e0dc537556f4740f7f0a9ec41c1322598799b0bdad4ef92"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a36d4a9dda1f19ce6e03c9a784a2921a4b726b02e1c736600ca9c22029474394"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:0c84947a22519e013607c9be43706dd42513f9e6ae5d39d3613ca1e142fba44d"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06b8f6fa7f5de8d5d2f7573fe8c863c051225a27b61e6860fd047b1775807858"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:a422368fc821589c228f4c49438a368831cb5bbc0eab5ebe1d7fac9dded6567b"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:61f642bf2378713e2c2e1de73444a3778e5f0a38be6fee0fe532fe30060282ff"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-win32.whl", hash = "sha256:e46dae94e34b085175f8abb3b0aaa7da40767865ac82c928eeb9e57e1ea8a543"},
+    {file = "PyNaCl-1.5.0-cp36-abi3-win_amd64.whl", hash = "sha256:20f42270d27e1b6a29f54032090b972d97f0a1b0948cc52392041ef7831fee93"},
+    {file = "PyNaCl-1.5.0.tar.gz", hash = "sha256:8ac7448f09ab85811607bdd21ec2464495ac8b7c66d146bf545b0f08fb9220ba"},
 ]
 pyopenssl = [
     {file = "pyOpenSSL-19.1.0-py2.py3-none-any.whl", hash = "sha256:621880965a720b8ece2f1b2f54ea2071966ab00e2970ad2ce11d596102063504"},
@@ -1620,27 +1602,27 @@ pyperclip = [
     {file = "pyperclip-1.8.2.tar.gz", hash = "sha256:105254a8b04934f0bc84e9c24eb360a591aaf6535c9def5f29d92af107a9bf57"},
 ]
 pyrsistent = [
-    {file = "pyrsistent-0.18.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:da6e5e818d18459fa46fac0a4a4e543507fe1110e808101277c5a2b5bab0cd2d"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5e4395bbf841693eaebaa5bb5c8f5cdbb1d139e07c975c682ec4e4f8126e03d2"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-win32.whl", hash = "sha256:527be2bfa8dc80f6f8ddd65242ba476a6c4fb4e3aedbf281dfbac1b1ed4165b1"},
-    {file = "pyrsistent-0.18.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2aaf19dc8ce517a8653746d98e962ef480ff34b6bc563fc067be6401ffb457c7"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:58a70d93fb79dc585b21f9d72487b929a6fe58da0754fa4cb9f279bb92369396"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4916c10896721e472ee12c95cdc2891ce5890898d2f9907b1b4ae0f53588b710"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:73ff61b1411e3fb0ba144b8f08d6749749775fe89688093e1efef9839d2dcc35"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-win32.whl", hash = "sha256:b29b869cf58412ca5738d23691e96d8aff535e17390128a1a52717c9a109da4f"},
-    {file = "pyrsistent-0.18.0-cp37-cp37m-win_amd64.whl", hash = "sha256:097b96f129dd36a8c9e33594e7ebb151b1515eb52cceb08474c10a5479e799f2"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:772e94c2c6864f2cd2ffbe58bb3bdefbe2a32afa0acb1a77e472aac831f83427"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c1a9ff320fa699337e05edcaae79ef8c2880b52720bc031b219e5b5008ebbdef"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cd3caef37a415fd0dae6148a1b6957a8c5f275a62cca02e18474608cb263640c"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-win32.whl", hash = "sha256:e79d94ca58fcafef6395f6352383fa1a76922268fa02caa2272fff501c2fdc78"},
-    {file = "pyrsistent-0.18.0-cp38-cp38-win_amd64.whl", hash = "sha256:a0c772d791c38bbc77be659af29bb14c38ced151433592e326361610250c605b"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d5ec194c9c573aafaceebf05fc400656722793dac57f254cd4741f3c27ae57b4"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:6b5eed00e597b5b5773b4ca30bd48a5774ef1e96f2a45d105db5b4ebb4bca680"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:48578680353f41dca1ca3dc48629fb77dfc745128b56fc01096b2530c13fd426"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-win32.whl", hash = "sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b"},
-    {file = "pyrsistent-0.18.0-cp39-cp39-win_amd64.whl", hash = "sha256:404e1f1d254d314d55adb8d87f4f465c8693d6f902f67eb6ef5b4526dc58e6ea"},
-    {file = "pyrsistent-0.18.0.tar.gz", hash = "sha256:773c781216f8c2900b42a7b638d5b517bb134ae1acbebe4d1e8f1f41ea60eb4b"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ed6784ceac462a7d6fcb7e9b663e93b9a6fb373b7f43594f9ff68875788e01e"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win32.whl", hash = "sha256:e4f3149fd5eb9b285d6bfb54d2e5173f6a116fe19172686797c056672689daf6"},
+    {file = "pyrsistent-0.18.1-cp310-cp310-win_amd64.whl", hash = "sha256:636ce2dc235046ccd3d8c56a7ad54e99d5c1cd0ef07d9ae847306c91d11b5fec"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e92a52c166426efbe0d1ec1332ee9119b6d32fc1f0bbfd55d5c1088070e7fc1b"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7a096646eab884bf8bed965bad63ea327e0d0c38989fc83c5ea7b8a87037bfc"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cdfd2c361b8a8e5d9499b9082b501c452ade8bbf42aef97ea04854f4a3f43b22"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win32.whl", hash = "sha256:7ec335fc998faa4febe75cc5268a9eac0478b3f681602c1f27befaf2a1abe1d8"},
+    {file = "pyrsistent-0.18.1-cp37-cp37m-win_amd64.whl", hash = "sha256:6455fc599df93d1f60e1c5c4fe471499f08d190d57eca040c0ea182301321286"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:fd8da6d0124efa2f67d86fa70c851022f87c98e205f0594e1fae044e7119a5a6"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bfe2388663fd18bd8ce7db2c91c7400bf3e1a9e8bd7d63bf7e77d39051b85ec"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e3e1fcc45199df76053026a51cc59ab2ea3fc7c094c6627e93b7b44cdae2c8c"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win32.whl", hash = "sha256:b568f35ad53a7b07ed9b1b2bae09eb15cdd671a5ba5d2c66caee40dbf91c68ca"},
+    {file = "pyrsistent-0.18.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1b96547410f76078eaf66d282ddca2e4baae8964364abb4f4dcdde855cd123a"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:f87cc2863ef33c709e237d4b5f4502a62a00fab450c9e020892e8e2ede5847f5"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bc66318fb7ee012071b2792024564973ecc80e9522842eb4e17743604b5e045"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:914474c9f1d93080338ace89cb2acee74f4f666fb0424896fcfb8d86058bf17c"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win32.whl", hash = "sha256:1b34eedd6812bf4d33814fca1b66005805d3640ce53140ab8bbb1e2651b0d9bc"},
+    {file = "pyrsistent-0.18.1-cp39-cp39-win_amd64.whl", hash = "sha256:e24a828f57e0c337c8d8bb9f6b12f09dfdf0273da25fda9e314f0b684b415a07"},
+    {file = "pyrsistent-0.18.1.tar.gz", hash = "sha256:d4d61f8b993a7255ba714df3aca52700f8125289f84f704cf80916517c46eb96"},
 ]
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
@@ -1704,84 +1686,84 @@ pyyaml = [
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 regex = [
-    {file = "regex-2021.11.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9345b6f7ee578bad8e475129ed40123d265464c4cfead6c261fd60fc9de00bcf"},
-    {file = "regex-2021.11.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:416c5f1a188c91e3eb41e9c8787288e707f7d2ebe66e0a6563af280d9b68478f"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0538c43565ee6e703d3a7c3bdfe4037a5209250e8502c98f20fea6f5fdf2965"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7ee1227cf08b6716c85504aebc49ac827eb88fcc6e51564f010f11a406c0a667"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6650f16365f1924d6014d2ea770bde8555b4a39dc9576abb95e3cd1ff0263b36"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:30ab804ea73972049b7a2a5c62d97687d69b5a60a67adca07eb73a0ddbc9e29f"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:68a067c11463de2a37157930d8b153005085e42bcb7ad9ca562d77ba7d1404e0"},
-    {file = "regex-2021.11.10-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:162abfd74e88001d20cb73ceaffbfe601469923e875caf9118333b1a4aaafdc4"},
-    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:b9ed0b1e5e0759d6b7f8e2f143894b2a7f3edd313f38cf44e1e15d360e11749b"},
-    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:473e67837f786404570eae33c3b64a4b9635ae9f00145250851a1292f484c063"},
-    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:2fee3ed82a011184807d2127f1733b4f6b2ff6ec7151d83ef3477f3b96a13d03"},
-    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:d5fd67df77bab0d3f4ea1d7afca9ef15c2ee35dfb348c7b57ffb9782a6e4db6e"},
-    {file = "regex-2021.11.10-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5d408a642a5484b9b4d11dea15a489ea0928c7e410c7525cd892f4d04f2f617b"},
-    {file = "regex-2021.11.10-cp310-cp310-win32.whl", hash = "sha256:98ba568e8ae26beb726aeea2273053c717641933836568c2a0278a84987b2a1a"},
-    {file = "regex-2021.11.10-cp310-cp310-win_amd64.whl", hash = "sha256:780b48456a0f0ba4d390e8b5f7c661fdd218934388cde1a974010a965e200e12"},
-    {file = "regex-2021.11.10-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:dba70f30fd81f8ce6d32ddeef37d91c8948e5d5a4c63242d16a2b2df8143aafc"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1f54b9b4b6c53369f40028d2dd07a8c374583417ee6ec0ea304e710a20f80a0"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fbb9dc00e39f3e6c0ef48edee202f9520dafb233e8b51b06b8428cfcb92abd30"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:666abff54e474d28ff42756d94544cdfd42e2ee97065857413b72e8a2d6a6345"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5537f71b6d646f7f5f340562ec4c77b6e1c915f8baae822ea0b7e46c1f09b733"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ed2e07c6a26ed4bea91b897ee2b0835c21716d9a469a96c3e878dc5f8c55bb23"},
-    {file = "regex-2021.11.10-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ca5f18a75e1256ce07494e245cdb146f5a9267d3c702ebf9b65c7f8bd843431e"},
-    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:74cbeac0451f27d4f50e6e8a8f3a52ca074b5e2da9f7b505c4201a57a8ed6286"},
-    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:3598893bde43091ee5ca0a6ad20f08a0435e93a69255eeb5f81b85e81e329264"},
-    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:50a7ddf3d131dc5633dccdb51417e2d1910d25cbcf842115a3a5893509140a3a"},
-    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:61600a7ca4bcf78a96a68a27c2ae9389763b5b94b63943d5158f2a377e09d29a"},
-    {file = "regex-2021.11.10-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:563d5f9354e15e048465061509403f68424fef37d5add3064038c2511c8f5e00"},
-    {file = "regex-2021.11.10-cp36-cp36m-win32.whl", hash = "sha256:93a5051fcf5fad72de73b96f07d30bc29665697fb8ecdfbc474f3452c78adcf4"},
-    {file = "regex-2021.11.10-cp36-cp36m-win_amd64.whl", hash = "sha256:b483c9d00a565633c87abd0aaf27eb5016de23fed952e054ecc19ce32f6a9e7e"},
-    {file = "regex-2021.11.10-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fff55f3ce50a3ff63ec8e2a8d3dd924f1941b250b0aac3d3d42b687eeff07a8e"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e32d2a2b02ccbef10145df9135751abea1f9f076e67a4e261b05f24b94219e36"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53db2c6be8a2710b359bfd3d3aa17ba38f8aa72a82309a12ae99d3c0c3dcd74d"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2207ae4f64ad3af399e2d30dde66f0b36ae5c3129b52885f1bffc2f05ec505c8"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5ca078bb666c4a9d1287a379fe617a6dccd18c3e8a7e6c7e1eb8974330c626a"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dd33eb9bdcfbabab3459c9ee651d94c842bc8a05fabc95edf4ee0c15a072495e"},
-    {file = "regex-2021.11.10-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05b7d6d7e64efe309972adab77fc2af8907bb93217ec60aa9fe12a0dad35874f"},
-    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:42b50fa6666b0d50c30a990527127334d6b96dd969011e843e726a64011485da"},
-    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:6e1d2cc79e8dae442b3fa4a26c5794428b98f81389af90623ffcc650ce9f6732"},
-    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:0416f7399e918c4b0e074a0f66e5191077ee2ca32a0f99d4c187a62beb47aa05"},
-    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:ce298e3d0c65bd03fa65ffcc6db0e2b578e8f626d468db64fdf8457731052942"},
-    {file = "regex-2021.11.10-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dc07f021ee80510f3cd3af2cad5b6a3b3a10b057521d9e6aaeb621730d320c5a"},
-    {file = "regex-2021.11.10-cp37-cp37m-win32.whl", hash = "sha256:e71255ba42567d34a13c03968736c5d39bb4a97ce98188fafb27ce981115beec"},
-    {file = "regex-2021.11.10-cp37-cp37m-win_amd64.whl", hash = "sha256:07856afef5ffcc052e7eccf3213317fbb94e4a5cd8177a2caa69c980657b3cb4"},
-    {file = "regex-2021.11.10-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ba05430e819e58544e840a68b03b28b6d328aff2e41579037e8bab7653b37d83"},
-    {file = "regex-2021.11.10-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7f301b11b9d214f83ddaf689181051e7f48905568b0c7017c04c06dfd065e244"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aaa4e0705ef2b73dd8e36eeb4c868f80f8393f5f4d855e94025ce7ad8525f50"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:788aef3549f1924d5c38263104dae7395bf020a42776d5ec5ea2b0d3d85d6646"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f8af619e3be812a2059b212064ea7a640aff0568d972cd1b9e920837469eb3cb"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:85bfa6a5413be0ee6c5c4a663668a2cad2cbecdee367630d097d7823041bdeec"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f23222527b307970e383433daec128d769ff778d9b29343fb3496472dc20dabe"},
-    {file = "regex-2021.11.10-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:da1a90c1ddb7531b1d5ff1e171b4ee61f6345119be7351104b67ff413843fe94"},
-    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:f5be7805e53dafe94d295399cfbe5227f39995a997f4fd8539bf3cbdc8f47ca8"},
-    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:a955b747d620a50408b7fdf948e04359d6e762ff8a85f5775d907ceced715129"},
-    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:139a23d1f5d30db2cc6c7fd9c6d6497872a672db22c4ae1910be22d4f4b2068a"},
-    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:ca49e1ab99593438b204e00f3970e7a5f70d045267051dfa6b5f4304fcfa1dbf"},
-    {file = "regex-2021.11.10-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:96fc32c16ea6d60d3ca7f63397bff5c75c5a562f7db6dec7d412f7c4d2e78ec0"},
-    {file = "regex-2021.11.10-cp38-cp38-win32.whl", hash = "sha256:0617383e2fe465732af4509e61648b77cbe3aee68b6ac8c0b6fe934db90be5cc"},
-    {file = "regex-2021.11.10-cp38-cp38-win_amd64.whl", hash = "sha256:a3feefd5e95871872673b08636f96b61ebef62971eab044f5124fb4dea39919d"},
-    {file = "regex-2021.11.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f7f325be2804246a75a4f45c72d4ce80d2443ab815063cdf70ee8fb2ca59ee1b"},
-    {file = "regex-2021.11.10-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:537ca6a3586931b16a85ac38c08cc48f10fc870a5b25e51794c74df843e9966d"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eef2afb0fd1747f33f1ee3e209bce1ed582d1896b240ccc5e2697e3275f037c7"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:432bd15d40ed835a51617521d60d0125867f7b88acf653e4ed994a1f8e4995dc"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b43c2b8a330a490daaef5a47ab114935002b13b3f9dc5da56d5322ff218eeadb"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:962b9a917dd7ceacbe5cd424556914cb0d636001e393b43dc886ba31d2a1e449"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fa8c626d6441e2d04b6ee703ef2d1e17608ad44c7cb75258c09dd42bacdfc64b"},
-    {file = "regex-2021.11.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3c5fb32cc6077abad3bbf0323067636d93307c9fa93e072771cf9a64d1c0f3ef"},
-    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:cd410a1cbb2d297c67d8521759ab2ee3f1d66206d2e4328502a487589a2cb21b"},
-    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e6096b0688e6e14af6a1b10eaad86b4ff17935c49aa774eac7c95a57a4e8c296"},
-    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:529801a0d58809b60b3531ee804d3e3be4b412c94b5d267daa3de7fadef00f49"},
-    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:0f594b96fe2e0821d026365f72ac7b4f0b487487fb3d4aaf10dd9d97d88a9737"},
-    {file = "regex-2021.11.10-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2409b5c9cef7054dde93a9803156b411b677affc84fca69e908b1cb2c540025d"},
-    {file = "regex-2021.11.10-cp39-cp39-win32.whl", hash = "sha256:3b5df18db1fccd66de15aa59c41e4f853b5df7550723d26aa6cb7f40e5d9da5a"},
-    {file = "regex-2021.11.10-cp39-cp39-win_amd64.whl", hash = "sha256:83ee89483672b11f8952b158640d0c0ff02dc43d9cb1b70c1564b49abe92ce29"},
-    {file = "regex-2021.11.10.tar.gz", hash = "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6"},
+    {file = "regex-2022.1.18-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:34316bf693b1d2d29c087ee7e4bb10cdfa39da5f9c50fa15b07489b4ab93a1b5"},
+    {file = "regex-2022.1.18-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7a0b9f6a1a15d494b35f25ed07abda03209fa76c33564c09c9e81d34f4b919d7"},
+    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f99112aed4fb7cee00c7f77e8b964a9b10f69488cdff626ffd797d02e2e4484f"},
+    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a2bf98ac92f58777c0fafc772bf0493e67fcf677302e0c0a630ee517a43b949"},
+    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8618d9213a863c468a865e9d2ec50221015f7abf52221bc927152ef26c484b4c"},
+    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b52cc45e71657bc4743a5606d9023459de929b2a198d545868e11898ba1c3f59"},
+    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e12949e5071c20ec49ef00c75121ed2b076972132fc1913ddf5f76cae8d10b4"},
+    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b02e3e72665cd02afafb933453b0c9f6c59ff6e3708bd28d0d8580450e7e88af"},
+    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:abfcb0ef78df0ee9df4ea81f03beea41849340ce33a4c4bd4dbb99e23ec781b6"},
+    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6213713ac743b190ecbf3f316d6e41d099e774812d470422b3a0f137ea635832"},
+    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:61ebbcd208d78658b09e19c78920f1ad38936a0aa0f9c459c46c197d11c580a0"},
+    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:b013f759cd69cb0a62de954d6d2096d648bc210034b79b1881406b07ed0a83f9"},
+    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9187500d83fd0cef4669385cbb0961e227a41c0c9bc39219044e35810793edf7"},
+    {file = "regex-2022.1.18-cp310-cp310-win32.whl", hash = "sha256:94c623c331a48a5ccc7d25271399aff29729fa202c737ae3b4b28b89d2b0976d"},
+    {file = "regex-2022.1.18-cp310-cp310-win_amd64.whl", hash = "sha256:1a171eaac36a08964d023eeff740b18a415f79aeb212169080c170ec42dd5184"},
+    {file = "regex-2022.1.18-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:49810f907dfe6de8da5da7d2b238d343e6add62f01a15d03e2195afc180059ed"},
+    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d2f5c3f7057530afd7b739ed42eb04f1011203bc5e4663e1e1d01bb50f813e3"},
+    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:85ffd6b1cb0dfb037ede50ff3bef80d9bf7fa60515d192403af6745524524f3b"},
+    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba37f11e1d020969e8a779c06b4af866ffb6b854d7229db63c5fdddfceaa917f"},
+    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637e27ea1ebe4a561db75a880ac659ff439dec7f55588212e71700bb1ddd5af9"},
+    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:37978254d9d00cda01acc1997513f786b6b971e57b778fbe7c20e30ae81a97f3"},
+    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e54a1eb9fd38f2779e973d2f8958fd575b532fe26013405d1afb9ee2374e7ab8"},
+    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:768632fd8172ae03852e3245f11c8a425d95f65ff444ce46b3e673ae5b057b74"},
+    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:de2923886b5d3214be951bc2ce3f6b8ac0d6dfd4a0d0e2a4d2e5523d8046fdfb"},
+    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:1333b3ce73269f986b1fa4d5d395643810074dc2de5b9d262eb258daf37dc98f"},
+    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:d19a34f8a3429bd536996ad53597b805c10352a8561d8382e05830df389d2b43"},
+    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d2f355a951f60f0843f2368b39970e4667517e54e86b1508e76f92b44811a8a"},
+    {file = "regex-2022.1.18-cp36-cp36m-win32.whl", hash = "sha256:2245441445099411b528379dee83e56eadf449db924648e5feb9b747473f42e3"},
+    {file = "regex-2022.1.18-cp36-cp36m-win_amd64.whl", hash = "sha256:25716aa70a0d153cd844fe861d4f3315a6ccafce22b39d8aadbf7fcadff2b633"},
+    {file = "regex-2022.1.18-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7e070d3aef50ac3856f2ef5ec7214798453da878bb5e5a16c16a61edf1817cc3"},
+    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22709d701e7037e64dae2a04855021b62efd64a66c3ceed99dfd684bfef09e38"},
+    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9099bf89078675c372339011ccfc9ec310310bf6c292b413c013eb90ffdcafc"},
+    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04611cc0f627fc4a50bc4a9a2e6178a974c6a6a4aa9c1cca921635d2c47b9c87"},
+    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:552a39987ac6655dad4bf6f17dd2b55c7b0c6e949d933b8846d2e312ee80005a"},
+    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e031899cb2bc92c0cf4d45389eff5b078d1936860a1be3aa8c94fa25fb46ed8"},
+    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2dacb3dae6b8cc579637a7b72f008bff50a94cde5e36e432352f4ca57b9e54c4"},
+    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:e5c31d70a478b0ca22a9d2d76d520ae996214019d39ed7dd93af872c7f301e52"},
+    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bb804c7d0bfbd7e3f33924ff49757de9106c44e27979e2492819c16972ec0da2"},
+    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:36b2d700a27e168fa96272b42d28c7ac3ff72030c67b32f37c05616ebd22a202"},
+    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:16f81025bb3556eccb0681d7946e2b35ff254f9f888cff7d2120e8826330315c"},
+    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:da80047524eac2acf7c04c18ac7a7da05a9136241f642dd2ed94269ef0d0a45a"},
+    {file = "regex-2022.1.18-cp37-cp37m-win32.whl", hash = "sha256:6ca45359d7a21644793de0e29de497ef7f1ae7268e346c4faf87b421fea364e6"},
+    {file = "regex-2022.1.18-cp37-cp37m-win_amd64.whl", hash = "sha256:38289f1690a7e27aacd049e420769b996826f3728756859420eeee21cc857118"},
+    {file = "regex-2022.1.18-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6014038f52b4b2ac1fa41a58d439a8a00f015b5c0735a0cd4b09afe344c94899"},
+    {file = "regex-2022.1.18-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0b5d6f9aed3153487252d00a18e53f19b7f52a1651bc1d0c4b5844bc286dfa52"},
+    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9d24b03daf7415f78abc2d25a208f234e2c585e5e6f92f0204d2ab7b9ab48e3"},
+    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bf594cc7cc9d528338d66674c10a5b25e3cde7dd75c3e96784df8f371d77a298"},
+    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fd914db437ec25bfa410f8aa0aa2f3ba87cdfc04d9919d608d02330947afaeab"},
+    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90b6840b6448203228a9d8464a7a0d99aa8fa9f027ef95fe230579abaf8a6ee1"},
+    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11772be1eb1748e0e197a40ffb82fb8fd0d6914cd147d841d9703e2bef24d288"},
+    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a602bdc8607c99eb5b391592d58c92618dcd1537fdd87df1813f03fed49957a6"},
+    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:7e26eac9e52e8ce86f915fd33380f1b6896a2b51994e40bb094841e5003429b4"},
+    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:519c0b3a6fbb68afaa0febf0d28f6c4b0a1074aefc484802ecb9709faf181607"},
+    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:3c7ea86b9ca83e30fa4d4cd0eaf01db3ebcc7b2726a25990966627e39577d729"},
+    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:51f02ca184518702975b56affde6c573ebad4e411599005ce4468b1014b4786c"},
+    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:385ccf6d011b97768a640e9d4de25412204fbe8d6b9ae39ff115d4ff03f6fe5d"},
+    {file = "regex-2022.1.18-cp38-cp38-win32.whl", hash = "sha256:1f8c0ae0a0de4e19fddaaff036f508db175f6f03db318c80bbc239a1def62d02"},
+    {file = "regex-2022.1.18-cp38-cp38-win_amd64.whl", hash = "sha256:760c54ad1b8a9b81951030a7e8e7c3ec0964c1cb9fee585a03ff53d9e531bb8e"},
+    {file = "regex-2022.1.18-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:93c20777a72cae8620203ac11c4010365706062aa13aaedd1a21bb07adbb9d5d"},
+    {file = "regex-2022.1.18-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6aa427c55a0abec450bca10b64446331b5ca8f79b648531138f357569705bc4a"},
+    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c38baee6bdb7fe1b110b6b3aaa555e6e872d322206b7245aa39572d3fc991ee4"},
+    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:752e7ddfb743344d447367baa85bccd3629c2c3940f70506eb5f01abce98ee68"},
+    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8acef4d8a4353f6678fd1035422a937c2170de58a2b29f7da045d5249e934101"},
+    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c73d2166e4b210b73d1429c4f1ca97cea9cc090e5302df2a7a0a96ce55373f1c"},
+    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:24c89346734a4e4d60ecf9b27cac4c1fee3431a413f7aa00be7c4d7bbacc2c4d"},
+    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:596f5ae2eeddb79b595583c2e0285312b2783b0ec759930c272dbf02f851ff75"},
+    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ecfe51abf7f045e0b9cdde71ca9e153d11238679ef7b5da6c82093874adf3338"},
+    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:1d6301f5288e9bdca65fab3de6b7de17362c5016d6bf8ee4ba4cbe833b2eda0f"},
+    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:93cce7d422a0093cfb3606beae38a8e47a25232eea0f292c878af580a9dc7605"},
+    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:cf0db26a1f76aa6b3aa314a74b8facd586b7a5457d05b64f8082a62c9c49582a"},
+    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:defa0652696ff0ba48c8aff5a1fac1eef1ca6ac9c660b047fc8e7623c4eb5093"},
+    {file = "regex-2022.1.18-cp39-cp39-win32.whl", hash = "sha256:6db1b52c6f2c04fafc8da17ea506608e6be7086715dab498570c3e55e4f8fbd1"},
+    {file = "regex-2022.1.18-cp39-cp39-win_amd64.whl", hash = "sha256:ebaeb93f90c0903233b11ce913a7cb8f6ee069158406e056f884854c737d2442"},
+    {file = "regex-2022.1.18.tar.gz", hash = "sha256:97f32dc03a8054a4c4a5ab5d761ed4861e828b2c200febd4e46857069a483916"},
 ]
 requests = [
-    {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
-    {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
+    {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
+    {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
 ]
 "ruamel.yaml" = [
     {file = "ruamel.yaml-0.16.13-py2.py3-none-any.whl", hash = "sha256:64b06e7873eb8e1125525ecef7345447d786368cadca92a7cd9b59eae62e95a3"},
@@ -1827,8 +1809,8 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomlkit = [
-    {file = "tomlkit-0.8.0-py3-none-any.whl", hash = "sha256:b824e3466f1d475b2b5f1c392954c6cb7ea04d64354ff7300dc7c14257dc85db"},
-    {file = "tomlkit-0.8.0.tar.gz", hash = "sha256:29e84a855712dfe0e88a48f6d05c21118dbafb283bb2eed614d46f80deb8e9a1"},
+    {file = "tomlkit-0.9.2-py3-none-any.whl", hash = "sha256:daf4f9c5f2fbf6b861d6adfc51940b98dee36c13e1d88749a6dc9fb280fff304"},
+    {file = "tomlkit-0.9.2.tar.gz", hash = "sha256:ebd982d61446af95a1e082b103e250cb9e6d152eae2581d4a07d31a70b34ab0f"},
 ]
 tornado = [
     {file = "tornado-6.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:d371e811d6b156d82aa5f9a4e08b58debf97c302a35714f6f45e35139c332e32"},
@@ -1915,8 +1897,8 @@ typing-extensions = [
     {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
-    {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
+    {file = "urllib3-1.26.8-py2.py3-none-any.whl", hash = "sha256:000ca7f471a233c2251c6c7023ee85305721bfdf18621ebff4fd17a8653427ed"},
+    {file = "urllib3-1.26.8.tar.gz", hash = "sha256:0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c"},
 ]
 urwid = [
     {file = "urwid-2.1.2.tar.gz", hash = "sha256:588bee9c1cb208d0906a9f73c613d2bd32c3ed3702012f51efe318a3f2127eae"},

--- a/goth_tests/pyproject.toml
+++ b/goth_tests/pyproject.toml
@@ -20,7 +20,8 @@ readme = "README.md"
 python = "^3.8.0"
 pytest = "^6.2"
 pytest-asyncio = "^0.14"
-goth = "^0.9"
+#goth = "^0.9"
+goth = { git = "https://github.com/golemfactory/goth.git", branch = "mf/batch-payments" }
 # to use development goth version uncomment below
 # goth = { git = "https://github.com/golemfactory/goth.git", branch = "your-branch-here" }
 


### PR DESCRIPTION
Payments are now grouped by the sender and payee addresses for the chosen payment platform. Batches are sent within a time window of the nearest `payment_due_date` (minus some constant payment processing overhead).

Payment batching is enabled by default when using `yagna payment init --sender` and can be disabled via the `--send-immediately` flag. Within an `accounts.json` file it's enough to specify a `"send": "auto"` mode; use the legacy value of `"send": true` to disable batching.

The original code was ported from branch `feature/win10`