### PR TITLE
Improve Offers display

### DIFF
--- a/agent/provider/src/execution/task_runner.rs
+++ b/agent/provider/src/execution/task_runner.rs
@@ -631,7 +631,7 @@ impl Handler<GetOfferTemplates> for TaskRunner {
                     _ => anyhow::bail!("offer template: invalid usage vector format"),
                 }
 
-                log::info!("offer-template: {} = {:?}", preset.name, template);
+                log::debug!("offer-template: {} = {:?}", preset.name, template);
                 result.insert(preset.name, template);
             }
             Ok(result)

--- a/agent/provider/src/market/provider_market.rs
+++ b/agent/provider/src/market/provider_market.rs
@@ -674,7 +674,11 @@ impl Handler<CreateOffer> for ProviderMarket {
                     msg.preset.name,
                 ))?;
 
-            log::debug!("Offer created: {}", offer.display());
+            log::info!(
+                "Offer for preset: {} = {}",
+                msg.preset.name,
+                offer.display()
+            );
 
             log::info!("Subscribing to events... [{}]", msg.preset.name);
 

--- a/utils/agreement-utils/src/template.rs
+++ b/utils/agreement-utils/src/template.rs
@@ -85,6 +85,13 @@ impl OfferTemplate {
             .collect();
         Ok(map)
     }
+
+    pub fn flatten(&self) -> OfferTemplate {
+        OfferTemplate {
+            properties: flatten_value(self.clone().properties),
+            constraints: self.constraints.clone(),
+        }
+    }
 }
 
 pub fn patch(a: &mut Value, b: Value) {
@@ -112,12 +119,9 @@ pub fn property_to_pointer_paths(property: &str) -> PointerPaths {
     PointerPaths { path, path_w_tag }
 }
 
-impl<'a> std::fmt::Display for OfferTemplate {
+impl std::fmt::Display for OfferTemplate {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let template = OfferTemplate {
-            properties: flatten_value(self.clone().properties),
-            constraints: self.constraints.clone(),
-        };
+        let template = self.flatten();
 
         // Display not pretty version as fallback.
         match serde_json::to_string_pretty(&template) {
@@ -129,10 +133,7 @@ impl<'a> std::fmt::Display for OfferTemplate {
 
 impl std::fmt::Debug for OfferTemplate {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let template = OfferTemplate {
-            properties: flatten_value(self.clone().properties),
-            constraints: self.constraints.clone(),
-        };
+        let template = self.flatten();
 
         // Display not pretty version as fallback.
         match serde_json::to_string(&template) {

--- a/utils/agreement-utils/src/template.rs
+++ b/utils/agreement-utils/src/template.rs
@@ -1,13 +1,14 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
+use std::fmt::Formatter;
 
-use crate::agreement::{flatten, PROPERTY_TAG};
+use crate::agreement::{flatten, flatten_value, PROPERTY_TAG};
 use crate::Error;
 
 /// TODO: Could we use Constraints instead of String?? This would require parsing string.
 ///  It is complicated, but we could use code from resolver to do this.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct OfferTemplate {
     pub properties: Value,
     pub constraints: String,
@@ -109,4 +110,34 @@ pub fn property_to_pointer_paths(property: &str) -> PointerPaths {
     let path = format!("/{}", property.replace('.', "/"));
     let path_w_tag = format!("{path}/{PROPERTY_TAG}");
     PointerPaths { path, path_w_tag }
+}
+
+impl<'a> std::fmt::Display for OfferTemplate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let template = OfferTemplate {
+            properties: flatten_value(self.clone().properties),
+            constraints: self.constraints.clone(),
+        };
+
+        // Display not pretty version as fallback.
+        match serde_json::to_string_pretty(&template) {
+            Ok(json) => write!(f, "{}", json),
+            Err(_) => write!(f, "{:?}", template),
+        }
+    }
+}
+
+impl std::fmt::Debug for OfferTemplate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let template = OfferTemplate {
+            properties: flatten_value(self.clone().properties),
+            constraints: self.constraints.clone(),
+        };
+
+        // Display not pretty version as fallback.
+        match serde_json::to_string(&template) {
+            Ok(json) => write!(f, "{}", json),
+            Err(_) => write!(f, "(serialization error)"),
+        }
+    }
 }


### PR DESCRIPTION
Offer template displayed on Debug level.
Offer displayed on Info level

Replacing:
```
[2023-02-03T15:13:36.012+0100 INFO  ya_provider::execution::task_runner] offer-template: vm = OfferTemplate { properties: Object {"golem.activity.caps.transfer.protocol": Array [String("http"), String("https"), String("gftp")], "golem.com.usage.vector": Array [String("golem.usage.duration_sec"), String("golem.usage.cpu_sec"), String("golem.usage.gib"), String("golem.usage.storage_gib"), String("golem.usage.cpu_sec"), String("golem.usage.duration_sec")], "golem.inf.cpu.brand": String("Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz"), "golem.inf.cpu.capabilities": Array [String("sse3"), String("pclmulqdq"), String("dtes64"), String("monitor"), String("dscpl"), String("vmx"), String("eist"), String("tm2"), String("ssse3"), String("fma"), String("cmpxchg16b"), String("pdcm"), String("pcid"), String("sse41"), String("sse42"), String("x2apic"), String("movbe"), String("popcnt"), String("tsc_deadline"), String("aesni"), String("xsave"), String("osxsave"), String("avx"), String("f16c"), String("rdrand"), String("fpu"), String("vme"), String("de"), String("pse"), String("tsc"), String("msr"), String("pae"), String("mce"), String("cx8"), String("apic"), String("sep"), String("mtrr"), String("pge"), String("mca"), String("cmov"), String("pat"), String("pse36"), String("clfsh"), String("ds"), String("acpi"), String("mmx"), String("fxsr"), String("sse"), String("sse2"), String("ss"), String("htt"), String("tm"), String("pbe"), String("fsgsbase"), String("adjust_msr"), String("bmi1"), String("avx2"), String("smep"), String("bmi2"), String("rep_movsb_stosb"), String("invpcid"), String("deprecate_fpu_cs_ds"), String("mpx"), String("rdseed"), String("adx"), String("smap"), String("clflushopt"), String("processor_trace"), String("sgx"), String("sgx_lc")], "golem.inf.cpu.model": String("Stepping 10 Family 6 Model 302"), "golem.inf.cpu.vendor": String("GenuineIntel"), "golem.runtime.capabilities": Array [String("inet"), String("vpn"), String("manifest-support"), String("start-entrypoint")]}, constraints: "" }
```
with:
```
[2023-02-06T13:49:05.075+0100 INFO  ya_provider::execution::task_runner] offer-template: vm = {"properties":{"golem.activity.caps.transfer.protocol":["http","https","gftp"],"golem.com.usage.vector":["golem.usage.duration_sec","golem.usage.cpu_sec","golem.usage.gib","golem.usage.storage_gib","golem.usage.duration_sec","golem.usage.cpu_sec"],"golem.inf.cpu.brand":"Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz","golem.inf.cpu.capabilities":["sse3","pclmulqdq","dtes64","monitor","dscpl","vmx","eist","tm2","ssse3","fma","cmpxchg16b","pdcm","pcid","sse41","sse42","x2apic","movbe","popcnt","tsc_deadline","aesni","xsave","osxsave","avx","f16c","rdrand","fpu","vme","de","pse","tsc","msr","pae","mce","cx8","apic","sep","mtrr","pge","mca","cmov","pat","pse36","clfsh","ds","acpi","mmx","fxsr","sse","sse2","ss","htt","tm","pbe","fsgsbase","adjust_msr","bmi1","avx2","smep","bmi2","rep_movsb_stosb","invpcid","deprecate_fpu_cs_ds","mpx","rdseed","adx","smap","clflushopt","processor_trace","sgx","sgx_lc"],"golem.inf.cpu.model":"Stepping 10 Family 6 Model 302","golem.inf.cpu.vendor":"GenuineIntel","golem.runtime.capabilities":["inet","vpn","manifest-support","start-entrypoint"]},"constraints":""}
```