### PR TITLE
Raw VPN GSB endpoint + GSB message compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7786,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-client"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=79611124e2ef908505c7ff79ff1719cfb1a2b6fb#79611124e2ef908505c7ff79ff1719cfb1a2b6fb"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=fd3a22bfa2ae173dce3d3d1bd70ea846b4454c7a#fd3a22bfa2ae173dce3d3d1bd70ea846b4454c7a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7801,13 +7801,13 @@ dependencies = [
  "url",
  "ya-relay-core",
  "ya-relay-proto",
- "ya-relay-stack 0.4.0 (git+https://github.com/golemfactory/ya-relay.git?rev=79611124e2ef908505c7ff79ff1719cfb1a2b6fb)",
+ "ya-relay-stack 0.4.0 (git+https://github.com/golemfactory/ya-relay.git?rev=fd3a22bfa2ae173dce3d3d1bd70ea846b4454c7a)",
 ]
 
 [[package]]
 name = "ya-relay-core"
-version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=79611124e2ef908505c7ff79ff1719cfb1a2b6fb#79611124e2ef908505c7ff79ff1719cfb1a2b6fb"
+version = "0.3.1"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=fd3a22bfa2ae173dce3d3d1bd70ea846b4454c7a#fd3a22bfa2ae173dce3d3d1bd70ea846b4454c7a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -7830,13 +7830,13 @@ dependencies = [
  "uuid",
  "ya-client-model 0.4.0",
  "ya-relay-proto",
- "ya-relay-stack 0.4.0 (git+https://github.com/golemfactory/ya-relay.git?rev=79611124e2ef908505c7ff79ff1719cfb1a2b6fb)",
+ "ya-relay-stack 0.4.0 (git+https://github.com/golemfactory/ya-relay.git?rev=fd3a22bfa2ae173dce3d3d1bd70ea846b4454c7a)",
 ]
 
 [[package]]
 name = "ya-relay-proto"
 version = "0.3.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=79611124e2ef908505c7ff79ff1719cfb1a2b6fb#79611124e2ef908505c7ff79ff1719cfb1a2b6fb"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=fd3a22bfa2ae173dce3d3d1bd70ea846b4454c7a#fd3a22bfa2ae173dce3d3d1bd70ea846b4454c7a"
 dependencies = [
  "anyhow",
  "bytes 1.1.0",
@@ -7871,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "ya-relay-stack"
 version = "0.4.0"
-source = "git+https://github.com/golemfactory/ya-relay.git?rev=79611124e2ef908505c7ff79ff1719cfb1a2b6fb#79611124e2ef908505c7ff79ff1719cfb1a2b6fb"
+source = "git+https://github.com/golemfactory/ya-relay.git?rev=fd3a22bfa2ae173dce3d3d1bd70ea846b4454c7a#fd3a22bfa2ae173dce3d3d1bd70ea846b4454c7a"
 dependencies = [
  "derive_more",
  "futures 0.3.21",
@@ -7907,7 +7907,7 @@ dependencies = [
 [[package]]
 name = "ya-sb-proto"
 version = "0.4.0"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=a60f7476c39a18fd3a369b3045b878544ae25598#a60f7476c39a18fd3a369b3045b878544ae25598"
+source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=dffa797a27533fa3c9b9566a3527601fc33bb5b4#dffa797a27533fa3c9b9566a3527601fc33bb5b4"
 dependencies = [
  "bytes 1.1.0",
  "prost 0.10.4",
@@ -7921,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "ya-sb-router"
 version = "0.4.5"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=a60f7476c39a18fd3a369b3045b878544ae25598#a60f7476c39a18fd3a369b3045b878544ae25598"
+source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=dffa797a27533fa3c9b9566a3527601fc33bb5b4#dffa797a27533fa3c9b9566a3527601fc33bb5b4"
 dependencies = [
  "actix",
  "actix-rt",
@@ -7949,7 +7949,7 @@ dependencies = [
 [[package]]
 name = "ya-sb-util"
 version = "0.2.0"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=a60f7476c39a18fd3a369b3045b878544ae25598#a60f7476c39a18fd3a369b3045b878544ae25598"
+source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=dffa797a27533fa3c9b9566a3527601fc33bb5b4#dffa797a27533fa3c9b9566a3527601fc33bb5b4"
 dependencies = [
  "actix",
  "bitflags",
@@ -8038,14 +8038,15 @@ dependencies = [
 
 [[package]]
 name = "ya-service-bus"
-version = "0.4.10"
-source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=a60f7476c39a18fd3a369b3045b878544ae25598#a60f7476c39a18fd3a369b3045b878544ae25598"
+version = "0.4.11"
+source = "git+https://github.com/golemfactory/ya-service-bus.git?rev=dffa797a27533fa3c9b9566a3527601fc33bb5b4#dffa797a27533fa3c9b9566a3527601fc33bb5b4"
 dependencies = [
  "actix",
  "flexbuffers",
  "futures 0.3.21",
  "lazy_static",
  "log",
+ "miniz_oxide",
  "rand 0.8.5",
  "semver 0.11.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,10 +181,10 @@ ya-service-api-interfaces = { path = "core/serv-api/interfaces" }
 ya-service-api-web = { path = "core/serv-api/web" }
 
 ## SERVICE BUS
-ya-service-bus = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "a60f7476c39a18fd3a369b3045b878544ae25598"}
-ya-sb-proto = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "a60f7476c39a18fd3a369b3045b878544ae25598"}
-ya-sb-router = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "a60f7476c39a18fd3a369b3045b878544ae25598"}
-ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "a60f7476c39a18fd3a369b3045b878544ae25598"}
+ya-service-bus = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "dffa797a27533fa3c9b9566a3527601fc33bb5b4"}
+ya-sb-proto = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "dffa797a27533fa3c9b9566a3527601fc33bb5b4"}
+ya-sb-router = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "dffa797a27533fa3c9b9566a3527601fc33bb5b4"}
+ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "dffa797a27533fa3c9b9566a3527601fc33bb5b4"}
 
 ## CLIENT
 ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "3883172196e29eea4665176d92ea91571305beb2" }

--- a/core/net/Cargo.toml
+++ b/core/net/Cargo.toml
@@ -15,7 +15,7 @@ ya-client-model = "0.4"
 ya-core-model = { version = "^0.7", features=["net", "identity"] }
 
 # ya-relay-client = "0.2"
-ya-relay-client = { git = "https://github.com/golemfactory/ya-relay.git", rev = "79611124e2ef908505c7ff79ff1719cfb1a2b6fb" }
+ya-relay-client = { git = "https://github.com/golemfactory/ya-relay.git", rev = "fd3a22bfa2ae173dce3d3d1bd70ea846b4454c7a" }
 
 ya-sb-proto = { version = "0.4" }
 ya-service-api = "0.1"

--- a/core/net/src/hybrid/service.rs
+++ b/core/net/src/hybrid/service.rs
@@ -67,6 +67,8 @@ impl Net {
     }
 
     pub async fn gsb<Context>(_: Context, config: Config) -> anyhow::Result<()> {
+        ya_service_bus::serialization::CONFIG.set_compress(true);
+
         let (default_id, ids) = crate::service::identities().await?;
         let (started_tx, started_rx) = oneshot::channel();
         let (shutdown_tx, shutdown_rx) = oneshot::channel();

--- a/core/vpn/src/network.rs
+++ b/core/vpn/src/network.rs
@@ -22,7 +22,7 @@ use crate::Result;
 use ya_core_model::activity::{VpnControl, VpnPacket};
 use ya_core_model::NodeId;
 use ya_service_bus::typed::{self, Endpoint};
-use ya_service_bus::{actix_rpc, RpcEndpoint, RpcEnvelope};
+use ya_service_bus::{actix_rpc, RpcEndpoint, RpcEnvelope, RpcRawCall};
 use ya_utils_networking::vpn::common::{to_ip, to_net};
 use ya_utils_networking::vpn::*;
 
@@ -79,7 +79,7 @@ impl VpnSupervisor {
 
     pub async fn create_network(
         &mut self,
-        node_id: &NodeId,
+        node_id: NodeId,
         network: ya_client_model::net::NewNetwork,
     ) -> Result<ya_client_model::net::Network> {
         let net = to_net(&network.ip, network.mask.as_ref())?;
@@ -103,7 +103,7 @@ impl VpnSupervisor {
             .arbiter
             .spawn_ext(async move {
                 let stack = Stack::new(net_ip, net_route(net_gw.clone())?);
-                let vpn = Vpn::new(stack, vpn_net);
+                let vpn = Vpn::new(node_id, stack, vpn_net);
                 Ok::<_, Error>(vpn.start())
             })
             .await?;
@@ -188,14 +188,20 @@ impl VpnSupervisor {
 }
 
 pub struct Vpn {
+    node_id: String,
     vpn: Network<network::DuoEndpoint<Endpoint>>,
     stack: Stack<'static>,
     connections: HashMap<SocketHandle, Connection>,
 }
 
 impl Vpn {
-    pub fn new(stack: Stack<'static>, vpn: Network<network::DuoEndpoint<Endpoint>>) -> Self {
+    pub fn new(
+        node_id: NodeId,
+        stack: Stack<'static>,
+        vpn: Network<network::DuoEndpoint<Endpoint>>,
+    ) -> Self {
         Self {
+            node_id: node_id.to_string(),
             vpn,
             stack,
             connections: Default::default(),
@@ -312,8 +318,10 @@ impl Vpn {
             };
 
             let id = vpn_id.clone();
+            let fut = endpoint.udp.call_raw_as(&self.node_id, frame.into());
+
             tokio::task::spawn_local(async move {
-                if let Err(err) = endpoint.udp.send(VpnPacket(frame.into())).await {
+                if let Err(err) = fut.await {
                     let addr = endpoint.tcp.addr();
                     log::warn!("VPN {}: send error to endpoint '{}': {}", id, addr, err);
                 }
@@ -330,7 +338,10 @@ impl Actor for Vpn {
     fn started(&mut self, ctx: &mut Self::Context) {
         let id = self.vpn.id();
         let vpn_url = gsb_local_url(&id);
-        actix_rpc::bind::<VpnPacket>(&vpn_url, ctx.address().recipient());
+        let addr = ctx.address();
+
+        actix_rpc::bind(&vpn_url, addr.clone().recipient());
+        actix_rpc::bind_raw(&format!("{vpn_url}/raw"), addr.recipient());
 
         ctx.run_interval(STACK_POLL_INTERVAL, |this, ctx| {
             this.poll(ctx.address());
@@ -350,6 +361,7 @@ impl Actor for Vpn {
 
         async move {
             let _ = typed::unbind(&vpn_url).await;
+            let _ = typed::unbind(&format!("{vpn_url}/raw")).await;
             log::info!("VPN {} stopped", id);
         }
         .into_actor(self)
@@ -596,6 +608,16 @@ impl Handler<RpcEnvelope<VpnPacket>> for Vpn {
     }
 }
 
+impl Handler<RpcRawCall> for Vpn {
+    type Result = std::result::Result<Vec<u8>, ya_service_bus::Error>;
+
+    fn handle(&mut self, msg: RpcRawCall, ctx: &mut Self::Context) -> Self::Result {
+        self.stack.receive_phy(msg.body);
+        self.poll(ctx.address());
+        Ok(Vec::new())
+    }
+}
+
 impl Handler<DataSent> for Vpn {
     type Result = <DataSent as Message>::Result;
 
@@ -726,7 +748,7 @@ fn gsb_local_url(net_id: &str) -> String {
 fn gsb_remote_url(node_id: &str, net_id: &str) -> network::DuoEndpoint<Endpoint> {
     network::DuoEndpoint {
         tcp: typed::service(format!("/net/{}/vpn/{}", node_id, net_id)),
-        udp: typed::service(format!("/udp/net/{}/vpn/{}", node_id, net_id)),
+        udp: typed::service(format!("/udp/net/{}/vpn/{}/raw", node_id, net_id)),
     }
 }
 
@@ -775,7 +797,7 @@ mod tests {
         let mut supervisor = VpnSupervisor::default();
         let network = supervisor
             .create_network(
-                &node_id,
+                node_id,
                 NewNetwork {
                     ip: "10.0.0.0".to_string(),
                     mask: None,

--- a/core/vpn/src/requestor.rs
+++ b/core/vpn/src/requestor.rs
@@ -73,7 +73,7 @@ async fn create_network(
     let network = model.into_inner();
     let mut supervisor = vpn_sup.lock().await;
     let network = supervisor
-        .create_network(&identity.identity, network)
+        .create_network(identity.identity, network)
         .await?;
     Ok::<_, ApiError>(web::Json(network))
 }

--- a/exe-unit/src/network.rs
+++ b/exe-unit/src/network.rs
@@ -174,7 +174,7 @@ fn write_prefix(dst: &mut Vec<u8>) {
 fn gsb_endpoint(node_id: &str, net_id: &str) -> DuoEndpoint<GsbEndpoint> {
     DuoEndpoint {
         tcp: typed::service(format!("/net/{}/vpn/{}", node_id, net_id)),
-        udp: typed::service(format!("/udp/net/{}/vpn/{}", node_id, net_id)),
+        udp: typed::service(format!("/udp/net/{}/vpn/{}/raw", node_id, net_id)),
     }
 }
 

--- a/utils/networking/src/vpn/network.rs
+++ b/utils/networking/src/vpn/network.rs
@@ -24,7 +24,7 @@ impl<E> Default for Networks<E> {
 
 impl<E: Clone> Networks<E> {
     pub fn get_mut(&mut self, id: &str) -> Result<&mut Network<E>, Error> {
-        self.networks.get_mut(id).ok_or_else(|| Error::NetNotFound)
+        self.networks.get_mut(id).ok_or(Error::NetNotFound)
     }
 
     pub fn endpoint<B: AsRef<[u8]>>(&self, ip: B) -> Option<E> {
@@ -50,8 +50,7 @@ impl<E: Clone> Networks<E> {
         if self
             .networks
             .values()
-            .find(|n| n.as_ref() == &network || n.as_ref().contains(&network.addr()))
-            .is_some()
+            .any(|n| n.as_ref() == &network || n.as_ref().contains(&network.addr()))
         {
             return Err(Error::NetAddrTaken(network.addr()));
         }
@@ -96,11 +95,7 @@ impl<E> Network<E> {
     }
 
     pub fn address(&self) -> Result<IpAddr, Error> {
-        self.addresses
-            .iter()
-            .next()
-            .cloned()
-            .ok_or_else(|| Error::NetEmpty)
+        self.addresses.iter().next().cloned().ok_or(Error::NetEmpty)
     }
 
     pub fn endpoints(&self) -> &HashMap<Box<[u8]>, E> {
@@ -112,7 +107,7 @@ impl<E> Network<E> {
     }
 
     pub fn add_address(&mut self, ip: &str) -> Result<(), Error> {
-        let ip = to_ip(ip.as_ref())?;
+        let ip = to_ip(ip)?;
         if !self.network.contains(&ip) {
             return Err(Error::NetAddr(ip.to_string()));
         }
@@ -129,7 +124,7 @@ impl<E> Network<E> {
         }
 
         let node_id = id.to_string();
-        let ip: Box<[u8]> = hton(ip_addr).into();
+        let ip: Box<[u8]> = hton(ip_addr);
 
         if self.endpoints.contains_key(&ip) {
             return Err(Error::IpAddrTaken(ip_addr));
@@ -145,11 +140,11 @@ impl<E> Network<E> {
     }
 
     pub fn remove_node(&mut self, node_id: &str) {
-        self.nodes.remove(node_id).map(|addrs| {
+        if let Some(addrs) = self.nodes.remove(node_id) {
             addrs.into_iter().for_each(|a| {
                 self.endpoints.remove(&to_octets(a));
             });
-        });
+        }
     }
 }
 


### PR DESCRIPTION
Uses raw GSB endpoints for transmitting VPN packets.
- GSB messages are no longer serialized twice (flexbuffers + prost), final data size is reduced by over 100%
- enables GSB (embedded) message compression to reduce payload size