### PR TITLE
Log correctly Invoice receival

### DIFF
--- a/core/payment/src/api/debit_notes.rs
+++ b/core/payment/src/api/debit_notes.rs
@@ -227,7 +227,7 @@ async fn send_debit_note(
 
     let timeout = query.timeout.unwrap_or(params::DEFAULT_ACK_TIMEOUT);
     let activity_id = debit_note.activity_id.clone();
-    let recipient_id = debit_note.recipient_id.clone();
+    let recipient_id = debit_note.recipient_id;
 
     let result = with_timeout(timeout, async move {
         match async move {

--- a/core/payment/src/api/invoices.rs
+++ b/core/payment/src/api/invoices.rs
@@ -226,7 +226,7 @@ async fn send_invoice(
     }
     let timeout = query.timeout.unwrap_or(params::DEFAULT_ACK_TIMEOUT);
     let agreement_id = invoice.agreement_id.clone();
-    let recipient_id = invoice.recipient_id.clone();
+    let recipient_id = invoice.recipient_id;
 
     let result = async move {
         match async move {

--- a/core/payment/src/api/invoices.rs
+++ b/core/payment/src/api/invoices.rs
@@ -148,9 +148,7 @@ async fn issue_invoice(db: Data<DbExecutor>, body: Json<NewInvoice>, id: Identit
     .await
     {
         Ok(Some(agreement)) => agreement,
-        Ok(None) => {
-            return response::bad_request(&format!("Agreement not found: {}", agreement_id))
-        }
+        Ok(None) => return response::bad_request(&format!("Agreement not found: {agreement_id}")),
         Err(e) => return response::server_error(&e),
     };
 
@@ -158,12 +156,11 @@ async fn issue_invoice(db: Data<DbExecutor>, body: Json<NewInvoice>, id: Identit
         match get_agreement_id(activity_id.clone(), ya_client_model::market::Role::Provider).await {
             Ok(Some(id)) if id != agreement_id => {
                 return response::bad_request(&format!(
-                    "Activity {} belongs to agreement {} not {}",
-                    activity_id, id, agreement_id
+                    "Activity {activity_id} belongs to agreement {id} not {agreement_id}"
                 ));
             }
             Ok(None) => {
-                return response::bad_request(&format!("Activity not found: {}", activity_id))
+                return response::bad_request(&format!("Activity not found: {activity_id}"))
             }
             Err(e) => return response::server_error(&e),
             _ => (),
@@ -188,8 +185,9 @@ async fn issue_invoice(db: Data<DbExecutor>, body: Json<NewInvoice>, id: Identit
 
         let dao: InvoiceDao = db.as_dao();
         let invoice_id = dao.create_new(invoice, node_id).await?;
-        let invoice = dao.get(invoice_id, node_id).await?;
+        let invoice = dao.get(invoice_id.clone(), node_id).await?;
 
+        log::info!("Invoice [{invoice_id}] for Agreement [{agreement_id}] issued.");
         counter!("payment.invoices.provider.issued", 1);
         Ok(invoice)
     }
@@ -214,7 +212,7 @@ async fn send_invoice(
     let node_id = id.identity;
     let dao: InvoiceDao = db.as_dao();
 
-    log::debug!("Requested send invoice [{}]", invoice_id);
+    log::debug!("Requested send invoice [{invoice_id}]");
     counter!("payment.invoices.provider.sent.call", 1);
 
     let invoice = match dao.get(invoice_id.clone(), node_id).await {
@@ -227,9 +225,12 @@ async fn send_invoice(
         return response::ok(Null); // Invoice has been already sent
     }
     let timeout = query.timeout.unwrap_or(params::DEFAULT_ACK_TIMEOUT);
+    let agreement_id = invoice.agreement_id.clone();
+    let recipient_id = invoice.recipient_id.clone();
 
     let result = async move {
         match async move {
+            let invoice_id = invoice.invoice_id.clone();
             log::debug!(
                 "Sending invoice [{}] to [{}].",
                 invoice_id,
@@ -248,7 +249,9 @@ async fn send_invoice(
         .await
         {
             Ok(Ok(_)) => {
-                log::info!("Invoice [{}] sent.", path.invoice_id);
+                log::info!(
+                    "Invoice [{invoice_id}] for Agreement [{agreement_id}] sent to [{recipient_id}]."
+                );
                 counter!("payment.invoices.provider.sent", 1);
                 response::ok(Null)
             }
@@ -297,11 +300,13 @@ async fn cancel_invoice(
     }
 
     let timeout = query.timeout.unwrap_or(params::DEFAULT_ACK_TIMEOUT);
+    let agreement_id = invoice.agreement_id.clone();
+
     let result = async move {
         match async move {
             log::debug!(
                 "Canceling invoice [{}] sent to [{}].",
-                invoice_id,
+                invoice.invoice_id,
                 invoice.recipient_id
             );
 
@@ -309,11 +314,11 @@ async fn cancel_invoice(
                 .to(invoice.recipient_id)
                 .service(PUBLIC_SERVICE)
                 .call(CancelInvoice {
-                    invoice_id: invoice_id.clone(),
+                    invoice_id: invoice.invoice_id.clone(),
                     recipient_id: invoice.recipient_id,
                 })
                 .await??;
-            dao.cancel(invoice_id, node_id).await?;
+            dao.cancel(invoice.invoice_id, node_id).await?;
             Ok(())
         }
         .timeout(Some(timeout))
@@ -321,7 +326,7 @@ async fn cancel_invoice(
         {
             Ok(Ok(_)) => {
                 counter!("payment.invoices.provider.cancelled", 1);
-                log::info!("Invoice [{}] cancelled.", path.invoice_id);
+                log::info!("Invoice [{invoice_id}] for Agreement [{agreement_id}] cancelled.");
                 response::ok(Null)
             }
             Ok(Err(Error::Rpc(RpcMessageError::Cancel(CancelError::Conflict)))) => {
@@ -471,7 +476,11 @@ async fn accept_invoice(
         {
             Ok(Ok(_)) => {
                 counter!("payment.invoices.requestor.accepted", 1);
-                log::info!("Invoice [{}] accepted.", path.invoice_id);
+                log::info!(
+                    "Invoice [{}] for Agreement [{}] accepted.",
+                    path.invoice_id,
+                    agreement_id
+                );
                 response::ok(Null)
             }
             Ok(Err(Error::Rpc(RpcMessageError::AcceptReject(AcceptRejectError::BadRequest(


### PR DESCRIPTION
!!! Should be retargeted to `release/v0.12` or at least cherry-picked after merge !!!

NodeId is flipped with Invoice ID. Moreover NodeId contains Invoice owner id, which is Requestor, not the sender.

`[2023-03-27T12:11:16.102+0000 INFO  ya_payment::service::public] Invoice [0x1648acff4435cee6b1cf50c438204530561368a4] received from node [03c1dd6e-3ad1-4fce-aa21-0d5b448d3f6d].`

Discovered when investigating: https://github.com/golemfactory/golem-internal/issues/627