### PR TITLE
Fix poetry version for nightly goth build

### DIFF
--- a/.github/workflows/integration-test-nightly.yml
+++ b/.github/workflows/integration-test-nightly.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Configure Poetry
         uses: Gr1N/setup-poetry@v7
         with:
-          poetry-version: 1.1.6
+          poetry-version: 1.2.2
 
       - name: Install dependencies
         run: poetry install --no-root


### PR DESCRIPTION
Poetry version was missed in https://github.com/golemfactory/yagna/commit/37539868b0aa52f9df0a133b4aa5467a309c2a7f
And nightly consistently fails since that change got merged so I think this will fix the build.

### :ballot_box_with_check: Definition of Done checklist
- [x] The code is tested enough
- [x] Testability insights are recorded on https://www.notion.so/golemnetwork/Testability-a42886f72cb649129cddd65bc9dfe2b9
