### PR TITLE
Add debit note due_date based on payment-interval-sec

### DIFF
--- a/agent/provider/src/payments/agreement.rs
+++ b/agent/provider/src/payments/agreement.rs
@@ -61,6 +61,9 @@ pub struct AgreementPayment {
     // If we are unable to send DebitNotes, we should break Agreement the same
     // way as in case, when Requestor doesn't accept them.
     pub last_send_debit_note: DateTime<Utc>,
+    // Keep track of the last payable debit note so we can send a payable
+    // debit note each payment_timeout
+    pub last_payable_debit_note: DateTime<Utc>,
 
     // Watches for waiting for activities. You can await on receiver
     // to observe changes in number of active activities.
@@ -110,6 +113,7 @@ impl AgreementPayment {
             payment_timeout,
             deadline_elapsed: false,
             last_send_debit_note: approved_ts,
+            last_payable_debit_note: approved_ts,
             watch_sender: sender,
             activities_watch: ActivitiesWaiter {
                 watch_receiver: receiver,

--- a/agent/provider/src/payments/payments.rs
+++ b/agent/provider/src/payments/payments.rs
@@ -577,7 +577,12 @@ impl Handler<ActivityDestroyed> for Payments {
         agreement.activity_destroyed(&msg.activity_id).unwrap();
 
         let payment_model = agreement.payment_model.clone();
-        let last_payable_debit_node = agreement.last_payable_debit_note;
+        let last_payable_debit_node = match agreement.payment_timeout {
+            // Ensure that last debit note is always payable, by
+            Some(timeout) => Utc::now() - timeout,
+            // Without payment timeout the last_payable_debit_node is ignored.
+            None => agreement.last_payable_debit_note,
+        };
         let provider_context = self.context.clone();
         let address = ctx.address();
         let debit_note_info = DebitNoteInfo {

--- a/agent/provider/src/payments/payments.rs
+++ b/agent/provider/src/payments/payments.rs
@@ -308,9 +308,10 @@ async fn send_debit_note(
     send_result?;
 
     log::info!(
-        "Debit note [{}] for activity [{}] sent.",
+        "Debit note [{}] for activity [{}] sent with due date: {:?}.",
         &debit_note.debit_note_id,
-        &debit_note_info.activity_id
+        &debit_note_info.activity_id,
+        &debit_note.payment_due_date
     );
 
     Ok(debit_note)

--- a/goth_tests/domain/payments/test_mid_payments.py
+++ b/goth_tests/domain/payments/test_mid_payments.py
@@ -97,5 +97,11 @@ async def test_mid_agreement_payments(
             if i == ITERATION_COUNT - 2:
                 await requestor.destroy_activity(activity_id)
                 await provider.wait_for_exeunit_finished()
+                # Invoice is required for the last payment
+                await provider.wait_for_invoice_sent()
+                invoices = await requestor.gather_invoices(agreement_id)
+                assert all(inv.agreement_id == agreement_id for inv in invoices)
+                await requestor.pay_invoices(invoices)
+                await provider.wait_for_invoice_paid()
 
         assert round(stats.amount, 12) == round(amount, 12)

--- a/goth_tests/domain/payments/test_mid_payments.py
+++ b/goth_tests/domain/payments/test_mid_payments.py
@@ -97,11 +97,5 @@ async def test_mid_agreement_payments(
             if i == ITERATION_COUNT - 2:
                 await requestor.destroy_activity(activity_id)
                 await provider.wait_for_exeunit_finished()
-                # Invoice is required for the last payment
-                await provider.wait_for_invoice_sent()
-                invoices = await requestor.gather_invoices(agreement_id)
-                assert all(inv.agreement_id == agreement_id for inv in invoices)
-                await requestor.pay_invoices(invoices)
-                await provider.wait_for_invoice_paid()
 
         assert round(stats.amount, 12) == round(amount, 12)


### PR DESCRIPTION
Resolves #1850 

- Remember "last_payable_debit_note", defaults to agreement start time
- Set debit note due date when `last_payable + payment-interval-sec < now()`