### PR TITLE
Significantly increase the _default_ max agreement expiration

### DIFF
--- a/agent/provider/src/market/negotiator/factory.rs
+++ b/agent/provider/src/market/negotiator/factory.rs
@@ -20,7 +20,7 @@ pub struct LimitAgreementsNegotiatorConfig {
 pub struct AgreementExpirationNegotiatorConfig {
     #[structopt(long, env, parse(try_from_str = humantime::parse_duration), default_value = "5min")]
     pub min_agreement_expiration: std::time::Duration,
-    #[structopt(long, env, parse(try_from_str = humantime::parse_duration), default_value = "10h")]
+    #[structopt(long, env, parse(try_from_str = humantime::parse_duration), default_value = "100years")]
     pub max_agreement_expiration: std::time::Duration,
     #[structopt(long, env, parse(try_from_str = humantime::parse_duration), default_value = "30min")]
     pub max_agreement_expiration_without_deadline: std::time::Duration,


### PR DESCRIPTION
Default max agreement expiration has been increased to 100 years. The check was not removed since the value should be configurable by the provider