### PR TITLE
NET client - reconnect to relay on "unauthorized" error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7421,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=56b02e83202faddf3d84ada836d0bd7e7b0be3ee#56b02e83202faddf3d84ada836d0bd7e7b0be3ee"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=9d694b4c82e95b21f6756370772a751b9e9502f2#9d694b4c82e95b21f6756370772a751b9e9502f2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7440,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-core"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=56b02e83202faddf3d84ada836d0bd7e7b0be3ee#56b02e83202faddf3d84ada836d0bd7e7b0be3ee"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=9d694b4c82e95b21f6756370772a751b9e9502f2#9d694b4c82e95b21f6756370772a751b9e9502f2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-proto"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=56b02e83202faddf3d84ada836d0bd7e7b0be3ee#56b02e83202faddf3d84ada836d0bd7e7b0be3ee"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=9d694b4c82e95b21f6756370772a751b9e9502f2#9d694b4c82e95b21f6756370772a751b9e9502f2"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -7485,7 +7485,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-stack"
 version = "0.4.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=56b02e83202faddf3d84ada836d0bd7e7b0be3ee#56b02e83202faddf3d84ada836d0bd7e7b0be3ee"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=9d694b4c82e95b21f6756370772a751b9e9502f2#9d694b4c82e95b21f6756370772a751b9e9502f2"
 dependencies = [
  "derive_more",
  "futures 0.3.13",

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -14,7 +14,7 @@ hybrid-net = []
 ya-core-model = { version = "^0.6", features=["net", "identity"] }
 
 # ya-relay-client = "0.2"
-ya-relay-client = { git = "https://github.com/golemfactory/ya-relay.git", rev = "56b02e83202faddf3d84ada836d0bd7e7b0be3ee" }
+ya-relay-client = { git = "https://github.com/golemfactory/ya-relay.git", rev = "9d694b4c82e95b21f6756370772a751b9e9502f2" }
 
 ya-sb-proto = { version = "0.4" }
 ya-service-api = "0.1"


### PR DESCRIPTION
Reconnecting to the relay server re-authenticates the client.

"Unauthorized" error message is returned when a session is invalid within the relay server. This usually happens when the server is started anew.