### PR TITLE
Golmek/fix typo in golemsp

### DIFF
--- a/golem_cli/Cargo.toml
+++ b/golem_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "golemsp"
-description = "User friedly CLI for running Golem Provider"
+description = "User friendly CLI for running Golem Provider"
 version = "0.3.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"

--- a/golem_cli/README.md
+++ b/golem_cli/README.md
@@ -1,6 +1,6 @@
 # Golem
 
-User friedly CLI for running provider.
+User friendly CLI for running provider.
 
 ## Under the hood
 


### PR DESCRIPTION
Fixing typo in Golemsp
IS: "User friedly CLI for running Golem Provider"
SHOULD BE: "User friendly CLI for running Golem Provider"