### PR TITLE
Fix vpn with manifest

### DIFF
--- a/exe-unit/src/manifest.rs
+++ b/exe-unit/src/manifest.rs
@@ -41,9 +41,12 @@ impl ManifestContext {
     pub fn try_new(agreement: &AgreementView) -> anyhow::Result<Self> {
         let policy = PolicyConfig::from_args_safe().unwrap_or_default();
         let manifest = read_manifest(agreement).context("Unable to read manifest")?;
-        let features = match manifest {
-            Some(ref manifest) => manifest.features(),
-            None => Self::build_default_features(agreement),
+        let features = {
+            let mut features = Self::build_default_features(agreement);
+            if let Some(ref manifest) = manifest {
+                features.extend(manifest.features().into_iter());
+            }
+            features
         };
 
         Ok(Self {

--- a/exe-unit/src/network/inet.rs
+++ b/exe-unit/src/network/inet.rs
@@ -43,7 +43,8 @@ use crate::message::Shutdown;
 use crate::network::Endpoint;
 use crate::{Error, Result};
 
-const IP4_ADDRESS: Ipv4Addr = Ipv4Addr::new(9, 0, 0x0d, 0x01);
+// 10.0.0.0/8 is a reserved private address space
+const IP4_ADDRESS: Ipv4Addr = Ipv4Addr::new(10, 42, 42, 1);
 const IP6_ADDRESS: Ipv6Addr = IP4_ADDRESS.to_ipv6_mapped();
 const TCP_KEEP_ALIVE: Duration = Duration::from_secs(30);
 const DEFAULT_MAX_PACKET_SIZE: usize = 65536;


### PR DESCRIPTION
Load default features even when manifest is present.
Changed IP for outbound feature to use a reserved private address space to avoid accidentally masking out valid public IPs.

### :ballot_box_with_check: Definition of Done checklist
- [x] The code is tested enough
- [x] Testability insights are recorded on https://www.notion.so/golemnetwork/Testability-a42886f72cb649129cddd65bc9dfe2b9
