### PR TITLE
VPN - fix for fragmented IP packets

### DIFF
--- a/utils/networking/src/vpn/packet.rs
+++ b/utils/networking/src/vpn/packet.rs
@@ -242,7 +242,7 @@ impl<'a> PeekPacket<'a> for IpV4Packet<'a> {
         let len = ntoh_u16(&data[Ipv4Field::TOTAL_LEN]).unwrap() as usize;
         let payload_off = Self::read_header_len(data);
 
-        if data_len < len || len < payload_off {
+        if len < payload_off {
             return Err(Error::PacketMalformed("IPv4: payload too short".into()));
         }
         Ok(())


### PR DESCRIPTION
Remove the unnecessary check for payload size; the fragment offset has not been accounted in and is not mandatory in this case