### PR TITLE
fixed: yagna service shutdown --gracefully

### DIFF
--- a/core/serv/src/main.rs
+++ b/core/serv/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::obfuscated_if_else)]
+
 use actix_web::{middleware, web, App, HttpServer, Responder};
 use anyhow::{Context, Result};
 use futures::prelude::*;


### PR DESCRIPTION
# Tests

## Normal shutdown

```
$ yagna service run
...
[2023-04-13T14:18:43.297+0200 INFO  yagna] Http server thread started on: 127.0.0.1:7465
...
```

```
$ yagna service shutdown
Ok
```

```
[2023-04-13T14:20:31.594+0200 INFO  yagna] ShutdownRequest
[2023-04-13T14:20:31.594+0200 INFO  actix_server::worker] shutting down idle worker
...
[2023-04-13T14:20:31.608+0200 INFO  ya_payment] Payment service stopped.
[2023-04-13T14:20:31.608+0200 INFO  ya_relay_client::client] Shutting down Hybrid NET client.
...
[2023-04-13T14:20:33.613+0200 INFO  ya_service_bus::connection] stopped connection to gsb
```

## Gracefully shutdown during load

Scenario:
 - start yagna
 - run blender rendering
 - run `yagna service shutdown --gracefully`

Result:

```
[2023-04-13T14:52:54.621+0200 INFO  yagna] ShutdownRequest graceful
[2023-04-13T14:52:54.621+0200 INFO  actix_server::worker] graceful worker shutdown; finishing 1 connections
[2023-04-13T14:52:54.621+0200 INFO  actix_server::worker] shutting down idle worker
[2023-04-13T14:52:54.621+0200 INFO  actix_server::worker] shutting down idle worker
[2023-04-13T14:52:54.621+0200 INFO  actix_server::worker] graceful worker shutdown; finishing 1 connections
[2023-04-13T14:52:54.621+0200 INFO  actix_server::worker] shutting down idle worker
[2023-04-13T14:52:54.621+0200 INFO  actix_server::worker] graceful worker shutdown; finishing 1 connections
[2023-04-13T14:52:54.621+0200 INFO  actix_server::worker] shutting down idle worker
[2023-04-13T14:52:54.621+0200 INFO  actix_server::worker] shutting down idle worker
[2023-04-13T14:52:54.621+0200 INFO  actix_server::worker] shutting down idle worker
[2023-04-13T14:52:54.621+0200 INFO  actix_server::worker] shutting down idle worker
[2023-04-13T14:52:54.621+0200 INFO  actix_server::accept] accept thread stopped
```





