### PR TITLE
Services POST response Location header

### DIFF
--- a/core/gsb-api/src/api.rs
+++ b/core/gsb-api/src/api.rs
@@ -220,7 +220,7 @@ mod tests {
                 "components": components,
                 "on": service_addr.to_string(),
             },
-            "services_id": encoded_addr
+            "servicesId": encoded_addr
         });
         assert_eq!(body, expected_body);
         let body: ServiceResponse = serde_json::value::from_value(body).unwrap();

--- a/core/gsb-api/src/api.rs
+++ b/core/gsb-api/src/api.rs
@@ -1,5 +1,5 @@
 use crate::model::{
-    GsbApiError, ServiceLinks, ServiceListenResponse, ServicePath, ServiceRequest, ServiceResponse,
+    GsbApiError, ServiceListenResponse, ServicePath, ServiceRequest, ServiceResponse,
 };
 use crate::service::StartBuffering;
 use crate::services::{Bind, Find, Services, Unbind};
@@ -39,19 +39,15 @@ async fn post_services(
     let response = services.send(bind).await;
     log::debug!("Service bind result: {:?}", response);
     response??;
-    let listen_on_encoded = BASE64.encode(&on);
-    let links = ServiceLinks {
-        messages: format!("gsb-api/v1/services/{listen_on_encoded}"),
-    };
+    let services_id = BASE64.encode(&on);
+    let services_path = format!("/{services_id}");
     let service = ServiceResponse {
-        listen: ServiceListenResponse {
-            on,
-            components,
-            links,
-        },
+        listen: ServiceListenResponse { on, components },
+        services_id,
     };
     Ok(web::Json(service)
         .customize()
+        .insert_header((actix_web::http::header::LOCATION, services_path))
         .with_status(StatusCode::CREATED))
 }
 
@@ -218,22 +214,25 @@ mod tests {
         assert_eq!(bind_resp.status(), StatusCode::CREATED);
         let body = bind_resp.body().await.unwrap();
         let body: ServiceResponse = serde_json::de::from_slice(&body).unwrap();
+        let encoded_addr = BASE64.encode(service_addr);
+        let services_path = format!("/{encoded_addr}");
         assert_eq!(
             body,
             ServiceResponse {
                 listen: ServiceListenResponse {
                     components,
                     on: service_addr.to_string(),
-                    links: ServiceLinks {
-                        messages: format!(
-                            "{}/services/{}",
-                            GSB_API_PATH,
-                            BASE64.encode(service_addr)
-                        )
-                    },
-                }
+                },
+                services_id: encoded_addr
             }
         );
+        let location = bind_resp
+            .headers()
+            .get(actix_web::http::header::LOCATION)
+            .expect("POST response contain Location header")
+            .to_str()
+            .expect("Location header is string");
+        assert_eq!(location, services_path);
         body
     }
 
@@ -265,7 +264,7 @@ mod tests {
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
 
-        let services_path = body.listen.links.messages;
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
         let mut ws_frames = api.ws_at(&services_path).await.unwrap();
 
         let gsb_endpoint = ya_service_bus::typed::service(service_addr.clone());
@@ -320,7 +319,7 @@ mod tests {
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
 
-        let services_path = body.listen.links.messages;
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
         let mut ws_frames = api.ws_at(&services_path).await.unwrap();
 
         let gsb_endpoint = ya_service_bus::typed::service(&service_addr);
@@ -391,7 +390,7 @@ mod tests {
         let body =
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
-        let services_path = body.listen.links.messages;
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
         let mut ws_frames = api.ws_at(&services_path).await.unwrap();
         println!("MSG: {msg}");
         let ws_res: Value = serde_json::de::from_str(msg).unwrap();
@@ -412,7 +411,7 @@ mod tests {
         let body =
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
-        let services_path = body.listen.links.messages;
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
         let mut ws_frames = api.ws_at(&services_path).await.unwrap();
         let gsb_endpoint = ya_service_bus::typed::service(&service_addr);
         let (gsb_res, ws_res) = tokio::join!(
@@ -474,7 +473,7 @@ mod tests {
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
 
-        let _services_path = body.listen.links.messages;
+        let _services_path = format!("gsb-api/v1/services/{}", body.services_id);
         let services_path = format!("/services/{}", BASE64.encode("no_such_service_address"));
         let ws_frames = api.ws_at(&services_path).await;
         assert!(matches!(
@@ -492,7 +491,7 @@ mod tests {
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
 
-        let services_path = body.listen.links.messages;
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
         let services_path = format!("{services_path}_broken_base64");
         let ws_frames = api.ws_at(&services_path).await;
         assert!(matches!(
@@ -526,7 +525,7 @@ mod tests {
         let body =
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
-        let services_path = body.listen.links.messages;
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
         let mut ws_frames = api.ws_at(&services_path).await.unwrap();
 
         verify_delete_service(&mut api, &service_addr).await;
@@ -552,7 +551,7 @@ mod tests {
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
         let gsb_endpoint = ya_service_bus::typed::service(&service_addr);
-        let services_path = body.listen.links.messages;
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
 
         let (gsb_res, ws_res) = tokio::join!(
             async {
@@ -617,7 +616,7 @@ mod tests {
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
         let gsb_endpoint = ya_service_bus::typed::service(&service_addr);
-        let services_path = body.listen.links.messages;
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
         println!("WS connect");
         let mut ws_frames = api.ws_at(&services_path).await.unwrap();
         println!("WS closing MSG");
@@ -692,7 +691,7 @@ mod tests {
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
         let gsb_endpoint = ya_service_bus::typed::service(&service_addr);
-        let services_path = body.listen.links.messages;
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
         println!("WS connect");
         let mut ws_frames = api.ws_at(&services_path).await.unwrap();
         println!("WS closing connection");
@@ -762,7 +761,7 @@ mod tests {
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
         let gsb_endpoint = ya_service_bus::typed::service(&service_addr);
-        let services_path = body.listen.links.messages;
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
         println!("WS connect");
         let mut ws_frames = api.ws_at(&services_path).await.unwrap();
         println!("WS closing connection");
@@ -804,7 +803,7 @@ mod tests {
             verify_bind_service_response(bind_req, vec!["GetChunk".to_string()], &service_addr)
                 .await;
         let gsb_endpoint = ya_service_bus::typed::service(&service_addr);
-        let services_path = body.listen.links.messages;
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
         println!("WS 0 connect");
         let mut ws_frames_0 = api.ws_at(&services_path).await.unwrap();
         println!("WS 1 connect");

--- a/core/gsb-api/src/model.rs
+++ b/core/gsb-api/src/model.rs
@@ -21,24 +21,30 @@ pub(crate) struct ServiceRequest {
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 pub(crate) struct ServiceResponse {
     pub(crate) listen: ServiceListenResponse,
+    /// Id of bound GSB services.
+    /// It allows to access WebSocket endpoint and to later unbind GSB services using DELETE method.
+    /// WebSocket endpoint allows to listen on incoming GSB messages.
+    pub(crate) services_id: String,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 pub(crate) struct ServiceListenRequest {
+    /// GSB services address prefix.
+    /// Example value: "/public/gftp/id_of_shared_data"
     pub(crate) on: String,
+    /// GSB services address prefix subpath.
+    /// Example value: ["GetMetadata", "GetChunk"]
     pub(crate) components: Vec<String>,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
 pub(crate) struct ServiceListenResponse {
+    /// GSB services address prefix.
+    /// Example value: "/public/gftp/id_of_shared_data"
     pub(crate) on: String,
+    /// GSB services address prefix subpath.
+    /// Example value: ["GetMetadata", "GetChunk"]
     pub(crate) components: Vec<String>,
-    pub(crate) links: ServiceLinks,
-}
-
-#[derive(Deserialize, Serialize, PartialEq, Debug)]
-pub(crate) struct ServiceLinks {
-    pub(crate) messages: String,
 }
 
 #[derive(thiserror::Error, Debug)]

--- a/core/gsb-api/src/model.rs
+++ b/core/gsb-api/src/model.rs
@@ -9,16 +9,19 @@ use serde::{Deserialize, Serialize};
 use ya_client_model::ErrorMessage;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct ServicePath {
     pub address: String,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct ServiceRequest {
     pub(crate) listen: ServiceListenRequest,
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct ServiceResponse {
     pub(crate) listen: ServiceListenResponse,
     /// Id of bound GSB services.
@@ -28,6 +31,7 @@ pub(crate) struct ServiceResponse {
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct ServiceListenRequest {
     /// GSB services address prefix.
     /// Example value: "/public/gftp/id_of_shared_data"
@@ -38,6 +42,7 @@ pub(crate) struct ServiceListenRequest {
 }
 
 #[derive(Deserialize, Serialize, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct ServiceListenResponse {
     /// GSB services address prefix.
     /// Example value: "/public/gftp/id_of_shared_data"


### PR DESCRIPTION
Resolves #2415 (code review changes)

Requested changes include:
- adding `Location` header to POST services response (with value: `/{servicesId}` - an URI relative to POST service)
- removing `listen.links.messages` with path to WS (with value like: `/gsb-api/v1/services/{servicesId}`) endpoint resource in favour of `servicesId` top level field (with value: `{serviceId}`).