### PR TITLE
Transfer progress support on streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84cda67535339806297f1b331d6dd6320470d2a0fe65381e79ee9e156dd3d13"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.6",
+ "parking_lot 0.12.1",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "crossterm_winapi"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2656,7 +2672,7 @@ dependencies = [
  "bigdecimal 0.2.2",
  "byte-unit",
  "chrono",
- "crossterm",
+ "crossterm 0.23.2",
  "directories",
  "dotenv",
  "env_logger 0.7.1",
@@ -7445,7 +7461,7 @@ checksum = "e7141e445af09c8919f1d5f8a20dae0b20c3b57a45dee0d5823c6ed5d237f15a"
 dependencies = [
  "bitflags",
  "chrono",
- "rustc_version 0.2.3",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -9041,6 +9057,7 @@ dependencies = [
  "async-compression",
  "awc",
  "bytes 1.4.0",
+ "crossterm 0.26.1",
  "env_logger 0.7.1",
  "futures 0.3.26",
  "gftp",

--- a/utils/transfer/Cargo.toml
+++ b/utils/transfer/Cargo.toml
@@ -47,6 +47,7 @@ branch = "feature/tokio-1"
 [dev-dependencies]
 actix-web = "4"
 anyhow = "1.0"
+crossterm = "0.26.1"
 env_logger = "0.7"
 sha2 = "0.8.1"
 structopt = "0.3.15"

--- a/utils/transfer/examples/gftp.rs
+++ b/utils/transfer/examples/gftp.rs
@@ -86,12 +86,16 @@ async fn main() -> Result<(), Error> {
     let ctx = TransferContext::default();
     let source = gftp_provider.source(&src_url, &ctx);
     let source_with_progress =
-        ya_transfer::wrap_with_progress_reporting(source, &ctx, |progress, size| {
-            log::info!("Progress: {} / {}", progress, size);
+        ya_transfer::wrap_stream_with_progress_reporting(source, &ctx, |progress, size| {
+            log::info!("Progress source: {} / {}", progress, size);
         });
     let dest = file_provider.destination(&dest_url, &ctx);
+    let dest_with_progress =
+        ya_transfer::wrap_sink_progress_reporting(dest, &ctx, |progress, size| {
+            log::info!("Progress dest: {} / {}", progress, size);
+        });
 
-    transfer(source_with_progress, dest).await?;
+    transfer(source_with_progress, dest_with_progress).await?;
 
     log::info!(
         "Transfer complete, comparing hashes of {:?} vs {:?}",
@@ -109,12 +113,16 @@ async fn main() -> Result<(), Error> {
     let ctx = TransferContext::default();
     let source = file_provider.source(&src_url, &ctx);
     let source_with_progress =
-        ya_transfer::wrap_with_progress_reporting(source, &ctx, |progress, size| {
-            log::info!("Progress: {} / {}", progress, size);
+        ya_transfer::wrap_stream_with_progress_reporting(source, &ctx, |progress, size| {
+            log::info!("Progress source: {} / {}", progress, size);
         });
     let dest = gftp_provider.destination(&dest_url, &ctx);
+    let dest_with_progress =
+        ya_transfer::wrap_sink_progress_reporting(dest, &ctx, |progress, size| {
+            log::info!("Progress dest: {} / {}", progress, size);
+        });
 
-    transfer(source_with_progress, dest).await?;
+    transfer(source_with_progress, dest_with_progress).await?;
 
     log::info!(
         "Transfer complete, comparing hashes of {:?} vs {:?}",

--- a/utils/transfer/examples/gftp.rs
+++ b/utils/transfer/examples/gftp.rs
@@ -32,7 +32,7 @@ fn create_file(path: &Path, name: &str, chunk_size: usize, chunk_count: usize) -
         rng.fill_bytes(&mut input);
 
         hasher.input(&input);
-        file_src.write(&input).unwrap();
+        file_src.write_all(&input).unwrap();
     }
     file_src.flush().unwrap();
     hasher.result()

--- a/utils/transfer/examples/gftp.rs
+++ b/utils/transfer/examples/gftp.rs
@@ -5,6 +5,8 @@ use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::env;
+use std::time::Instant;
+use crossterm::{QueueableCommand, cursor, terminal, ExecutableCommand};
 use tempdir::TempDir;
 use url::Url;
 use ya_transfer::error::Error;
@@ -51,6 +53,33 @@ fn hash_file(path: &Path) -> HashOutput {
     hasher.result()
 }
 
+// processing progress updates must not panic or the transfer will be aborted
+fn progress_to_stdout(start_offset: u64, start_time: Instant, progress: u64, size: u64) {
+    let elapsed = start_time.elapsed();
+    let elapsed_secs = elapsed.as_secs() as f64 + elapsed.subsec_nanos() as f64 * 1e-9;
+    let (speed, unit) = {
+        let raw_speed = (progress - start_offset) as f64 / elapsed_secs;
+        if raw_speed > 1024.0 * 1024.0 {
+            (raw_speed / 1024.0 / 1024.0, "MB/s")
+        } else if raw_speed > 1024.0 {
+            (raw_speed / 1024.0, "KB/s")
+        } else {
+            (raw_speed, "B/s")
+        }
+    };
+    let (percent, total_size) = if size > 0 {
+        (format!("{:.2}", 100.0 * progress as f64 / size as f64), size.to_string())
+    } else {
+        ("--".into(), "unknown".into())
+    };
+
+    let mut stdout = std::io::stdout();
+    stdout.queue(terminal::Clear(terminal::ClearType::CurrentLine)).ok();
+    stdout.write_all(format!("{} / {} ({:.2} {}) {}%", progress, total_size, speed, unit, percent).as_bytes()).ok();
+    stdout.queue(cursor::RestorePosition).ok();
+    stdout.flush().ok();
+}
+
 #[actix_rt::main]
 async fn main() -> Result<(), Error> {
     env::set_var(
@@ -61,7 +90,7 @@ async fn main() -> Result<(), Error> {
 
     let temp_dir = TempDir::new("transfer").unwrap();
     let chunk_size = 4096_usize;
-    let chunk_count = 256_usize;
+    let chunk_count = 25600_usize;
 
     log::info!(
         "Creating a random file of size {} * {}",
@@ -85,17 +114,26 @@ async fn main() -> Result<(), Error> {
 
     let ctx = TransferContext::default();
     let source = gftp_provider.source(&src_url, &ctx);
-    let source_with_progress =
-        ya_transfer::wrap_stream_with_progress_reporting(source, &ctx, |progress, size| {
-            log::info!("Progress source: {} / {}", progress, size);
-        });
     let dest = file_provider.destination(&dest_url, &ctx);
+
+    // progress reporting on the TransferSink
+
+    let mut stdout = std::io::stdout();
+    stdout.execute(cursor::Hide).ok();
+    stdout.queue(cursor::SavePosition).ok();
+    let start_offset = ctx.state.offset();
+    let start_time = Instant::now();
     let dest_with_progress =
-        ya_transfer::wrap_sink_progress_reporting(dest, &ctx, |progress, size| {
-            log::info!("Progress dest: {} / {}", progress, size);
+        ya_transfer::wrap_sink_progress_reporting(dest, &ctx, move |progress, size| {
+            progress_to_stdout(start_offset, start_time, progress, size);
+            // could also log progress:
+            // log::info!("Transfer progress {} / {} ({:.2}%)", progress, size, 100.0 * progress as f64 / size as f64);
         });
 
-    transfer(source_with_progress, dest_with_progress).await?;
+    let transfer_done = transfer(source, dest_with_progress).await;
+    stdout.execute(cursor::Show).ok();
+    writeln!(stdout).ok();
+    transfer_done?;
 
     log::info!(
         "Transfer complete, comparing hashes of {:?} vs {:?}",
@@ -106,23 +144,32 @@ async fn main() -> Result<(), Error> {
 
     let src_url = Url::parse(&format!("file://{}", path_dl.to_str().unwrap()))?;
     let dest_url = gftp::open_for_upload(&path_up).await.unwrap();
+
     log::info!("Awaiting upload at {}", dest_url);
     log::info!("Sharing file at {:?}", src_url.path());
     log::info!("Expecting file at {:?}", dest_url.path());
 
     let ctx = TransferContext::default();
     let source = file_provider.source(&src_url, &ctx);
+
+    // works on TransferStreams also
+
+    let mut stdout = std::io::stdout();
+    stdout.execute(cursor::Hide).ok();
+    stdout.queue(cursor::SavePosition).ok();
+    let start_offset = ctx.state.offset();
+    let start_time = Instant::now();
     let source_with_progress =
-        ya_transfer::wrap_stream_with_progress_reporting(source, &ctx, |progress, size| {
-            log::info!("Progress source: {} / {}", progress, size);
-        });
-    let dest = gftp_provider.destination(&dest_url, &ctx);
-    let dest_with_progress =
-        ya_transfer::wrap_sink_progress_reporting(dest, &ctx, |progress, size| {
-            log::info!("Progress dest: {} / {}", progress, size);
+        ya_transfer::wrap_stream_with_progress_reporting(source, &ctx, move |progress, size| {
+            progress_to_stdout(start_offset, start_time, progress, size);
         });
 
-    transfer(source_with_progress, dest_with_progress).await?;
+    let dest = gftp_provider.destination(&dest_url, &ctx);
+
+    let transfer_done = transfer(source_with_progress, dest).await;
+    stdout.execute(cursor::Show).ok();
+    writeln!(stdout).ok();
+    transfer_done?;
 
     log::info!(
         "Transfer complete, comparing hashes of {:?} vs {:?}",

--- a/utils/transfer/src/lib.rs
+++ b/utils/transfer/src/lib.rs
@@ -30,9 +30,9 @@ pub use crate::file::{DirTransferProvider, FileTransferProvider};
 pub use crate::gftp::GftpTransferProvider;
 pub use crate::http::HttpTransferProvider;
 pub use crate::location::{TransferUrl, UrlExt};
+pub use crate::progress::{wrap_sink_with_progress_reporting, wrap_stream_with_progress_reporting};
 pub use crate::retry::Retry;
 pub use crate::traverse::PathTraverse;
-pub use crate::progress::*;
 
 use ya_client_model::activity::TransferArgs;
 

--- a/utils/transfer/src/lib.rs
+++ b/utils/transfer/src/lib.rs
@@ -32,7 +32,7 @@ pub use crate::http::HttpTransferProvider;
 pub use crate::location::{TransferUrl, UrlExt};
 pub use crate::retry::Retry;
 pub use crate::traverse::PathTraverse;
-pub use crate::progress::wrap_with_progress_reporting;
+pub use crate::progress::*;
 
 use ya_client_model::activity::TransferArgs;
 

--- a/utils/transfer/src/lib.rs
+++ b/utils/transfer/src/lib.rs
@@ -4,6 +4,7 @@ mod file;
 mod gftp;
 mod http;
 mod location;
+mod progress;
 mod retry;
 mod traverse;
 
@@ -31,6 +32,7 @@ pub use crate::http::HttpTransferProvider;
 pub use crate::location::{TransferUrl, UrlExt};
 pub use crate::retry::Retry;
 pub use crate::traverse::PathTraverse;
+pub use crate::progress::wrap_with_progress_reporting;
 
 use ya_client_model::activity::TransferArgs;
 

--- a/utils/transfer/src/progress.rs
+++ b/utils/transfer/src/progress.rs
@@ -1,0 +1,41 @@
+use crate::error::Error;
+use crate::{TransferStream, abortable_stream};
+use crate::{TransferContext, TransferData};
+use futures::{SinkExt, StreamExt, TryFutureExt};
+use tokio::task::spawn_local;
+
+type Stream = TransferStream<TransferData, Error>;
+
+/// Wraps a stream to report progress.
+/// The `report` function is called with the current offset and the total size.
+/// The total size is 0 if the size is unknown. (For example, when the source is a directory.)
+pub fn wrap_with_progress_reporting<F>(mut source: Stream, ctx: &TransferContext, report: F) -> Stream
+where
+    F: Fn(u64, u64) -> () + Send + 'static,
+{
+    let (stream, tx, abort_reg) = Stream::create(1);
+    let mut txc = tx.clone();
+    let state = ctx.state.clone();
+
+    spawn_local(async move {
+        let fut = async move {
+            while let Some(result) = source.next().await {
+                if let Ok(data) = result.as_ref() {
+                    let data_len = data.as_ref().len() as u64;
+                    let offset = state.offset() + data_len as u64;
+                    report(offset, state.size().unwrap_or(0));
+                }
+                txc.send(result).await?;
+            };
+            Ok::<(), Error>(())
+        }
+        .map_err(|error| {
+            log::error!("Error forwading data: {}", error);
+            error
+        });
+
+        abortable_stream(fut, abort_reg, tx).await
+    });
+
+    stream
+}

--- a/utils/transfer/src/progress.rs
+++ b/utils/transfer/src/progress.rs
@@ -9,6 +9,7 @@ type Stream = TransferStream<TransferData, Error>;
 /// Wraps a stream to report progress.
 /// The `report` function is called with the current offset and the total size.
 /// The total size is 0 if the size is unknown. (For example, when the source is a directory.)
+/// The reporting function should not block as it will block the transfer.
 pub fn wrap_stream_with_progress_reporting<F>(mut source: Stream, ctx: &TransferContext, report: F) -> Stream
 where
     F: Fn(u64, u64) -> () + Send + 'static,
@@ -46,6 +47,7 @@ type Sink = TransferSink<TransferData, Error>;
 /// Wraps a sink to report progress.
 /// The `report` function is called with the current offset and the total size.
 /// The total size is 0 if the size is unknown. (For example, when the source is a directory.)
+/// The reporting function should not block as it will block the transfer.
 pub fn wrap_sink_progress_reporting<F>(mut dest: Sink, ctx: &TransferContext, report: F) -> Sink
 where
     F: Fn(u64, u64) -> () + Send + 'static,

--- a/utils/transfer/src/progress.rs
+++ b/utils/transfer/src/progress.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use crate::{TransferStream, abortable_stream, TransferSink, abortable_sink};
+use crate::{abortable_sink, abortable_stream, TransferSink, TransferStream};
 use crate::{TransferContext, TransferData};
 use futures::{SinkExt, StreamExt, TryFutureExt};
 use tokio::task::spawn_local;
@@ -10,7 +10,11 @@ type Stream = TransferStream<TransferData, Error>;
 /// The `report` function is called with the current offset and the total size.
 /// The total size is 0 if the size is unknown. (For example, when the source is a directory.)
 /// The reporting function should not block as it will block the transfer.
-pub fn wrap_stream_with_progress_reporting<F>(mut source: Stream, ctx: &TransferContext, report: F) -> Stream
+pub fn wrap_stream_with_progress_reporting<F>(
+    mut source: Stream,
+    ctx: &TransferContext,
+    report: F,
+) -> Stream
 where
     F: Fn(u64, u64) -> () + Send + 'static,
 {
@@ -28,7 +32,7 @@ where
                     report(offset, state.size().unwrap_or(0));
                 }
                 txc.send(result).await?;
-            };
+            }
             Ok::<(), Error>(())
         }
         .map_err(|error| {
@@ -48,7 +52,11 @@ type Sink = TransferSink<TransferData, Error>;
 /// The `report` function is called with the current offset and the total size.
 /// The total size is 0 if the size is unknown. (For example, when the source is a directory.)
 /// The reporting function should not block as it will block the transfer.
-pub fn wrap_sink_progress_reporting<F>(mut dest: Sink, ctx: &TransferContext, report: F) -> Sink
+pub fn wrap_sink_with_progress_reporting<F>(
+    mut dest: Sink,
+    ctx: &TransferContext,
+    report: F,
+) -> Sink
 where
     F: Fn(u64, u64) -> () + Send + 'static,
 {


### PR DESCRIPTION
Transfer progress support wrapper for streams and sinks.

Extended the logic of TransferStreams to set the total data size in context when it is known. `DirTransferProvider` does streaming archiving/compression so it is not able to set total data size.

Related to #2609