### PR TITLE
GSB API response payload any data type support

### DIFF
--- a/core/gsb-api/src/api.rs
+++ b/core/gsb-api/src/api.rs
@@ -123,8 +123,6 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::{json, Value};
     use serial_test::serial;
-    use std::collections::HashMap;
-    use std::io::Write;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
     use test_case::test_case;
@@ -304,22 +302,10 @@ mod tests {
                     }
                     msg => panic!("Unexpected msg: {:?}", msg),
                 };
-                // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 let ws_res = TestWsResponse {
                     id: ws_req.id,
                     payload: (),
                 };
-                // let ws_res = serde_json::json!({
-                //     "id": "0",
-                //     "payload": null,
-                // });
-                // let ws_res = serde_json::json!({
-                //     "id": "0",
-                //     "payload": {
-                //         "Ok": {},
-                //     },
-                // });
-                // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
                 let ws_res = flexbuffers::to_vec(ws_res).unwrap();
                 ws_frames
                     .send(ws::Message::Binary(Bytes::from(ws_res)))
@@ -328,8 +314,9 @@ mod tests {
         );
 
         ws_res.unwrap();
-        let gsb_res = gsb_res.unwrap().unwrap();
-        assert_eq!(gsb_res, ());
+        gsb_res
+            .expect("Response is unit type")
+            .expect("Response is ok");
 
         verify_delete_service(&mut api, &service_addr).await;
     }

--- a/core/gsb-api/src/api.rs
+++ b/core/gsb-api/src/api.rs
@@ -123,10 +123,12 @@ mod tests {
     use serde::{Deserialize, Serialize};
     use serde_json::{json, Value};
     use serial_test::serial;
+    use std::collections::HashMap;
+    use std::io::Write;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
     use test_case::test_case;
-    use ya_core_model::gftp::{GetChunk, GftpChunk};
+    use ya_core_model::gftp::{GetChunk, GftpChunk, UploadChunk};
     use ya_core_model::NodeId;
     use ya_service_api_interfaces::Provider;
     use ya_service_api_web::middleware::auth::dummy::DummyAuth;
@@ -253,6 +255,83 @@ mod tests {
             StatusCode::OK,
             "Can delete service, but got {delete_resp:?}"
         );
+    }
+
+    #[actix_web::test]
+    #[serial]
+    async fn upload_chunk_test() {
+        let mut api = dummy_api();
+
+        let service_number = SERVICE_COUNTER.fetch_add(1, Ordering::SeqCst);
+        let service_addr = format!("{SERVICE_ADDR}_{service_number}");
+
+        let bind_req = api
+            .post(format!("/{}/{}", GSB_API_PATH, "services"))
+            .send_json(&ServiceRequest {
+                listen: ServiceListenRequest {
+                    components: vec!["UploadChunk".to_string()],
+                    on: service_addr.clone(),
+                },
+            });
+
+        let body =
+            verify_bind_service_response(bind_req, vec!["UploadChunk".to_string()], &service_addr)
+                .await;
+
+        let services_path = format!("gsb-api/v1/services/{}", body.services_id);
+        let mut ws_frames = api.ws_at(&services_path).await.unwrap();
+
+        let gsb_endpoint = ya_service_bus::typed::service(service_addr.clone());
+
+        let (gsb_res, ws_res) = tokio::join!(
+            async {
+                gsb_endpoint
+                    .call(UploadChunk {
+                        chunk: GftpChunk {
+                            offset: 0,
+                            content: vec![1, 2, 3],
+                        },
+                    })
+                    .await
+            },
+            async {
+                println!("WS sleep");
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                let ws_req = ws_frames.next().await;
+                let ws_req = match ws_req {
+                    Some(Ok(Frame::Binary(ws_req))) => {
+                        flexbuffers::from_slice::<TestWsRequest<UploadChunk>>(&ws_req).unwrap()
+                    }
+                    msg => panic!("Unexpected msg: {:?}", msg),
+                };
+                // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                let ws_res = TestWsResponse {
+                    id: ws_req.id,
+                    payload: (),
+                };
+                // let ws_res = serde_json::json!({
+                //     "id": "0",
+                //     "payload": null,
+                // });
+                // let ws_res = serde_json::json!({
+                //     "id": "0",
+                //     "payload": {
+                //         "Ok": {},
+                //     },
+                // });
+                // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+                let ws_res = flexbuffers::to_vec(ws_res).unwrap();
+                ws_frames
+                    .send(ws::Message::Binary(Bytes::from(ws_res)))
+                    .await
+            }
+        );
+
+        ws_res.unwrap();
+        let gsb_res = gsb_res.unwrap().unwrap();
+        assert_eq!(gsb_res, ());
+
+        verify_delete_service(&mut api, &service_addr).await;
     }
 
     #[actix_web::test]

--- a/core/gsb-api/src/lib.rs
+++ b/core/gsb-api/src/lib.rs
@@ -41,7 +41,7 @@ impl GsbApiService {
 pub(crate) type GsbError = ya_service_bus::Error;
 
 #[derive(Message, Serialize, Deserialize, Debug)]
-#[rtype(result = "Result<(), anyhow::Error>")]
+#[rtype(result = "anyhow::Result<()>")]
 struct WsRequest {
     id: String,
     component: String,
@@ -49,7 +49,7 @@ struct WsRequest {
 }
 
 #[derive(Message, Debug)]
-#[rtype(result = "Result<(), anyhow::Error>")]
+#[rtype(result = "anyhow::Result<()>")]
 pub(crate) struct WsResponse {
     pub id: String,
     pub response: WsResponseMsg,
@@ -373,10 +373,7 @@ mod flexbuffer_util {
         }
     }
 
-    pub(crate) fn read_string(
-        reader: &MapReader<&[u8]>,
-        key: &str,
-    ) -> Result<String, anyhow::Error> {
+    pub(crate) fn read_string(reader: &MapReader<&[u8]>, key: &str) -> anyhow::Result<String> {
         match reader.index(key) {
             Ok(field) => match field.get_str() {
                 Ok(txt) => Ok(txt.to_string()),
@@ -389,7 +386,7 @@ mod flexbuffer_util {
     pub(crate) fn as_map<'a>(
         reader: &Reader<&'a [u8]>,
         allow_empty: bool,
-    ) -> Result<MapReader<&'a [u8]>, anyhow::Error> {
+    ) -> anyhow::Result<MapReader<&'a [u8]>> {
         match reader.get_map() {
             Ok(map) => {
                 if allow_empty || !map.is_empty() {

--- a/core/gsb-api/src/lib.rs
+++ b/core/gsb-api/src/lib.rs
@@ -234,7 +234,6 @@ impl Handler<WsRequest> for WsMessagesHandler {
         let payload_map_builder = request_map_builder.start_map("payload");
 
         let payload = Reader::get_root(&*request.payload).unwrap(); //TODO handle error
-        // flexbuffer_util::clone_field(payload_map_builder, &payload).unwrap(); //TODO handle error
         let payload_map = payload.as_map(); //TODO check type before as_map
         flexbuffer_util::clone_map(payload_map_builder, &payload_map).unwrap(); //TODO handle error
         request_map_builder.end_map();


### PR DESCRIPTION
Bugfix for GSB API making `payload` response field to support any data type, not only map