### PR TITLE
ExeUnit - fix `offer-template` for runtimes requiring extra arguments

### DIFF
--- a/exe-unit/src/bin.rs
+++ b/exe-unit/src/bin.rs
@@ -227,7 +227,8 @@ fn run() -> anyhow::Result<()> {
             args
         }
         Command::OfferTemplate => {
-            let offer_template = ExeUnit::<RuntimeProcess>::offer_template(cli.binary)?;
+            let args = cli.runtime_arg.clone();
+            let offer_template = ExeUnit::<RuntimeProcess>::offer_template(cli.binary, args)?;
             println!("{}", serde_json::to_string(&offer_template)?);
             return Ok(());
         }

--- a/exe-unit/src/lib.rs
+++ b/exe-unit/src/lib.rs
@@ -83,10 +83,10 @@ impl<R: Runtime> ExeUnit<R> {
         }
     }
 
-    pub fn offer_template(binary: PathBuf) -> Result<OfferTemplate> {
+    pub fn offer_template(binary: PathBuf, args: Vec<String>) -> Result<OfferTemplate> {
         use crate::runtime::process::RuntimeProcess;
 
-        let runtime_template = RuntimeProcess::offer_template(binary)?;
+        let runtime_template = RuntimeProcess::offer_template(binary, args)?;
         let supervisor_template = OfferTemplate::new(serde_json::json!({
             "golem.com.usage.vector": MetricsService::usage_vector(),
             "golem.activity.caps.transfer.protocol": TransferService::schemes(),

--- a/exe-unit/src/runtime/process.rs
+++ b/exe-unit/src/runtime/process.rs
@@ -65,9 +65,9 @@ impl RuntimeProcess {
         }
     }
 
-    pub fn offer_template(binary: PathBuf) -> Result<OfferTemplate, Error> {
+    pub fn offer_template(binary: PathBuf, mut args: Vec<String>) -> Result<OfferTemplate, Error> {
         let current_path = std::env::current_dir();
-        let args = vec![OsString::from("offer-template")];
+        args.push("offer-template".to_string());
 
         log::info!(
             "Executing {:?} with {:?} from path {:?}",


### PR DESCRIPTION
Extra runtime arguments were not passed to runtimes when executing the `offer-template` command. Runtime properties were never included in the offer.

This issue currently only affects `ya-runtime-http-auth`