### PR TITLE
goth: specify ubuntu version

### DIFF
--- a/.github/workflows/integration-test-hybrid-net.yml
+++ b/.github/workflows/integration-test-hybrid-net.yml
@@ -26,7 +26,7 @@ jobs:
 
   integration-test:
     name: Integration Tests (hybrid-net)
-    runs-on: goth
+    runs-on: [goth, ubuntu-18.04]
     needs: test_check
     defaults:
       run:

--- a/.github/workflows/integration-test-nightly.yml
+++ b/.github/workflows/integration-test-nightly.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix-json) }}
       fail-fast: false
-    runs-on: goth
+    runs-on: [goth, ubuntu-18.04]
     name: Integration Tests (nightly) @ ${{ matrix.branch }}
     defaults:
       run:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -26,7 +26,7 @@ jobs:
 
   integration-test:
     name: Integration Tests
-    runs-on: goth
+    runs-on: [goth, ubuntu-18.04]
     needs: test_check
     defaults:
       run:


### PR DESCRIPTION
Prepare for runners update by pinning current version.

https://docs.github.com/en/actions/using-github-hosted-runners/using-larger-runners#using-multiple-labels
> You can specify multiple labels that need to be matched for a job to run on a runner. A runner will need to match all labels to be eligible to run the job.