### PR TITLE
Replace actix_rt with tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2440,7 +2440,6 @@ dependencies = [
 name = "golemsp"
 version = "0.3.0"
 dependencies = [
- "actix-rt",
  "ansi_term",
  "anyhow",
  "bigdecimal 0.2.2",

--- a/golem_cli/Cargo.toml
+++ b/golem_cli/Cargo.toml
@@ -13,7 +13,6 @@ ya-provider = "0.3"
 ya-utils-path = "0.1.0"
 ya-utils-process = { version = "0.2", features = ["lock"] }
 
-actix-rt="2.7"
 ansi_term="0.12.1"
 anyhow = "1.0"
 bigdecimal = "0.2"
@@ -36,7 +35,7 @@ strip-ansi-escapes = "0.1"
 structopt = "0.3"
 strum = "0.24"
 strum_macros = "0.24"
-tokio = { version = "1", features = ["process", "signal", "time", "io-util", "io-std", "macros"] }
+tokio = { version = "1", features = ["process", "signal", "time", "io-util", "io-std", "macros", "rt"] }
 url = "2.1"
 
 [target.'cfg(target_family = "unix")'.dependencies]

--- a/golem_cli/src/main.rs
+++ b/golem_cli/src/main.rs
@@ -136,7 +136,7 @@ pub fn banner() {
     .unwrap();
 }
 
-#[actix_rt::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     std::process::exit(match my_main().await {
         Ok(code) => code,


### PR DESCRIPTION
Resolves #2308 

Replaced actix_rt single threaded runtime with the tokio solution as golem_cli does not use any other actix component.

### :ballot_box_with_check: Definition of Done checklist
- [x] The code is tested enough
- [x] Testability insights are recorded on https://www.notion.so/golemnetwork/Testability-a42886f72cb649129cddd65bc9dfe2b9
