### PR TITLE
gvmkit-build-rs in requestor releases

### DIFF
--- a/.ci/pack-build.sh
+++ b/.ci/pack-build.sh
@@ -11,6 +11,7 @@ not_empty() {
 
 not_empty "$GITHUB_REF" GITHUB_REF
 not_empty "$OS_NAME" OS_NAME
+not_empty "$GVMKIT_BUILD_DIR" GVMKIT_BUILD_DIR
 
 
 if [ "$OS_NAME" = "ubuntu" ]; then
@@ -43,12 +44,19 @@ generate_asset() {
   for bin in $bins; do
     cp "target/${target}release/${bin}${exe}" "$TARGET_DIR/"
   done
+
   if test -n "$lib_bins"; then
     mkdir -p "$TARGET_DIR/plugins"
     for bin in $lib_bins; do
       cp "target/${target}release/${bin}${exe}" "$TARGET_DIR/plugins"
     done
   fi
+
+  if [ $asset_type = "requestor" ]; then
+    strip -x ${GVMKIT_BUILD_DIR}/gvmkit-build${exe}
+    cp "${GVMKIT_BUILD_DIR}/gvmkit-build${exe}" "$TARGET_DIR/"
+  fi
+
   if [ "$OS_NAME" = "windows" ]; then
     echo "::set-output name=${asset_type}Artifact::golem-${asset_type}-${OS_NAME}-${TAG_NAME}.zip"
     echo "::set-output name=${asset_type}Media::application/zip"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   rust_stable: 1.68.2
-  gvmkit-build_tag: v0.2.2
+  gvmkit-build_tag: v0.3.5
   gvmkit-build_dir: gvmkit-build
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   rust_stable: 1.68.2
+  gvmkit-build_tag: v0.2.2
+  gvmkit-build_dir: gvmkit-build
 
 jobs:
   create-release:
@@ -56,6 +58,13 @@ jobs:
           - ubuntu
           - windows
           - macos
+        include:
+          - os: ubuntu
+            gvmkit-build_archive: gvmkit-build-x86_64-unknown-linux-gnu.tar.gz
+          - os: windows
+            gvmkit-build_archive: gvmkit-build-x86_64-pc-windows-msvc.zip
+          - os: macos
+            gvmkit-build_archive: gvmkit-build-x86_64-apple-darwin.tar.gz
 
     env:
       X86_64_PC_WINDOWS_MSVC_OPENSSL_DIR: c:/vcpkg/installed/x64-windows-static
@@ -124,12 +133,23 @@ jobs:
           (cd golem_cli && cargo build --bin golemsp -p golemsp --release --target x86_64-unknown-linux-musl)
           (cd agent/provider && cargo build --bin ya-provider -p ya-provider --release --target x86_64-unknown-linux-musl)
           (cd exe-unit && cargo build --bin exe-unit -p ya-exe-unit --release --features openssl/vendored --target x86_64-unknown-linux-musl)
+      - name: Download gvmkit-build
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repository: golemfactory/gvmkit-build-rs
+          tag: ${{ env.gvmkit-build_tag }}
+          fileName: ${{ matrix.gvmkit-build_archive }}
+          extract: true
+          out-file-path: ${{ env.gvmkit-build_dir }}
+          tarBall: false
+          zipBall: false
       - name: Pack
         id: pack
         shell: bash
         env:
           OS_NAME: ${{ matrix.os }}
           GITHUB_REF: ${{ github.ref }}
+          GVMKIT_BUILD_DIR: ${{ env.gvmkit-build_dir }}
         run: |
           bash .ci/pack-build.sh
       - name: Upload Release Asset [Requestor]
@@ -199,13 +219,23 @@ jobs:
             --release
             --features static-openssl
             --target aarch64-unknown-linux-musl
-
+      - name: Download gvmkit-build
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repository: golemfactory/gvmkit-build-rs
+          tag: ${{ env.gvmkit-build_tag }}
+          fileName: gvmkit-build-aarch64-unknown-linux-musl.tar.gz
+          extract: true
+          out-file-path: ${{ env.gvmkit-build_dir }}
+          tarBall: false
+          zipBall: false
       - name: Pack
         id: pack
         shell: bash
         env:
           OS_NAME: linux-aarch64
           GITHUB_REF: ${{ github.ref }}
+          GVMKIT_BUILD_DIR: ${{ env.gvmkit-build_dir }}
         run: |
           bash .ci/pack-build.sh
       - name: Upload Release Asset [Requestor]


### PR DESCRIPTION
Resolves: https://github.com/golemfactory/yagna/issues/2585

GH release action will now add OS/arch matching binary of https://github.com/golemfactory/gvmkit-build-rs/releases/tag/v0.3.5 to _requestor_ archives.
This PR does !!!NOT!!! change content of _requestor_ `.deb` package (because there is some custom GH action to build debs).