### PR TITLE
Fix manifest negotiator test whitelists. Change default matching to more restrictive option.

### DIFF
--- a/utils/manifest-utils/src/matching/domain.rs
+++ b/utils/manifest-utils/src/matching/domain.rs
@@ -88,7 +88,7 @@ pub struct DomainPattern {
 
 impl DomainPattern {
     fn default_domain_match() -> ArgMatch {
-        ArgMatch::Regex
+        ArgMatch::Strict
     }
 }
 


### PR DESCRIPTION
Resolves: #2419 

The whitelist was malformed in the tests.
The default matching should be the most restrictive option.