### PR TITLE
Add file descriptor metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3138,9 +3138,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libm"
@@ -3761,6 +3761,8 @@ dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
  "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
 ]
 
 [[package]]
@@ -7551,6 +7553,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ya-fd-metrics"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "nix 0.25.0",
+]
+
+[[package]]
 name = "ya-file-logging"
 version = "0.1.0"
 dependencies = [
@@ -8478,6 +8488,7 @@ dependencies = [
  "gftp",
  "lazy_static",
  "log",
+ "metrics 0.12.1",
  "openssl",
  "openssl-probe",
  "serde",
@@ -8494,6 +8505,7 @@ dependencies = [
  "ya-core-model",
  "ya-dummy-driver",
  "ya-erc20-driver",
+ "ya-fd-metrics",
  "ya-file-logging",
  "ya-identity",
  "ya-market",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ ya-utils-path = "0.1"
 ya-utils-futures = "0.2"
 ya-utils-process = { version = "0.2", features = ["lock"] }
 ya-utils-networking = "0.2"
+ya-fd-metrics = { path = "utils/fd-metrics" }
 ya-version = "0.2"
 ya-vpn = "0.2"
 ya-client = "0.7"
@@ -67,6 +68,7 @@ dotenv = "0.15.0"
 futures = "0.3"
 lazy_static = "1.4"
 log = "0.4"
+metrics = "0.12"
 openssl = "0.10"
 openssl-probe = { version = "0.1", optional = true }
 serde = "1.0"
@@ -155,6 +157,7 @@ members = [
     "utils/scheduler",
     "utils/transfer",
     "utils/diesel-utils",
+    "utils/fd-metrics",
     "core/metrics"
 ]
 

--- a/utils/fd-metrics/Cargo.toml
+++ b/utils/fd-metrics/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "ya-fd-metrics"
+version = "0.1.0"
+authors = ["Golem Factory <contact@golem.network>"]
+edition = "2021"
+description = "Provides file descriptor statistics"
+
+[dependencies]
+libc = "0.2.137"
+nix = "0.25"

--- a/utils/fd-metrics/src/lib.rs
+++ b/utils/fd-metrics/src/lib.rs
@@ -1,0 +1,133 @@
+#![allow(clippy::needless_return)]
+
+use std::{collections::HashMap, fmt::Display};
+
+/// Type of a file descriptor corresponding to st_mode in stat
+///
+/// See https://man7.org/linux/man-pages/man2/lstat.2.html
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum FdType {
+    Fifo,
+    Chr,
+    Dir,
+    Blk,
+    Reg,
+    Lnk,
+    Sock,
+    Fmt,
+    Other,
+}
+
+impl Display for FdType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use FdType::*;
+
+        write!(
+            f,
+            "{}",
+            match self {
+                Fifo => "fifo",
+                Chr => "chr",
+                Dir => "dir",
+                Blk => "blk",
+                Reg => "reg",
+                Lnk => "lnk",
+                Sock => "sock",
+                Fmt => "fmt",
+                Other => "other",
+            }
+        )
+    }
+}
+
+impl FdType {
+    /// List of all enum variants
+    pub fn all() -> [Self; 9] {
+        use FdType::*;
+
+        // Could use strum proc macro, but compilation times are already terrible enough
+        [Fifo, Chr, Dir, Blk, Reg, Lnk, Sock, Fmt, Other]
+    }
+}
+
+pub fn fd_metrics() -> HashMap<FdType, usize> {
+    let mut result = HashMap::new();
+
+    // populate all variants
+    for fd_type in FdType::all() {
+        result.insert(fd_type, 0);
+    }
+
+    let measured_fds = list_fds().into_iter().flat_map(fd_type);
+    for fd_type in measured_fds {
+        *result.get_mut(&fd_type).unwrap() += 1;
+    }
+
+    result
+}
+
+/// Maps fd to FdType
+///
+/// Uses fstat on unix, always returns None on Windows
+fn fd_type(fd: i32) -> Option<FdType> {
+    #[cfg(target_family = "unix")]
+    {
+        use nix::sys::stat::SFlag;
+
+        let stat = nix::sys::stat::fstat(fd).ok()?;
+
+        use FdType::*;
+        return Some(if stat.st_mode & SFlag::S_IFIFO.bits() != 0 {
+            Fifo
+        } else if stat.st_mode & SFlag::S_IFCHR.bits() != 0 {
+            Chr
+        } else if stat.st_mode & SFlag::S_IFDIR.bits() != 0 {
+            Dir
+        } else if stat.st_mode & SFlag::S_IFBLK.bits() != 0 {
+            Blk
+        } else if stat.st_mode & SFlag::S_IFREG.bits() != 0 {
+            Reg
+        } else if stat.st_mode & SFlag::S_IFLNK.bits() != 0 {
+            Lnk
+        } else if stat.st_mode & SFlag::S_IFSOCK.bits() != 0 {
+            Sock
+        } else if stat.st_mode & SFlag::S_IFMT.bits() != 0 {
+            Fmt
+        } else {
+            Other
+        });
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        return None;
+    }
+}
+
+/// List of all open file descriptors
+///
+/// Reads from `/proc/self/fd` on linux, empty Vec on other systems.
+///
+/// This is the function you need to modify to support other *nix systems.
+fn list_fds() -> Vec<i32> {
+    #[cfg(target_os = "linux")]
+    {
+        let fd_dir = if let Ok(fd_dir) = std::fs::read_dir("/proc/self/fd/") {
+            fd_dir
+        } else {
+            return Vec::new();
+        };
+
+        return fd_dir
+            .flat_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .flat_map(|fname| fname.into_string().ok())
+            .flat_map(|fname| fname.parse::<i32>().ok())
+            .collect();
+    }
+
+    #[cfg(not(all(target_os = "linux")))]
+    {
+        return Vec::new();
+    }
+}


### PR DESCRIPTION
This adds the `yagna.fds.FD_TYPE` metrics, where `FD_TYPE` can be:
* fifo
* chr
* dir
* blk
* reg
* lnk
* sock
* fmt
* other

Uses `/proc/self/fd` and `fstat` on Linux. All metrics are 0 on other operating systems.

### :ballot_box_with_check: Definition of Done checklist
- [x] The code is tested enough
- [x] Testability insights are recorded on https://www.notion.so/golemnetwork/Testability-a42886f72cb649129cddd65bc9dfe2b9
