### PR TITLE
Bump ya-client revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7303,7 +7303,7 @@ dependencies = [
 [[package]]
 name = "ya-client"
 version = "0.6.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=f2d33f947a4b4f3e873a796e7439a2e5522c2005#f2d33f947a4b4f3e873a796e7439a2e5522c2005"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=ada12de80045f67670cc0d0fc7d9f2ee3d42ae11#ada12de80045f67670cc0d0fc7d9f2ee3d42ae11"
 dependencies = [
  "actix-codec",
  "awc",
@@ -7345,7 +7345,7 @@ dependencies = [
 [[package]]
 name = "ya-client-model"
 version = "0.4.0"
-source = "git+https://github.com/golemfactory/ya-client.git?rev=f2d33f947a4b4f3e873a796e7439a2e5522c2005#f2d33f947a4b4f3e873a796e7439a2e5522c2005"
+source = "git+https://github.com/golemfactory/ya-client.git?rev=ada12de80045f67670cc0d0fc7d9f2ee3d42ae11#ada12de80045f67670cc0d0fc7d9f2ee3d42ae11"
 dependencies = [
  "bigdecimal 0.2.2",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,8 +187,8 @@ ya-sb-router = { git = "https://github.com/golemfactory/ya-service-bus.git", rev
 ya-sb-util = { git = "https://github.com/golemfactory/ya-service-bus.git", rev = "f61744d5bedd12b136ad9523f918ac6f872012ad"}
 
 ## CLIENT
-ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "f2d33f947a4b4f3e873a796e7439a2e5522c2005" }
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "f2d33f947a4b4f3e873a796e7439a2e5522c2005" }
+ya-client = { git = "https://github.com/golemfactory/ya-client.git", rev = "ada12de80045f67670cc0d0fc7d9f2ee3d42ae11" }
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "ada12de80045f67670cc0d0fc7d9f2ee3d42ae11" }
 
 ## OTHERS
 gftp = { path = "core/gftp" }

--- a/core/market/src/cli.rs
+++ b/core/market/src/cli.rs
@@ -64,9 +64,9 @@ impl AgreementsCommand {
                     agreements_json.push(serde_json::to_value([
                         agreement.id,
                         agreement.role.to_string(),
-                        agreement.creation_ts.to_rfc3339(),
+                        agreement.timestamp.to_rfc3339(),
                         agreement
-                            .approve_ts
+                            .approved_date
                             .map(|ts| ts.to_rfc3339())
                             .unwrap_or("N/A".to_owned()),
                     ])?);

--- a/core/market/src/market.rs
+++ b/core/market/src/market.rs
@@ -261,8 +261,8 @@ impl MarketService {
 
             result.push(AgreementListEntry {
                 id: agreement.id.into_client(),
-                creation_ts: naive_to_utc(agreement.creation_ts),
-                approve_ts: agreement.approved_ts.map(naive_to_utc),
+                timestamp: naive_to_utc(agreement.creation_ts),
+                approved_date: agreement.approved_ts.map(naive_to_utc),
                 role,
             });
         }

--- a/core/market/src/market/agreement.rs
+++ b/core/market/src/market/agreement.rs
@@ -44,8 +44,8 @@ async fn list_agreements(
 
         result.push(AgreementListEntry {
             id: agreement.id.into_client(),
-            creation_ts: naive_to_utc(agreement.creation_ts),
-            approve_ts: agreement.approved_ts.map(naive_to_utc),
+            timestamp: naive_to_utc(agreement.creation_ts),
+            approved_date: agreement.approved_ts.map(naive_to_utc),
             role,
         });
     }


### PR DESCRIPTION
Reflects changes in https://github.com/golemfactory/ya-client/pull/127. Adresses https://github.com/golemfactory/ya-client/issues/126.
The following fields of `AgreementListEntry` were renamed:
- `creation_ts` -> `timestamp`
- `approve_ts` -> `approved_date`