### PR TITLE
Add timeout for NET shutdown

### DIFF
--- a/core/net/src/hybrid/service.rs
+++ b/core/net/src/hybrid/service.rs
@@ -27,6 +27,7 @@ use ya_relay_client::{Client, ClientBuilder, ForwardReceiver, TransportType};
 use ya_sb_proto::codec::GsbMessage;
 use ya_sb_proto::CallReplyCode;
 use ya_sb_util::RevPrefixes;
+use ya_service_bus::timeout::IntoTimeoutFuture;
 use ya_service_bus::untyped::{Fn4HandlerExt, Fn4StreamHandlerExt};
 use ya_service_bus::{
     serialization, typed, untyped as local_bus, Error, ResponseChunk, RpcEndpoint, RpcMessage,
@@ -95,7 +96,13 @@ impl Net {
 
     pub async fn shutdown() -> anyhow::Result<()> {
         if let Ok(client) = Self::client().await {
-            let _ = client.shutdown().await;
+            if let Err(_) = client
+                .shutdown()
+                .timeout(Some(std::time::Duration::from_secs(30)))
+                .await
+            {
+                log::info!("NET shutdown due to timeout.");
+            }
         }
         if let Some(sender) = { SHUTDOWN_TX.write().await.take() } {
             let _ = sender.send(());


### PR DESCRIPTION
resolves: https://github.com/golemfactory/yagna-triage/issues/235

This is rather workaround than solution, but users won't have to kill yagna process

### :ballot_box_with_check: Definition of Done checklist
- [x] The code is tested enough
- [x] Testability insights are recorded on https://www.notion.so/golemnetwork/Testability-a42886f72cb649129cddd65bc9dfe2b9
