### PR TITLE
Add REST, GSB and CLI endpoints for listing and getting agreements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7303,7 +7303,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.6.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=3883172196e29eea4665176d92ea91571305beb2#3883172196e29eea4665176d92ea91571305beb2"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=f2d33f947a4b4f3e873a796e7439a2e5522c2005#f2d33f947a4b4f3e873a796e7439a2e5522c2005"
 dependencies = [
  "actix-codec",
  "awc",
@@ -7345,7 +7345,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.4.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=3883172196e29eea4665176d92ea91571305beb2#3883172196e29eea4665176d92ea91571305beb2"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=f2d33f947a4b4f3e873a796e7439a2e5522c2005#f2d33f947a4b4f3e873a796e7439a2e5522c2005"
 dependencies = [
  "bigdecimal 0.2.2",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,8 +187,8 @@ ya-sb-router = { git = "https://github.com/golemfactory/ya-service-bus.git", rev
 ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "f61744d5bedd12b136ad9523f918ac6f872012ad"}
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "3883172196e29eea4665176d92ea91571305beb2" }
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "3883172196e29eea4665176d92ea91571305beb2" }
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "f2d33f947a4b4f3e873a796e7439a2e5522c2005" }
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "f2d33f947a4b4f3e873a796e7439a2e5522c2005" }
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/core/activity/src/api.rs
+++ b/core/activity/src/api.rs
@@ -21,7 +21,8 @@ mod common {
     use actix_web::{web, HttpResponse, Responder};
     use futures::prelude::*;
 
-    use ya_core_model::{activity, NodeId, Role};
+    use ya_client_model::market::Role;
+    use ya_core_model::{activity, NodeId};
     use ya_persistence::executor::DbExecutor;
     use ya_service_api_web::middleware::Identity;
     use ya_service_bus::{timeout::IntoTimeoutFuture, RpcEndpoint};

--- a/core/activity/src/common.rs
+++ b/core/activity/src/common.rs
@@ -7,10 +7,10 @@ use uuid::Uuid;
 
 use ya_client_model::{
     activity::{ActivityState, ActivityUsage},
-    market::Agreement,
+    market::{Agreement, Role},
     NodeId,
 };
-use ya_core_model::{activity, market, Role};
+use ya_core_model::{activity, market};
 use ya_net::RemoteEndpoint;
 use ya_persistence::executor::DbExecutor;
 use ya_service_api_web::middleware::Identity;

--- a/core/activity/src/provider/mod.rs
+++ b/core/activity/src/provider/mod.rs
@@ -1,9 +1,9 @@
 //! Provider side operations
 use actix_web::{web, Responder};
 use ya_client_model::activity::{ActivityState, ProviderEvent};
+use ya_client_model::market::Role;
 use ya_service_bus::timeout::IntoTimeoutFuture;
 
-use ya_core_model::Role;
 use ya_persistence::executor::DbExecutor;
 use ya_service_api_web::middleware::Identity;
 

--- a/core/activity/src/provider/service.rs
+++ b/core/activity/src/provider/service.rs
@@ -6,12 +6,11 @@ use std::convert::From;
 use std::time::Duration;
 
 use ya_client_model::activity::{ActivityState, ActivityUsage, State, StatePair};
-use ya_client_model::market::agreement::State as AgreementState;
+use ya_client_model::market::{agreement::State as AgreementState, Role};
 use ya_client_model::NodeId;
 use ya_core_model::activity;
 use ya_core_model::activity::local::Credentials;
 use ya_core_model::activity::RpcMessageError;
-use ya_core_model::Role;
 use ya_persistence::executor::DbExecutor;
 use ya_service_bus::{timeout::*, typed::ServiceBinder};
 

--- a/core/activity/src/requestor/control.rs
+++ b/core/activity/src/requestor/control.rs
@@ -12,8 +12,8 @@ use ya_client_model::activity::{
     ActivityState, CreateActivityRequest, CreateActivityResult, Credentials, ExeScriptCommand,
     ExeScriptRequest, SgxCredentials, State,
 };
-use ya_client_model::market::Agreement;
-use ya_core_model::{activity, Role};
+use ya_client_model::market::{Agreement, Role};
+use ya_core_model::activity;
 use ya_net::{self as net, RemoteEndpoint};
 use ya_persistence::executor::DbExecutor;
 use ya_service_api_web::middleware::Identity;

--- a/core/activity/src/requestor/state.rs
+++ b/core/activity/src/requestor/state.rs
@@ -1,6 +1,7 @@
 use actix_web::{web, Responder};
 
-use ya_core_model::{activity, Role};
+use ya_client_model::market::Role;
+use ya_core_model::activity;
 use ya_persistence::executor::DbExecutor;
 use ya_service_api_web::middleware::Identity;
 use ya_service_bus::{timeout::IntoTimeoutFuture, RpcEndpoint};

--- a/core/market/src/cli.rs
+++ b/core/market/src/cli.rs
@@ -1,0 +1,100 @@
+use chrono::{DateTime, Utc};
+use structopt::StructOpt;
+use ya_client::model::market::{agreement::State, Role};
+use ya_core_model::market::{GetAgreement, ListAgreements};
+use ya_service_api::{CliCtx, CommandOutput, ResponseTable};
+use ya_service_bus::{typed as bus, RpcEndpoint};
+
+/// Market management
+#[derive(StructOpt, Debug)]
+pub enum Command {
+    Agreements(AgreementsCommand),
+}
+
+impl Command {
+    pub async fn run_command(self, ctx: &CliCtx) -> anyhow::Result<CommandOutput> {
+        match self {
+            Command::Agreements(agreements_cmd) => agreements_cmd.run_command(ctx).await,
+        }
+    }
+}
+
+#[derive(StructOpt, Debug)]
+pub enum AgreementsCommand {
+    List {
+        #[structopt(long, help = "Only show agreements with this state")]
+        state: Option<State>,
+        #[structopt(long, help = "Only show agreements after this date, rfc3339")]
+        before: Option<DateTime<Utc>>,
+        #[structopt(long, help = "Only show agreements before this date, rfc3339")]
+        after: Option<DateTime<Utc>>,
+        #[structopt(long, help = "Only show agreements with this app session id")]
+        app_session_id: Option<String>,
+    },
+    Get {
+        #[structopt(long, help = "Agreement ID, may be obtained via list-agreements")]
+        id: String,
+        #[structopt(long, help = "Your role in the agreement (Provider | Requestor)")]
+        role: Role,
+    },
+}
+
+impl AgreementsCommand {
+    pub async fn run_command(self, _ctx: &CliCtx) -> anyhow::Result<CommandOutput> {
+        match self {
+            AgreementsCommand::List {
+                state,
+                before,
+                after,
+                app_session_id,
+            } => {
+                let request = ListAgreements {
+                    state: state.into(),
+                    before_date: before,
+                    after_date: after,
+                    app_session_id,
+                };
+
+                let agreements = bus::service(ya_core_model::market::BUS_ID)
+                    .send(request)
+                    .await??;
+
+                let mut agreements_json = Vec::new();
+                for agreement in agreements {
+                    agreements_json.push(serde_json::to_value([
+                        agreement.id,
+                        agreement.role.to_string(),
+                        agreement.creation_ts.to_rfc3339(),
+                        agreement
+                            .approve_ts
+                            .map(|ts| ts.to_rfc3339())
+                            .unwrap_or("N/A".to_owned()),
+                    ])?);
+                }
+
+                Ok(ResponseTable {
+                    columns: vec![
+                        "id".to_owned(),
+                        "role".to_owned(),
+                        "created".to_owned(),
+                        "approved".to_owned(),
+                    ],
+                    values: agreements_json,
+                }
+                .with_header("\nMatching agreements:\n".to_owned()))
+            }
+            AgreementsCommand::Get { id, role } => {
+                let request = GetAgreement {
+                    agreement_id: id,
+                    role,
+                };
+
+                let agreement = bus::service(ya_core_model::market::BUS_ID)
+                    .send(request)
+                    .await??;
+
+                CommandOutput::object(agreement)
+            }
+        }
+    }
+}

--- a/core/market/src/db/dao/agreement.rs
+++ b/core/market/src/db/dao/agreement.rs
@@ -1,4 +1,4 @@
-use chrono::{NaiveDateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
 use diesel::prelude::*;
 
 use ya_client::model::market::Reason;
@@ -61,6 +61,48 @@ pub enum AgreementDaoError {
 }
 
 impl<'c> AgreementDao<'c> {
+    pub async fn list(
+        &self,
+        node_id: Option<NodeId>,
+        state: Option<AgreementState>,
+        before: Option<DateTime<Utc>>,
+        after: Option<DateTime<Utc>>,
+        app_session_id: Option<String>,
+    ) -> Result<Vec<Agreement>, AgreementDaoError> {
+        do_with_transaction(self.pool, move |conn| {
+            let mut query = market_agreement.into_boxed();
+
+            if let Some(node_id) = node_id {
+                query = query.filter(
+                    agreement::provider_id
+                        .eq(node_id)
+                        .or(agreement::requestor_id.eq(node_id)),
+                );
+            };
+
+            if let Some(app_session_id) = app_session_id {
+                query = query.filter(agreement::session_id.eq(app_session_id))
+            }
+
+            if let Some(state) = state {
+                query = query.filter(agreement::state.eq(state));
+            }
+
+            if let Some(before) = before {
+                query = query.filter(agreement::creation_ts.lt(before.naive_utc()));
+            }
+
+            if let Some(after) = after {
+                query = query.filter(agreement::creation_ts.gt(after.naive_utc()));
+            }
+
+            let agreements = query.get_results::<Agreement>(conn)?;
+
+            Ok(agreements)
+        })
+        .await
+    }
+
     pub async fn select(
         &self,
         id: &AgreementId,

--- a/core/market/src/db/model/agreement.rs
+++ b/core/market/src/db/model/agreement.rs
@@ -194,6 +194,20 @@ impl From<AgreementState> for ClientAgreementState {
     }
 }
 
+impl From<ClientAgreementState> for AgreementState {
+    fn from(agreement_state: ClientAgreementState) -> Self {
+        match agreement_state {
+            ClientAgreementState::Proposal => AgreementState::Proposal,
+            ClientAgreementState::Pending => AgreementState::Pending,
+            ClientAgreementState::Cancelled => AgreementState::Cancelled,
+            ClientAgreementState::Rejected => AgreementState::Rejected,
+            ClientAgreementState::Approved => AgreementState::Approved,
+            ClientAgreementState::Expired => AgreementState::Expired,
+            ClientAgreementState::Terminated => AgreementState::Terminated,
+        }
+    }
+}
+
 pub fn check_transition(from: AgreementState, to: AgreementState) -> Result<(), AgreementDaoError> {
     log::trace!("Checking Agreement state transition: {} => {}", from, to);
     match from {

--- a/core/market/src/lib.rs
+++ b/core/market/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate diesel;
 
+mod cli;
 mod config;
 mod db;
 mod identity;

--- a/core/market/src/market.rs
+++ b/core/market/src/market.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 
 use crate::config::Config;
 use crate::db::dao::AgreementDao;
-use crate::db::model::{AgreementId, AppSessionId, SubscriptionId};
+use crate::db::model::{AgreementId, AppSessionId, Owner, SubscriptionId};
 use crate::identity::{IdentityApi, IdentityGSB};
 use crate::matcher::error::{
     DemandError, MatcherError, MatcherInitError, QueryDemandsError, QueryOfferError,
@@ -19,10 +19,11 @@ use crate::negotiation::error::{
 };
 use crate::negotiation::{EventNotifier, ProviderBroker, RequestorBroker};
 use crate::rest_api;
+use crate::testing::AgreementState;
 
 use ya_client::model::market::{
-    Agreement, AgreementOperationEvent as ClientAgreementEvent, Demand, NewDemand, NewOffer, Offer,
-    Reason,
+    Agreement, AgreementListEntry, AgreementOperationEvent as ClientAgreementEvent, Demand,
+    NewDemand, NewOffer, Offer, Reason, Role,
 };
 use ya_core_model::market::{local, BUS_ID};
 use ya_service_api_interfaces::{Provider, Service};
@@ -232,6 +233,41 @@ impl MarketService {
 
         counter!("market.demands.unsubscribed", 1);
         Ok(())
+    }
+
+    pub async fn list_agreements(
+        &self,
+        id: &Identity,
+        state: Option<AgreementState>,
+        before: Option<DateTime<Utc>>,
+        after: Option<DateTime<Utc>>,
+        app_sesssion_id: Option<String>,
+    ) -> Result<Vec<AgreementListEntry>, AgreementError> {
+        let agreements = self
+            .db
+            .as_dao::<AgreementDao>()
+            .list(Some(id.identity), state, before, after, app_sesssion_id)
+            .await
+            .map_err(|e| AgreementError::Internal(e.to_string()))?;
+
+        let mut result = Vec::new();
+        let naive_to_utc = |ts| DateTime::<Utc>::from_utc(ts, Utc);
+
+        for agreement in agreements {
+            let role = match agreement.id.owner() {
+                Owner::Provider => Role::Provider,
+                Owner::Requestor => Role::Requestor,
+            };
+
+            result.push(AgreementListEntry {
+                id: agreement.id.into_client(),
+                creation_ts: naive_to_utc(agreement.creation_ts),
+                approve_ts: agreement.approved_ts.map(naive_to_utc),
+                role,
+            });
+        }
+
+        Ok(result)
     }
 
     pub async fn get_agreement(

--- a/core/market/src/market.rs
+++ b/core/market/src/market.rs
@@ -321,7 +321,7 @@ impl MarketService {
 }
 
 impl Service for MarketService {
-    type Cli = ();
+    type Cli = crate::cli::Command;
 }
 
 // =========================================== //

--- a/core/market/src/market/agreement.rs
+++ b/core/market/src/market/agreement.rs
@@ -1,10 +1,6 @@
-use chrono;
-
-use ya_client::model::market::Agreement as ClientAgreement;
-use ya_core_model::{
-    market::{GetAgreement, RpcMessageError},
-    Role,
-};
+use chrono::{DateTime, Utc};
+use ya_client::model::market::{Agreement as ClientAgreement, AgreementListEntry, Role};
+use ya_core_model::market::{GetAgreement, ListAgreements, RpcMessageError};
 use ya_service_bus::typed::ServiceBinder;
 
 use crate::db::dao::AgreementDao;
@@ -13,8 +9,48 @@ use crate::db::DbMixedExecutor;
 
 pub async fn bind_gsb(db: DbMixedExecutor, public_prefix: &str, _local_prefix: &str) {
     log::trace!("Binding market agreement public service to service bus");
-    ServiceBinder::new(public_prefix, &db, ()).bind(get_agreement);
+    ServiceBinder::new(public_prefix, &db, ())
+        .bind(list_agreements)
+        .bind(get_agreement);
     log::debug!("Successfully bound market agreement public service to service bus");
+}
+
+async fn list_agreements(
+    db: DbMixedExecutor,
+    _sender_id: String,
+    msg: ListAgreements,
+) -> Result<Vec<AgreementListEntry>, RpcMessageError> {
+    let dao = db.as_dao::<AgreementDao>();
+
+    let agreements = dao
+        .list(
+            None,
+            msg.state.map(Into::into),
+            msg.before_date,
+            msg.after_date,
+            msg.app_session_id,
+        )
+        .await
+        .map_err(|e| RpcMessageError::Market(e.to_string()))?;
+
+    let mut result = Vec::new();
+    let naive_to_utc = |ts| DateTime::<Utc>::from_utc(ts, Utc);
+
+    for agreement in agreements {
+        let role = match agreement.id.owner() {
+            Owner::Provider => Role::Provider,
+            Owner::Requestor => Role::Requestor,
+        };
+
+        result.push(AgreementListEntry {
+            id: agreement.id.into_client(),
+            creation_ts: naive_to_utc(agreement.creation_ts),
+            approve_ts: agreement.approved_ts.map(naive_to_utc),
+            role,
+        });
+    }
+
+    Ok(result)
 }
 
 async fn get_agreement(

--- a/core/market/src/negotiation/error.rs
+++ b/core/market/src/negotiation/error.rs
@@ -68,8 +68,12 @@ pub enum AgreementError {
     Get(String, AgreementDaoError),
     #[error("Agreement [{0}]. Error: {1}")]
     UpdateState(AgreementId, AgreementDaoError),
+    #[error("Invalid date. {0}")]
+    InvalidDate(#[from] chrono::ParseError),
     #[error("Invalid Agreement id. {0}")]
     InvalidId(#[from] ProposalIdParseError),
+    #[error("Invalid Agreement state. {0}")]
+    InvalidAgreementState(#[from] strum::ParseError),
     #[error(transparent)]
     Gsb(#[from] GsbAgreementError),
     #[error("Protocol error: {0}")]

--- a/core/market/src/rest_api.rs
+++ b/core/market/src/rest_api.rs
@@ -9,7 +9,7 @@ use actix_web::{error::InternalError, http::StatusCode, web::PathConfig};
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 
-use ya_client::model::ErrorMessage;
+use ya_client::model::{market::agreement::State, ErrorMessage};
 
 use crate::db::model::{
     AgreementId, AppSessionId, Owner, ProposalId, ProposalIdParseError, SubscriptionId,
@@ -57,6 +57,15 @@ pub struct PathSubscription {
 pub struct PathSubscriptionProposal {
     pub subscription_id: SubscriptionId,
     pub proposal_id: ProposalId,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryAgreementList {
+    pub state: Option<State>,
+    pub before_date: Option<DateTime<Utc>>,
+    pub after_date: Option<DateTime<Utc>>,
+    pub app_session_id: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/core/market/src/rest_api/error.rs
+++ b/core/market/src/rest_api/error.rs
@@ -216,6 +216,8 @@ impl ResponseError for AgreementError {
             | AgreementError::OwnProposal(..)
             | AgreementError::ProposalNotFound(..)
             | AgreementError::ProposalCountered(..)
+            | AgreementError::InvalidDate(..)
+            | AgreementError::InvalidAgreementState(..)
             | AgreementError::InvalidId(..) => HttpResponse::BadRequest().json(msg).into(),
             AgreementError::GetProposal(..)
             | AgreementError::Save(..)

--- a/core/model/src/activity.rs
+++ b/core/model/src/activity.rs
@@ -5,7 +5,6 @@
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
-use crate::Role;
 use ya_client_model::activity::{
     ActivityState, ActivityUsage, ExeScriptCommand, ExeScriptCommandResult, ExeScriptCommandState,
     RuntimeEvent,
@@ -280,6 +279,7 @@ pub mod local {
     use super::*;
     use chrono::{DateTime, Utc};
     use std::collections::BTreeMap;
+    use ya_client_model::market::Role;
 
     /// Local activity bus address.
     pub const BUS_ID: &str = "/local/activity";

--- a/core/model/src/lib.rs
+++ b/core/model/src/lib.rs
@@ -31,12 +31,4 @@ pub mod sgx;
 #[cfg(feature = "version")]
 pub mod version;
 
-use derive_more::Display;
-use serde::{Deserialize, Serialize};
 pub use ya_client_model::NodeId;
-
-#[derive(Clone, Copy, Debug, Display, PartialEq, Serialize, Deserialize)]
-pub enum Role {
-    Provider,
-    Requestor,
-}

--- a/core/model/src/market.rs
+++ b/core/model/src/market.rs
@@ -1,8 +1,9 @@
 //! Market service bus API.
+use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::Role;
-pub use ya_client_model::market::Agreement;
+use ya_client_model::market::{agreement::State, Role};
+pub use ya_client_model::market::{Agreement, AgreementListEntry};
 use ya_service_bus::RpcMessage;
 
 /// Public Market bus address.
@@ -38,6 +39,22 @@ impl GetAgreement {
 impl RpcMessage for GetAgreement {
     const ID: &'static str = "GetAgreement";
     type Item = Agreement;
+    type Error = RpcMessageError;
+}
+
+/// Lists all agreements
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ListAgreements {
+    pub state: Option<State>,
+    pub before_date: Option<DateTime<Utc>>,
+    pub after_date: Option<DateTime<Utc>>,
+    pub app_session_id: Option<String>,
+}
+
+impl RpcMessage for ListAgreements {
+    const ID: &'static str = "ListAgreements";
+    type Item = Vec<AgreementListEntry>;
     type Error = RpcMessageError;
 }
 

--- a/core/payment/src/api/debit_notes.rs
+++ b/core/payment/src/api/debit_notes.rs
@@ -160,7 +160,7 @@ async fn issue_debit_note(
 
     let agreement = match get_agreement_for_activity(
         activity_id.clone(),
-        ya_core_model::Role::Provider,
+        ya_client_model::market::Role::Provider,
     )
     .await
     {

--- a/core/payment/src/api/invoices.rs
+++ b/core/payment/src/api/invoices.rs
@@ -141,7 +141,12 @@ async fn issue_invoice(db: Data<DbExecutor>, body: Json<NewInvoice>, id: Identit
     let agreement_id = invoice.agreement_id.clone();
     let activity_ids = invoice.activity_ids.clone().unwrap_or_default();
 
-    let agreement = match get_agreement(agreement_id.clone(), ya_core_model::Role::Provider).await {
+    let agreement = match get_agreement(
+        agreement_id.clone(),
+        ya_client_model::market::Role::Provider,
+    )
+    .await
+    {
         Ok(Some(agreement)) => agreement,
         Ok(None) => {
             return response::bad_request(&format!("Agreement not found: {}", agreement_id))
@@ -150,7 +155,7 @@ async fn issue_invoice(db: Data<DbExecutor>, body: Json<NewInvoice>, id: Identit
     };
 
     for activity_id in activity_ids.iter() {
-        match get_agreement_id(activity_id.clone(), ya_core_model::Role::Provider).await {
+        match get_agreement_id(activity_id.clone(), ya_client_model::market::Role::Provider).await {
             Ok(Some(id)) if id != agreement_id => {
                 return response::bad_request(&format!(
                     "Activity {} belongs to agreement {} not {}",

--- a/core/payment/src/service.rs
+++ b/core/payment/src/service.rs
@@ -4,7 +4,6 @@ use futures::prelude::*;
 use metrics::counter;
 use std::collections::HashMap;
 use std::sync::Arc;
-use ya_core_model as core;
 use ya_persistence::executor::DbExecutor;
 use ya_service_bus::typed::ServiceBinder;
 
@@ -402,7 +401,12 @@ mod public {
         );
         counter!("payment.debit_notes.requestor.received.call", 1);
 
-        let agreement = match get_agreement(agreement_id.clone(), core::Role::Requestor).await {
+        let agreement = match get_agreement(
+            agreement_id.clone(),
+            ya_client_model::market::Role::Requestor,
+        )
+        .await
+        {
             Err(e) => {
                 return Err(SendError::ServiceError(e.to_string()));
             }
@@ -541,7 +545,12 @@ mod public {
         );
         counter!("payment.invoices.requestor.received.call", 1);
 
-        let agreement = match get_agreement(agreement_id.clone(), core::Role::Requestor).await {
+        let agreement = match get_agreement(
+            agreement_id.clone(),
+            ya_client_model::market::Role::Requestor,
+        )
+        .await
+        {
             Err(e) => {
                 return Err(SendError::ServiceError(e.to_string()));
             }
@@ -555,7 +564,12 @@ mod public {
         };
 
         for activity_id in activity_ids.iter() {
-            match provider::get_agreement_id(activity_id.clone(), core::Role::Requestor).await {
+            match provider::get_agreement_id(
+                activity_id.clone(),
+                ya_client_model::market::Role::Requestor,
+            )
+            .await
+            {
                 Ok(Some(id)) if id != agreement_id => {
                     return Err(SendError::BadRequest(format!(
                         "Activity {} belongs to agreement {} not {}",

--- a/core/payment/src/utils.rs
+++ b/core/payment/src/utils.rs
@@ -3,8 +3,8 @@ use actix_web::HttpResponse;
 use futures::Future;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-use ya_client_model::market::Agreement;
-use ya_core_model::{market, Role};
+use ya_client_model::market::{Agreement, Role};
+use ya_core_model::market;
 use ya_service_bus::{typed as bus, RpcEndpoint};
 
 pub fn fake_get_agreement(agreement_id: String, agreement: Agreement) {
@@ -43,8 +43,8 @@ pub async fn get_agreement(agreement_id: String, role: Role) -> Result<Option<Ag
 
 pub mod provider {
     use crate::error::{Error, ExternalServiceError};
-    use ya_client_model::market::Agreement;
-    use ya_core_model::{activity, market, Role};
+    use ya_client_model::market::{Agreement, Role};
+    use ya_core_model::{activity, market};
     use ya_service_bus::{typed as bus, RpcEndpoint};
 
     pub fn fake_get_agreement_id(agreement_id: String) {

--- a/core/serv/src/main.rs
+++ b/core/serv/src/main.rs
@@ -251,7 +251,7 @@ enum Services {
     //TODO enable VpnService::rest for v2 / or create common scope for v1 and v2
     #[enable(rest)]
     Vpn(VpnService),
-    #[enable(gsb, rest)]
+    #[enable(gsb, rest, cli)]
     Market(MarketService),
     #[enable(gsb, rest, cli)]
     Activity(ActivityService),


### PR DESCRIPTION
Adresses #1658 and #2175.

Depends on https://github.com/golemfactory/ya-client/pull/124 -- when it gets merged, the patched `ya-client` and `ya-client-model` crates may be updated to point to the revision on `master`.