### PR TITLE
Dedicated hybrid net thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5445,16 +5445,15 @@ dependencies = [
 
 [[package]]
 name = "smoltcp"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2308a1657c8db1f5b4993bab4e620bdbe5623bd81f254cf60326767bb243237"
+checksum = "72165c4af59f5f19c7fb774b88b95660591b612380305b5f4503157341a9f7ee"
 dependencies = [
  "bitflags",
  "byteorder",
  "libc",
  "log",
  "managed 0.8.0",
- "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -7233,6 +7232,7 @@ dependencies = [
 name = "ya-net"
 version = "0.2.0"
 dependencies = [
+ "actix",
  "actix-rt",
  "anyhow",
  "bytes 0.5.6",
@@ -7421,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=56b02e83202faddf3d84ada836d0bd7e7b0be3ee#56b02e83202faddf3d84ada836d0bd7e7b0be3ee"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=86e7d08f4ca4ef8908b3be386855949ac73514aa#86e7d08f4ca4ef8908b3be386855949ac73514aa"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7440,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-core"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=56b02e83202faddf3d84ada836d0bd7e7b0be3ee#56b02e83202faddf3d84ada836d0bd7e7b0be3ee"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=86e7d08f4ca4ef8908b3be386855949ac73514aa#86e7d08f4ca4ef8908b3be386855949ac73514aa"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-proto"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=56b02e83202faddf3d84ada836d0bd7e7b0be3ee#56b02e83202faddf3d84ada836d0bd7e7b0be3ee"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=86e7d08f4ca4ef8908b3be386855949ac73514aa#86e7d08f4ca4ef8908b3be386855949ac73514aa"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -7485,7 +7485,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-stack"
 version = "0.4.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=56b02e83202faddf3d84ada836d0bd7e7b0be3ee#56b02e83202faddf3d84ada836d0bd7e7b0be3ee"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=86e7d08f4ca4ef8908b3be386855949ac73514aa#86e7d08f4ca4ef8908b3be386855949ac73514aa"
 dependencies = [
  "derive_more",
  "futures 0.3.13",
@@ -7494,7 +7494,7 @@ dependencies = [
  "num-derive",
  "num-traits",
  "rand 0.8.4",
- "smoltcp 0.8.0",
+ "smoltcp 0.8.1",
  "thiserror",
  "tokio 0.2.25",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7421,7 +7421,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=86e7d08f4ca4ef8908b3be386855949ac73514aa#86e7d08f4ca4ef8908b3be386855949ac73514aa"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=28b1a8f5c95020e0dae834325505f96e45c25d03#28b1a8f5c95020e0dae834325505f96e45c25d03"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7440,7 +7440,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-core"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=86e7d08f4ca4ef8908b3be386855949ac73514aa#86e7d08f4ca4ef8908b3be386855949ac73514aa"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=28b1a8f5c95020e0dae834325505f96e45c25d03#28b1a8f5c95020e0dae834325505f96e45c25d03"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7468,7 +7468,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-proto"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=86e7d08f4ca4ef8908b3be386855949ac73514aa#86e7d08f4ca4ef8908b3be386855949ac73514aa"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=28b1a8f5c95020e0dae834325505f96e45c25d03#28b1a8f5c95020e0dae834325505f96e45c25d03"
 dependencies = [
  "anyhow",
  "bytes 0.5.6",
@@ -7485,7 +7485,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-stack"
 version = "0.4.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=86e7d08f4ca4ef8908b3be386855949ac73514aa#86e7d08f4ca4ef8908b3be386855949ac73514aa"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=28b1a8f5c95020e0dae834325505f96e45c25d03#28b1a8f5c95020e0dae834325505f96e45c25d03"
 dependencies = [
  "derive_more",
  "futures 0.3.13",

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -14,7 +14,7 @@ hybrid-net = []
 ya-core-model = { version = "^0.6", features=["net", "identity"] }
 
 # ya-relay-client = "0.2"
-ya-relay-client = { git = "https://github.com/golemfactory/ya-relay.git", rev = "56b02e83202faddf3d84ada836d0bd7e7b0be3ee" }
+ya-relay-client = { git = "https://github.com/golemfactory/ya-relay.git", rev = "86e7d08f4ca4ef8908b3be386855949ac73514aa" }
 
 ya-sb-proto = { version = "0.4" }
 ya-service-api = "0.1"
@@ -22,6 +22,7 @@ ya-service-api-interfaces = "0.1"
 ya-service-bus = "0.4"
 ya-utils-networking = "0.1"
 
+actix = "0.10"
 actix-rt = "1.0"
 anyhow = "1.0"
 futures = "0.3"

--- a/core/net/src/config.rs
+++ b/core/net/src/config.rs
@@ -4,7 +4,7 @@ use strum::VariantNames;
 use strum::{EnumString, EnumVariantNames, IntoStaticStr};
 use url::Url;
 
-#[derive(StructOpt, EnumString, EnumVariantNames, IntoStaticStr, Clone)]
+#[derive(StructOpt, EnumString, EnumVariantNames, IntoStaticStr, Copy, Clone)]
 #[strum(serialize_all = "lowercase")]
 pub enum NetType {
     Central,
@@ -32,7 +32,7 @@ impl Config {
     pub fn from_env() -> Result<Config, structopt::clap::Error> {
         // Empty command line arguments, because we want to use ENV fallback
         // or default values if ENV variables are not set.
-        Ok(Config::from_iter_safe(&[""])?)
+        Config::from_iter_safe(&[""])
     }
 }
 

--- a/core/net/src/hybrid/cli.rs
+++ b/core/net/src/hybrid/cli.rs
@@ -11,79 +11,82 @@ use ya_service_bus::timeout::IntoTimeoutFuture;
 use ya_service_bus::typed::ServiceBinder;
 use ya_service_bus::{typed as bus, RpcEndpoint};
 
-use crate::hybrid::service::CLIENT;
+use crate::hybrid::Net;
 
 pub(crate) fn bind_service() {
-    let _ = bus::bind(model::BUS_ID, cli_ping);
+    let _ = bus::bind(model::BUS_ID, |_: model::GsbPing| {
+        cli_ping().map_err(status_err)
+    });
 
     ServiceBinder::new(DIAGNOSTIC, &(), ())
         .bind(move |_, _caller: String, _msg: GsbRemotePing| async move { Ok(GsbRemotePing {}) });
 
-    let _ = bus::bind(model::BUS_ID, move |_: model::Status| async move {
-        let client = {
-            CLIENT.with(|c| c.borrow().clone()).ok_or_else(|| {
-                model::StatusError::RuntimeException("client not initialized".to_string())
-            })?
-        };
+    let _ = bus::bind(model::BUS_ID, move |_: model::Status| {
+        async move {
+            let client = Net::client().await?;
 
-        Ok(model::StatusResponse {
-            node_id: client.node_id(),
-            listen_address: client.bind_addr().await.ok(),
-            public_address: client.public_addr().await,
-            sessions: client.sessions().await.len(),
-            metrics: to_status_metrics(&mut client.metrics()),
-        })
-    });
-    let _ = bus::bind(model::BUS_ID, move |_: model::Sessions| async move {
-        let client = CLIENT.with(|c| c.borrow().clone()).ok_or_else(|| {
-            model::StatusError::RuntimeException("client not initialized".to_string())
-        })?;
-
-        let mut responses = Vec::new();
-        let now = Instant::now();
-
-        for session in client.sessions().await {
-            let node_id = client.remote_id(&session.remote).await;
-            let kind = match node_id {
-                Some(id) => {
-                    let is_p2p = client.sessions.is_p2p(&id).await;
-                    is_p2p.then(|| "p2p").unwrap_or("relay")
-                }
-                None => "",
-            };
-
-            responses.push(model::SessionResponse {
-                node_id,
-                id: session.id.to_string(),
-                session_type: kind.to_string(),
-                remote_address: session.remote,
-                seen: now - session.last_seen,
-                duration: now - session.created,
-                ping: session.last_ping,
-            });
-        }
-
-        Ok(responses)
-    });
-    let _ = bus::bind(model::BUS_ID, move |_: model::Sockets| async move {
-        let client = CLIENT.with(|c| c.borrow().clone()).ok_or_else(|| {
-            model::StatusError::RuntimeException("client not initialized".to_string())
-        })?;
-
-        let sockets = client
-            .sockets()
-            .into_iter()
-            .map(|(desc, mut state)| model::SocketResponse {
-                protocol: desc.protocol.to_string().to_lowercase(),
-                state: state.to_string(),
-                local_port: desc.local.port_repr(),
-                remote_addr: desc.remote.addr_repr(),
-                remote_port: desc.remote.port_repr(),
-                metrics: to_status_metrics(state.inner_mut()),
+            Ok(model::StatusResponse {
+                node_id: client.node_id().await?,
+                listen_address: client.bind_addr().await?,
+                public_address: client.public_addr().await?,
+                sessions: client.sessions().await?.len(),
+                metrics: to_status_metrics(&mut client.metrics().await?),
             })
-            .collect();
+        }
+        .map_err(status_err)
+    });
+    let _ = bus::bind(model::BUS_ID, move |_: model::Sessions| {
+        async move {
+            let client = Net::client().await?;
+            let mut responses = Vec::new();
+            let now = Instant::now();
 
-        Ok(sockets)
+            for session in client.sessions().await? {
+                let node_id = client.remote_id(session.remote).await?;
+                let kind = match node_id {
+                    Some(id) => {
+                        let is_p2p = client.is_p2p(id).await?;
+                        is_p2p.then(|| "p2p").unwrap_or("relay")
+                    }
+                    None => "",
+                };
+
+                responses.push(model::SessionResponse {
+                    node_id,
+                    id: session.id.to_string(),
+                    session_type: kind.to_string(),
+                    remote_address: session.remote,
+                    seen: now - session.last_seen,
+                    duration: now - session.created,
+                    ping: session.last_ping,
+                });
+            }
+
+            Ok(responses)
+        }
+        .map_err(status_err)
+    });
+    let _ = bus::bind(model::BUS_ID, move |_: model::Sockets| {
+        async move {
+            let client = Net::client().await?;
+
+            let sockets = client
+                .sockets()
+                .await?
+                .into_iter()
+                .map(|(desc, mut state)| model::SocketResponse {
+                    protocol: desc.protocol.to_string().to_lowercase(),
+                    state: state.to_string(),
+                    local_port: desc.local.port_repr(),
+                    remote_addr: desc.remote.addr_repr(),
+                    remote_port: desc.remote.port_repr(),
+                    metrics: to_status_metrics(state.inner_mut()),
+                })
+                .collect();
+
+            Ok(sockets)
+        }
+        .map_err(status_err)
     });
 }
 
@@ -99,19 +102,15 @@ fn to_status_metrics(metrics: &mut ChannelMetrics) -> model::StatusMetrics {
     }
 }
 
-pub async fn cli_ping(_msg: model::GsbPing) -> Result<Vec<GsbPingResponse>, StatusError> {
-    let client = {
-        CLIENT.with(|c| c.borrow().clone()).ok_or_else(|| {
-            model::StatusError::RuntimeException("client not initialized".to_string())
-        })?
-    };
+pub async fn cli_ping() -> anyhow::Result<Vec<GsbPingResponse>> {
+    let client = Net::client().await?;
 
     // This will update sessions ping. We don't display them in this view
     // but I think it is good place to enforce this.
-    client.ping_sessions().await;
+    client.ping_sessions().await?;
 
-    let nodes = client.connected_nodes().await;
-    let our_node_id = client.node_id();
+    let nodes = client.connected_nodes().await?;
+    let our_node_id = client.node_id().await?;
     let ping_timeout = Duration::from_secs(10);
 
     log::debug!("Ping: Num connected nodes: {}", nodes.len());
@@ -159,7 +158,6 @@ pub async fn cli_ping(_msg: model::GsbPing) -> Result<Vec<GsbPingResponse>, Stat
                     .map_err(|e| anyhow!("(Tcp ping). {}", e))
                 })
             })
-            .map(|future| future.map_err(|e| StatusError::RuntimeException(e.to_string())))
             .collect::<Vec<_>>(),
     )
     .await
@@ -172,7 +170,7 @@ pub async fn cli_ping(_msg: model::GsbPing) -> Result<Vec<GsbPingResponse>, Stat
             GsbPingResponse {
                 node_id: nodes[idx].0,
                 node_alias: nodes[idx].1,
-                tcp_ping: ping_timeout.clone(),
+                tcp_ping: ping_timeout,
                 udp_ping: ping_timeout,
                 is_p2p: false, // Updated later
             }
@@ -185,7 +183,12 @@ pub async fn cli_ping(_msg: model::GsbPing) -> Result<Vec<GsbPingResponse>, Stat
             Some(id) => id,
             None => result.node_id,
         };
-        result.is_p2p = client.sessions.is_p2p(&main_id).await;
+        result.is_p2p = client.is_p2p(main_id).await?;
     }
     Ok(results)
+}
+
+#[inline]
+fn status_err(e: anyhow::Error) -> StatusError {
+    StatusError::RuntimeException(e.to_string())
 }

--- a/core/net/src/hybrid/client.rs
+++ b/core/net/src/hybrid/client.rs
@@ -1,0 +1,173 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use actix::prelude::*;
+use anyhow::{anyhow, bail};
+use tokio::sync::RwLock;
+
+use ya_core_model::NodeId;
+use ya_relay_client::{ChannelMetrics, Client, SessionDesc, SocketDesc, SocketState};
+
+lazy_static::lazy_static! {
+    static ref ADDRESS: Arc<RwLock<Option<Addr<ClientActor >>>> = Default::default();
+}
+
+#[derive(Clone)]
+pub struct ClientProxy(Addr<ClientActor>);
+
+impl ClientProxy {
+    pub async fn new() -> anyhow::Result<Self> {
+        let addr = match ADDRESS.read().await.clone() {
+            Some(addr) => addr,
+            None => bail!("network not initialized"),
+        };
+
+        Ok(Self(addr))
+    }
+
+    async fn call<M>(&self, msg: M) -> anyhow::Result<M::Result>
+    where
+        M: Message + Send + 'static,
+        <M as Message>::Result: Send + 'static,
+        ClientActor: Handler<M>,
+    {
+        let resp = self
+            .0
+            .send(msg)
+            .await
+            .map_err(|_| anyhow!("network not running"))?;
+        Ok(resp)
+    }
+}
+
+pub(crate) struct ClientActor {
+    client: Client,
+}
+
+impl ClientActor {
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+}
+
+impl Actor for ClientActor {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        let addr = ctx.address();
+        ctx.wait(
+            async move {
+                ADDRESS.write().await.replace(addr);
+            }
+            .into_actor(self),
+        );
+    }
+}
+
+macro_rules! proxy {
+    ($ident:ident -> $ty:ty, $by:ident, $handler:expr) => {
+        #[derive(Default)]
+        struct $ident;
+
+        impl Message for $ident {
+            type Result = $ty;
+        }
+
+        impl Handler<$ident> for ClientActor {
+            type Result = ResponseFuture<$ty>;
+
+            fn handle(&mut self, _: $ident, _: &mut Self::Context) -> Self::Result {
+                let client = self.client.clone();
+                let fut = $handler(client);
+                Box::pin(fut)
+            }
+        }
+
+        impl ClientProxy {
+            #[inline]
+            pub async fn $by(&self) -> anyhow::Result<$ty> {
+                self.call($ident::default()).await
+            }
+        }
+    };
+    ($ident:ident($arg0:ty) -> $ty:ty, $by:ident, $handler:expr) => {
+        struct $ident($arg0);
+
+        impl Message for $ident {
+            type Result = $ty;
+        }
+
+        impl Handler<$ident> for ClientActor {
+            type Result = ResponseFuture<$ty>;
+
+            fn handle(&mut self, msg: $ident, _: &mut Self::Context) -> Self::Result {
+                let client = self.client.clone();
+                let fut = $handler(client, msg);
+                Box::pin(fut)
+            }
+        }
+
+        impl ClientProxy {
+            #[inline]
+            pub async fn $by(&self, val: $arg0) -> anyhow::Result<$ty> {
+                self.call($ident(val)).await
+            }
+        }
+    };
+}
+
+proxy!(
+    IsP2p(NodeId) -> bool,
+    is_p2p,
+    |client: Client, msg: IsP2p| async move { client.sessions.is_p2p(&msg.0).await }
+);
+proxy!(
+    GetRemoteId(SocketAddr) -> Option<NodeId>,
+    remote_id,
+    |client: Client, msg: GetRemoteId| async move { client.sessions.remote_id(&msg.0).await }
+);
+proxy!(
+    GetNodeId -> NodeId,
+    node_id,
+    |client: Client| futures::future::ready(client.node_id())
+);
+proxy!(
+    GetMetrics -> ChannelMetrics,
+    metrics,
+    |client: Client| futures::future::ready(client.metrics())
+);
+proxy!(
+    GetSockets -> Vec<(SocketDesc, SocketState<ChannelMetrics>)>,
+    sockets,
+    |client: Client| { futures::future::ready(client.sockets()) }
+);
+proxy!(
+    GetSessions -> Vec<SessionDesc>,
+    sessions,
+    |client: Client| async move { client.sessions().await }
+);
+proxy!(
+    GetBindAddr -> Option<SocketAddr>,
+    bind_addr,
+    |client: Client| async move { client.bind_addr().await.ok() }
+);
+proxy!(
+    GetPublicAddr -> Option<SocketAddr>,
+    public_addr,
+    |client: Client| async move { client.public_addr().await }
+);
+proxy!(
+    ConnectedNodes -> Vec<(NodeId, Option<NodeId>)>,
+    connected_nodes,
+    |client: Client| async move { client.connected_nodes().await }
+);
+proxy!(
+    PingSessions -> (),
+    ping_sessions,
+    |client: Client| async move { client.ping_sessions().await }
+);
+proxy!(
+    Shutdown -> anyhow::Result<()>,
+    shutdown,
+    |mut client: Client| async move { client.shutdown().await }
+);

--- a/core/net/src/hybrid/mod.rs
+++ b/core/net/src/hybrid/mod.rs
@@ -1,8 +1,9 @@
 mod api;
 pub(crate) mod cli;
+mod client;
 mod codec;
 mod crypto;
 mod service;
 
 pub use api::*;
-pub use service::{bind_remote, start_network, Net};
+pub use service::{start_network, Net};

--- a/core/net/src/hybrid/service.rs
+++ b/core/net/src/hybrid/service.rs
@@ -34,7 +34,7 @@ use crate::hybrid::client::{ClientActor, ClientProxy};
 use crate::hybrid::codec;
 use crate::hybrid::crypto::IdentityCryptoProvider;
 
-const DEFAULT_NET_RELAY_HOST: &str = "52.17.188.4:7464";
+const DEFAULT_NET_RELAY_HOST: &str = "127.0.0.1:7464";
 
 pub type BCastHandler = Box<dyn FnMut(String, &[u8]) + Send>;
 

--- a/core/net/src/hybrid/service.rs
+++ b/core/net/src/hybrid/service.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
-use std::net::{SocketAddr, ToSocketAddrs};
+use std::net::SocketAddr;
 use std::rc::Rc;
 use std::str::FromStr;
 use std::sync::atomic::AtomicBool;
@@ -9,8 +9,9 @@ use std::sync::atomic::Ordering::Relaxed;
 use std::sync::Arc;
 use std::task::Poll;
 
+use actix::Actor;
 use anyhow::{anyhow, Context as AnyhowContext};
-use futures::channel::mpsc;
+use futures::channel::{mpsc, oneshot};
 use futures::lock::Mutex;
 use futures::stream::LocalBoxStream;
 use futures::{FutureExt, SinkExt, Stream, StreamExt, TryStreamExt};
@@ -20,6 +21,7 @@ use url::Url;
 
 use ya_core_model::{identity, net, NodeId};
 use ya_relay_client::codec::forward::{PrefixedSink, PrefixedStream, SinkKind};
+use ya_relay_client::crypto::CryptoProvider;
 use ya_relay_client::{Client, ClientBuilder, ForwardReceiver};
 use ya_sb_proto::codec::GsbMessage;
 use ya_sb_proto::CallReplyCode;
@@ -28,10 +30,11 @@ use ya_utils_networking::resolver;
 
 use crate::bcast::BCastService;
 use crate::config::Config;
+use crate::hybrid::client::{ClientActor, ClientProxy};
 use crate::hybrid::codec;
 use crate::hybrid::crypto::IdentityCryptoProvider;
 
-const DEFAULT_NET_RELAY_HOST: &str = "127.0.0.1:7464";
+const DEFAULT_NET_RELAY_HOST: &str = "52.17.188.4:7464";
 
 pub type BCastHandler = Box<dyn FnMut(String, &[u8]) + Send>;
 
@@ -46,66 +49,58 @@ type ArcMap<K, V> = Arc<RwLock<HashMap<K, V>>>;
 
 lazy_static::lazy_static! {
     pub(crate) static ref BCAST: BCastService = Default::default();
-}
-
-lazy_static::lazy_static! {
     pub(crate) static ref BCAST_HANDLERS: ArcMap<String, Arc<Mutex<BCastHandler>>> = Default::default();
-}
-
-lazy_static::lazy_static! {
     pub(crate) static ref BCAST_SENDER: Arc<RwLock<Option<NetSender>>> = Default::default();
+    pub(crate) static ref SHUTDOWN_TX: Arc<RwLock<Option<oneshot::Sender<()>>>> = Default::default();
 }
 
 thread_local! {
-    pub(crate) static CLIENT: RefCell<Option<Client>> = Default::default();
-}
-
-async fn relay_addr(config: &Config) -> anyhow::Result<SocketAddr> {
-    let host_port = match &config.host {
-        Some(val) => val.to_string(),
-        None => resolver::resolve_yagna_srv_record("_net_relay._udp")
-            .await
-            // FIXME: remove
-            .unwrap_or_else(|_| DEFAULT_NET_RELAY_HOST.to_string()),
-    };
-    log::trace!("resolving host_port: {}", host_port);
-    let (host, port) = &host_port
-        .split_once(":")
-        .context("Please use host:port format")?;
-    let ip = resolver::try_resolve_dns_record(&host).await;
-    let ip_port = format!("{}:{}", ip, port);
-    let socket = ip_port
-        .to_socket_addrs()?
-        .next()
-        .expect("relay address needed");
-    Ok(socket)
+    static CLIENT: RefCell<Option<Client>> = Default::default();
 }
 
 pub struct Net;
 
 impl Net {
+    #[inline]
+    pub async fn client() -> anyhow::Result<ClientProxy> {
+        ClientProxy::new().await
+    }
+
     pub async fn gsb<Context>(_: Context, config: Config) -> anyhow::Result<()> {
         let (default_id, ids) = crate::service::identities().await?;
+        let (started_tx, started_rx) = oneshot::channel();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
         log::info!(
             "HYBRID_NET - Using default identity as network id: {:?}",
             default_id
         );
-        start_network(Arc::new(config), default_id, ids).await?;
-        Ok(())
+
+        std::thread::spawn(move || {
+            let mut system = actix::System::new("hybrid-net");
+            system.block_on(async move {
+                SHUTDOWN_TX.write().await.replace(shutdown_tx);
+
+                let result = start_network(Arc::new(config), default_id, ids).await;
+                started_tx.send(result).expect("Unable to start network");
+                let _ = shutdown_rx.await;
+            });
+        });
+
+        started_rx
+            .await
+            .map_err(|_| anyhow!("Error starting network"))?
     }
 
     pub async fn shutdown() -> anyhow::Result<()> {
-        let mut client = CLIENT
-            .with(|c| c.borrow().clone())
-            .ok_or_else(|| anyhow::anyhow!("network not initialized"))?;
-        client.shutdown().await
+        if let Ok(client) = Self::client().await {
+            let _ = client.shutdown().await;
+        }
+        if let Some(sender) = { SHUTDOWN_TX.write().await.take() } {
+            let _ = sender.send(());
+        }
+        Ok(())
     }
-}
-
-// FIXME: examples compatibility
-#[allow(unused)]
-pub async fn bind_remote<T>(_: T, default_id: NodeId, ids: Vec<NodeId>) -> anyhow::Result<()> {
-    start_network(Arc::new(Config::from_env()?), default_id, ids).await
 }
 
 pub async fn start_network(
@@ -116,35 +111,22 @@ pub async fn start_network(
     counter!("net.connections.p2p", 0);
     counter!("net.connections.relay", 0);
 
-    let url = Url::parse(&format!(
-        "udp://{}",
-        relay_addr(&config)
-            .await
-            .map_err(|e| anyhow!("Resolving hybrid NET relay server failed. Error: {}", e))?
-    ))?;
-
-    log::debug!("Setting up hybrid net with url: {}", url);
     log::info!("Starting network (hybrid) with identity: {}", default_id);
 
+    let broadcast_size = config.broadcast_size;
     let crypto = IdentityCryptoProvider::new(default_id);
-    let client = ClientBuilder::from_url(url)
-        .crypto(crypto.clone())
-        .listen(config.bind_url.clone())
-        .expire_session_after(config.session_expiration.clone())
-        .virtual_tcp_buffer_size_multiplier(config.vtcp_buffer_size_multiplier)
-        .connect()
-        .build()
-        .await?;
-    CLIENT.with(|c| {
-        c.borrow_mut().replace(client.clone());
+
+    let client = build_client(config, crypto.clone()).await?;
+    CLIENT.with(|inner| {
+        inner.borrow_mut().replace(client.clone());
     });
 
-    let (btx, brx) = mpsc::channel(1);
-    {
-        BCAST_SENDER.write().await.replace(btx);
-    }
+    ClientActor::new(client.clone()).start();
 
-    let receiver = client.forward_receiver().await.unwrap();
+    let (btx, brx) = mpsc::channel(1);
+    BCAST_SENDER.write().await.replace(btx);
+
+    let receiver = client.clone().forward_receiver().await.unwrap();
     let mut services: HashSet<_> = Default::default();
     ids.iter().for_each(|id| {
         let service = net::net_service(id);
@@ -155,13 +137,9 @@ pub async fn start_network(
 
     // outbound traffic
     let net_handler = || {
-        let default_id = default_id.clone();
-        move |_: &str, addr: &str| {
-            let from = default_id.clone();
-            match parse_net_to_addr(addr) {
-                Ok((to, addr)) => Ok((from, to, addr)),
-                Err(err) => anyhow::bail!("invalid address: {}", err),
-            }
+        move |_: &str, addr: &str| match parse_net_to_addr(addr) {
+            Ok((to, addr)) => Ok((default_id, to, addr)),
+            Err(err) => anyhow::bail!("invalid address: {}", err),
         }
     };
     bind_local_bus(net::BUS_ID_UDP, state.clone(), false, net_handler());
@@ -181,7 +159,7 @@ pub async fn start_network(
     bind_local_bus("/from", state.clone(), true, from_handler());
     bind_local_bus("/udp/from", state.clone(), false, from_handler());
 
-    tokio::task::spawn_local(broadcast_handler(brx, config.clone()));
+    tokio::task::spawn_local(broadcast_handler(brx, broadcast_size));
     tokio::task::spawn_local(forward_handler(receiver, state.clone()));
 
     bind_identity_event_handler(crypto).await;
@@ -194,6 +172,45 @@ pub async fn start_network(
     }
 
     Ok(())
+}
+
+async fn build_client(
+    config: Arc<Config>,
+    crypto: impl CryptoProvider + 'static,
+) -> anyhow::Result<Client> {
+    let addr = relay_addr(&config)
+        .await
+        .map_err(|e| anyhow!("Resolving hybrid NET relay server failed. Error: {}", e))?;
+    let url = Url::parse(&format!("udp://{addr}"))?;
+
+    log::debug!("Setting up hybrid net with url: {url}");
+
+    ClientBuilder::from_url(url)
+        .crypto(crypto)
+        .listen(config.bind_url.clone())
+        .expire_session_after(config.session_expiration)
+        .virtual_tcp_buffer_size_multiplier(config.vtcp_buffer_size_multiplier)
+        .connect()
+        .build()
+        .await
+}
+
+async fn relay_addr(config: &Config) -> anyhow::Result<SocketAddr> {
+    let host_port = match &config.host {
+        Some(val) => val.to_string(),
+        None => resolver::resolve_yagna_srv_record("_net_relay._udp")
+            .await
+            .unwrap_or_else(|_| DEFAULT_NET_RELAY_HOST.to_string()),
+    };
+    log::trace!("resolving host_port: {}", host_port);
+    let (host, port) = &host_port
+        .split_once(':')
+        .context("Please use host:port format")?;
+    let ip = resolver::try_resolve_dns_record(host).await;
+    let socket = format!("{}:{}", ip, port)
+        .parse()
+        .context("Invalid relay address")?;
+    Ok(socket)
 }
 
 fn bind_local_bus<F>(address: &'static str, state: State, reliable: bool, resolver: F)
@@ -311,14 +328,15 @@ async fn bind_identity_event_handler(crypto: IdentityCryptoProvider) {
         let client = CLIENT.with(|c| c.borrow().clone());
 
         async move {
-            Ok(if let Some(client) = client {
+            if let Some(client) = client {
                 match event {
                     identity::event::Event::AccountUnlocked { .. }
                     | identity::event::Event::AccountLocked { .. } => {
                         client.reconnect_server().await
                     }
                 }
-            })
+            };
+            Ok(())
         }
     });
 
@@ -407,7 +425,7 @@ fn forward_bus_to_net(
         match state.forward_sink(remote_id, reliable).await {
             Ok(mut sink) => {
                 let _ = sink.send(msg).await.map_err(|_| {
-                    let err = format!("error sending message: session closed");
+                    let err = "error sending message: session closed".to_string();
                     handler_reply_service_err(request_id, err, tx);
                 });
             }
@@ -424,16 +442,15 @@ fn forward_bus_to_net(
 /// Forward broadcast messages from the network to the local bus
 fn broadcast_handler(
     rx: NetReceiver,
-    config: Arc<Config>,
+    broadcast_size: u32,
 ) -> impl Future<Output = ()> + Unpin + 'static {
     StreamExt::for_each(rx, move |payload| {
-        let config = config.clone();
         async move {
             let client = CLIENT
                 .with(|c| c.borrow().clone())
                 .ok_or_else(|| anyhow::anyhow!("network not initialized"))?;
             client
-                .broadcast(payload, config.broadcast_size)
+                .broadcast(payload, broadcast_size)
                 .await
                 .map_err(|e| anyhow!("Broadcast failed: {}", e))
         }
@@ -480,7 +497,7 @@ fn forward_handler(
 
                 log::trace!("received forward packet ({} B)", fwd.payload.len());
 
-                if tx.send(fwd.payload.into()).await.is_err() {
+                if tx.send(fwd.payload).await.is_err() {
                     log::debug!("net routing error: channel closed");
                     state.remove(&key);
                 }
@@ -568,7 +585,6 @@ fn handle_request(
 
     let eos = Rc::new(AtomicBool::new(false));
     let eos_map = eos.clone();
-    let eos_chain = eos.clone();
 
     let stream = match {
         let inner = state.inner.borrow();
@@ -606,10 +622,10 @@ fn handle_request(
         }
     })
     .chain(futures::stream::poll_fn(move |_| {
-        if eos_chain.load(Relaxed) {
+        if eos.load(Relaxed) {
             Poll::Ready(None)
         } else {
-            eos_chain.store(true, Relaxed);
+            eos.store(true, Relaxed);
             Poll::Ready(Some(codec::reply_eos(request_id_chain.clone())))
         }
     }))
@@ -691,7 +707,7 @@ fn handle_reply(
         } else {
             ResponseChunk::Part(data)
         };
-        if let Err(_) = request.tx.send(chunk).await {
+        if request.tx.send(chunk).await.is_err() {
             log::debug!("failed to forward reply: channel closed");
         }
     });
@@ -726,7 +742,7 @@ fn handle_broadcast(
             .resolve(&topic)
             .await
             .into_iter()
-            .filter_map(|e| handlers.get(e.as_ref()).clone())
+            .filter_map(|e| handlers.get(e.as_ref()))
         {
             let mut h = handler.lock().await;
             (*(h))(caller.clone(), data.as_ref());
@@ -783,11 +799,10 @@ impl State {
 
     fn remove(&self, key: &NetSinkKey) {
         let mut inner = self.inner.borrow_mut();
-        inner.routes.remove(&key);
+        inner.routes.remove(key);
     }
 }
 
-#[allow(dead_code)]
 #[derive(Clone)]
 struct Request<S: Clone> {
     #[allow(dead_code)]
@@ -823,7 +838,7 @@ fn handler_reply_err(
 fn parse_net_to_addr(addr: &str) -> anyhow::Result<(NodeId, String)> {
     const ADDR_CONST: usize = 6;
 
-    let mut it = addr.split("/").fuse().skip(1).peekable();
+    let mut it = addr.split('/').fuse().skip(1).peekable();
     let (prefix, to) = match (it.next(), it.next(), it.next()) {
         (Some("udp"), Some("net"), Some(to)) if it.peek().is_some() => ("/udp", to),
         (Some("net"), Some(to), Some(_)) => ("", to),
@@ -840,7 +855,7 @@ fn parse_net_to_addr(addr: &str) -> anyhow::Result<(NodeId, String)> {
 fn parse_from_to_addr(addr: &str) -> anyhow::Result<(NodeId, NodeId, String)> {
     const ADDR_CONST: usize = 10;
 
-    let mut it = addr.split("/").fuse().skip(1).peekable();
+    let mut it = addr.split('/').fuse().skip(1).peekable();
     let (prefix, from, to) = match (it.next(), it.next(), it.next(), it.next(), it.next()) {
         (Some("udp"), Some("from"), Some(from), Some("to"), Some(to)) if it.peek().is_some() => {
             ("/udp", from, to)
@@ -860,5 +875,5 @@ fn parse_from_to_addr(addr: &str) -> anyhow::Result<(NodeId, NodeId, String)> {
 fn gen_id() -> u64 {
     use rand::Rng;
     let mut rng = rand::thread_rng();
-    rng.gen::<u64>() & 0x1f_ff_ff__ff_ff_ff_ffu64
+    rng.gen::<u64>() & 0x001f_ffff_ffff_ffff_u64
 }

--- a/core/net/src/lib.rs
+++ b/core/net/src/lib.rs
@@ -2,6 +2,7 @@ pub use ya_core_model::net::{
     from, NetApiError, NetDst, NetSrc, RemoteEndpoint, TryRemoteEndpoint,
 };
 
+pub use config::Config;
 pub use service::{bind_broadcast_with_caller, broadcast, Net};
 
 mod bcast;

--- a/core/net/src/service.rs
+++ b/core/net/src/service.rs
@@ -45,7 +45,7 @@ impl Net {
         let config = Config::from_env()?;
 
         {
-            (*NET_TYPE.write().unwrap()) = config.net_type.clone();
+            (*NET_TYPE.write().unwrap()) = config.net_type;
         }
 
         match &config.net_type {
@@ -64,7 +64,7 @@ impl Net {
         let config = Config::from_env()?;
 
         {
-            (*NET_TYPE.write().unwrap()) = config.net_type.clone();
+            (*NET_TYPE.write().unwrap()) = config.net_type;
         }
 
         match &config.net_type {
@@ -90,7 +90,8 @@ where
     M: BroadcastMessage + Send + Sync + Unpin + 'static,
     S: ToString + 'static,
 {
-    match { NET_TYPE.read().unwrap().clone() } {
+    let net_type = { *NET_TYPE.read().unwrap() };
+    match net_type {
         NetType::Central => crate::central::broadcast(caller, message).await,
         NetType::Hybrid => crate::hybrid::broadcast(caller, message).await,
     }
@@ -112,7 +113,8 @@ where
         > + 'static,
     F: FnMut(String, SendBroadcastMessage<M>) -> T + Send + 'static,
 {
-    match { NET_TYPE.read().unwrap().clone() } {
+    let net_type = { *NET_TYPE.read().unwrap() };
+    match net_type {
         NetType::Central => {
             crate::central::bind_broadcast_with_caller(broadcast_address, handler).await
         }

--- a/core/payment/examples/payment_api.rs
+++ b/core/payment/examples/payment_api.rs
@@ -18,6 +18,7 @@ use ya_core_model::driver::{driver_bus_id, AccountMode, Fund, Init};
 use ya_core_model::identity;
 use ya_dummy_driver as dummy;
 use ya_erc20_driver as erc20;
+use ya_net::Config;
 use ya_payment::processor::PaymentProcessor;
 use ya_payment::{migrations, utils, PaymentService};
 use ya_persistence::executor::DbExecutor;
@@ -25,7 +26,6 @@ use ya_service_api_web::middleware::auth::dummy::DummyAuth;
 use ya_service_api_web::middleware::Identity;
 use ya_service_api_web::rest_api_addr;
 use ya_service_api_web::scope::ExtendableScope;
-use ya_service_bus::connection::ClientInfo;
 use ya_service_bus::typed as bus;
 use ya_zksync_driver as zksync;
 
@@ -339,9 +339,12 @@ async fn main() -> anyhow::Result<()> {
     let requestor_id = requestor_id.parse()?;
     log::info!("bind remote...");
 
-    let client_info = ClientInfo::new("payment");
-    let _ = ya_net::hybrid::bind_remote(client_info, provider_id, vec![provider_id, requestor_id])
-        .await?;
+    let _ = ya_net::hybrid::start_network(
+        Arc::new(Config::from_env()?),
+        provider_id,
+        vec![provider_id, requestor_id],
+    )
+    .await?;
 
     log::info!("get_rest_addr...");
     let rest_addr = rest_api_addr();


### PR DESCRIPTION
`ya_relay_client::Client` (single-threaded, neither `Send` nor `Sync`) is now operating in a dedicated thread.

Because the instance of `Client` is stored in thread-local memory, `ClientProxy` was
created to arbitrate communication between the threads (mainly CLI requests).

Other changes:

- ~development revision of `ya-relay-client` (`SessionDesc` struct export)~
- apply suggestions from `clippy`
- drop `ya_net::hybrid::service::bind_remote`