### PR TITLE
Wkargul/new release notification

### DIFF
--- a/core/version/src/db/dao.rs
+++ b/core/version/src/db/dao.rs
@@ -91,6 +91,7 @@ fn get_release(conn: &ConnType, ver: &str) -> anyhow::Result<Option<Release>> {
 fn get_pending_release(conn: &ConnType, include_seen: bool) -> anyhow::Result<Option<Release>> {
     let mut query = version_release
         // insertion_ts is to distinguish among fake-entries of `DBRelease::current`
+        .filter(release::version.not_like("%rc%"))
         .order((release::release_ts.desc(), release::insertion_ts.desc()))
         .into_boxed();
     if !include_seen {

--- a/core/version/src/github.rs
+++ b/core/version/src/github.rs
@@ -74,7 +74,6 @@ pub(crate) async fn check_running_release(db: &DbExecutor) -> anyhow::Result<Rel
             .repo_name(REPO_NAME)
             .bin_name("") // seems required by builder but unused
             .current_version("") // similar as above
-            .target_version_tag("latest")
             .build()?
             .get_release_version(running_tag)
     })

--- a/core/version/src/github.rs
+++ b/core/version/src/github.rs
@@ -62,6 +62,12 @@ pub(crate) async fn check_running_release(db: &DbExecutor) -> anyhow::Result<Rel
     let running_tag = ya_compile_time_utils::git_tag!();
     log::debug!("Checking release for running tag: {}", running_tag);
 
+    if running_tag.contains("-rc") {
+        log::trace!("Currently running Yagna rc release. Not stored in DB.");
+
+        return Ok(DBRelease::current()?.into());
+    }
+
     let db_rel = match tokio::task::spawn_blocking(move || {
         UpdateBuilder::new()
             .repo_owner(REPO_OWNER)

--- a/core/version/src/github.rs
+++ b/core/version/src/github.rs
@@ -68,6 +68,7 @@ pub(crate) async fn check_running_release(db: &DbExecutor) -> anyhow::Result<Rel
             .repo_name(REPO_NAME)
             .bin_name("") // seems required by builder but unused
             .current_version("") // similar as above
+            .target_version_tag("latest")
             .build()?
             .get_release_version(running_tag)
     })

--- a/core/version/src/github.rs
+++ b/core/version/src/github.rs
@@ -21,6 +21,7 @@ pub async fn check_latest_release(db: &DbExecutor) -> anyhow::Result<Release> {
             .repo_name(REPO_NAME)
             .bin_name("") // seems required by builder but unused
             .current_version("") // similar as above
+            .target_version_tag("latest")
             .build()?
             .get_latest_release()?)
     })

--- a/core/version/src/notifier.rs
+++ b/core/version/src/notifier.rs
@@ -24,9 +24,9 @@ pub async fn on_start(db: &DbExecutor) -> anyhow::Result<()> {
 
 pub(crate) async fn worker(db: DbExecutor) {
     // TODO: make interval configurable
-    let mut interval = tokio::time::interval(Duration::from_secs(3600 * 24));
+    let interval = Duration::from_secs(3600 * 24);
     loop {
-        interval.tick().await;
+        tokio::time::delay_for(interval).await;
         if let Err(e) = github::check_latest_release(&db).await {
             log::error!("Failed to check for new Yagna release: {}", e);
         };
@@ -35,10 +35,10 @@ pub(crate) async fn worker(db: DbExecutor) {
 
 pub(crate) async fn pinger(db: DbExecutor) -> ! {
     // TODO: make interval configurable
-    let mut interval = tokio::time::interval(Duration::from_secs(30 * 60));
+    let interval = Duration::from_secs(30 * 60);
     loop {
         let release_dao = db.as_dao::<ReleaseDAO>();
-        interval.tick().await;
+        tokio::time::delay_for(interval).await;
         match release_dao.pending_release().await {
             Ok(Some(release)) => {
                 if !release.seen {


### PR DESCRIPTION
This PR consists of fix for "new release" notification. The main problem was with "rc" versions being reported as available for update. The second issue was redundant notification at yagna start.

Main issue solved with filter impl for "%rc%" versions fetched from local DB. What is more, I sealed github client reading the latest released versions of yagna. It is now reading only those with tag -> `latest`.

Second issue is solved with a slightly change in interval. `tick()` is replaced with `delay_for()` as we do not need this level of accuracy when counting the interval. `tick()` was also problematic as caused redundant logs at yagna startup (if newest yagna's version was avaialble).

It fixes https://github.com/golemfactory/yagna/issues/1819