### PR TITLE
Break up goth build

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -32,6 +32,9 @@ jobs:
     name: Integration Tests (hybrid-net)
     runs-on: [goth, ubuntu-18.04]
     needs: test_check
+    strategy:
+      matrix:
+        group: [1, 2, 3, 4, 5]
     defaults:
       run:
         working-directory: "./goth_tests"
@@ -91,7 +94,7 @@ jobs:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           poetry run poe goth-assets
-          poetry run poe goth-tests --config-override docker-compose.build-environment.binary-path=/tmp/yagna-build
+          poetry run poe goth-tests --splits 5 --group ${{ matrix.group }} --config-override docker-compose.build-environment.binary-path=/tmp/yagna-build
 
       - name: Upload test logs
         uses: actions/upload-artifact@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -22,8 +22,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: "Build binaries (x86-64) (ubuntu-latest)"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
-          intervalSeconds: 60
-          timeoutSeconds: 7200
+          intervalSeconds: 30
+          timeoutSeconds: 3600
 
       - name: Fail if build was not a success ( ubuntu )
         run: echo job status= ${{ steps.wait-for-build-ubu.outputs.conclusion }} && ${{ fromJSON('["false", "true"]')[steps.wait-for-build-ubu.outputs.conclusion == 'success'] }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Fail if build was not a success ( ubuntu )
         run: echo job status= ${{ steps.wait-for-build-ubu.outputs.conclusion }} && ${{ fromJSON('["false", "true"]')[steps.wait-for-build-ubu.outputs.conclusion == 'success'] }}
 
-  integration-test:
-    name: Integration Tests (hybrid-net)
+  integration-test-groups:
+    name: Integration Tests (hybrid-net) group
     runs-on: [goth, ubuntu-18.04]
     needs: test_check
     strategy:
@@ -115,3 +115,12 @@ jobs:
         # In the future we'll be able to use the `--all` flag here to remove envs for
         # all Python versions (https://github.com/python-poetry/poetry/issues/3208).
         run: poetry env remove python3.8
+
+  integration-test:
+    name: Integration Tests (hybrid-net)
+    runs-on: ubuntu-latest
+    needs: [integration-test-groups]
+    steps:
+      - name: Check status
+        if: needs.integration-test-groups.result != 'success'
+        run: exit 1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -34,7 +34,7 @@ jobs:
     needs: test_check
     strategy:
       matrix:
-        group: [1, 2, 3, 4, 5]
+        group: [1, 2]
     defaults:
       run:
         working-directory: "./goth_tests"
@@ -94,7 +94,7 @@ jobs:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           poetry run poe goth-assets
-          poetry run poe goth-tests --splits 5 --group ${{ matrix.group }} --config-override docker-compose.build-environment.binary-path=/tmp/yagna-build
+          poetry run poe goth-tests --splits 2 --group ${{ matrix.group }} --config-override docker-compose.build-environment.binary-path=/tmp/yagna-build
 
       - name: Upload test logs
         uses: actions/upload-artifact@v2

--- a/goth_tests/.test_durations
+++ b/goth_tests/.test_durations
@@ -1,0 +1,21 @@
+{
+    "domain/exe_units/test_runtime_counters.py::test_custom_runtime_counter": 72.41198446500493,
+    "domain/payments/test_mid_payments.py::test_mid_agreement_payments": 91.58806692000508,
+    "domain/payments/test_payment_driver_list_cmd.py::test_payment_driver_list": 42.259517082005914,
+    "domain/payments/test_payment_release_allocations.py::test_payment_release_allocations": 47.1836760330043,
+    "domain/payments/test_payment_validate_allocations.py::test_payment_validate_allocations": 42.542111344009754,
+    "domain/payments/test_zero_amount_txs.py::test_zero_amount_invoice": 64.66282967099687,
+    "domain/ya-provider/test_provider_break_agreement.py::test_provider_debit_notes_accept_timeout": 105.64584831699904,
+    "domain/ya-provider/test_provider_break_agreement.py::test_provider_idle_agreement": 67.70010097500199,
+    "domain/ya-provider/test_provider_break_agreement.py::test_provider_idle_agreement_after_2_activities": 135.86370565499965,
+    "domain/ya-provider/test_provider_break_agreement.py::test_provider_timeout_unresponsive_requestor": 73.18756224899698,
+    "domain/ya-provider/test_provider_multi_activity.py::test_provider_multi_activity": 136.00878052100597,
+    "domain/ya-provider/test_provider_multi_activity.py::test_provider_recover_from_abandoned_task": 77.49658892300067,
+    "domain/ya-provider/test_provider_multi_activity.py::test_provider_renegotiate_proposal": 166.87385216399707,
+    "domain/ya-provider/test_provider_multi_activity.py::test_provider_single_simultaneous_activity": 66.33334043600189,
+    "e2e/vm/test_e2e_rule_partner_outbound.py::test_e2e_rule_partner_outbound": 105.95762435700453,
+    "e2e/vm/test_e2e_rule_partner_outbound_unrestricted.py::test_e2e_rule_partner_outbound_unrestricted": 105.69478582400916,
+    "e2e/vm/test_e2e_vm.py::test_e2e_vm": 228.68717026399827,
+    "e2e/vm/test_e2e_x509_signature_outbound.py::test_e2e_x509_signature_outbound": 118.35896305299684,
+    "e2e/wasi/test_e2e_wasi.py::test_e2e_wasi": 178.58433114900254
+}

--- a/goth_tests/poetry.lock
+++ b/goth_tests/poetry.lock
@@ -803,6 +803,17 @@ packaging = ">=17.1"
 pytest = ">=5.3"
 
 [[package]]
+name = "pytest-split"
+version = "0.8.1"
+description = "Pytest plugin which splits the test suite to equally sized sub suites based on test execution time."
+category = "main"
+optional = false
+python-versions = ">=3.7.1,<4.0"
+
+[package.dependencies]
+pytest = ">=5,<8"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1072,7 +1083,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8.0"
-content-hash = "45399ad6d9040061f4899a61507ae40b53dfb17526428c9bd02a9f0292aaa660"
+content-hash = "bf3937e61238fb0e7deba8b7cfd0543a5c1d81ef7d8e0205b9c0243e056ad2eb"
 
 [metadata.files]
 aiohttp = [
@@ -1886,6 +1897,10 @@ pytest-asyncio = [
 pytest-rerunfailures = [
     {file = "pytest-rerunfailures-10.3.tar.gz", hash = "sha256:d8244d799f89a6edb5e57301ddaeb3b6f10d6691638d51e80b371311592e28c6"},
     {file = "pytest_rerunfailures-10.3-py3-none-any.whl", hash = "sha256:6be6f96510bf94b54198bf15bc5568fe2cdff88e83875912e22d29810acf65ff"},
+]
+pytest-split = [
+    {file = "pytest_split-0.8.1-py3-none-any.whl", hash = "sha256:74b110ea091bd147cc1c5f9665a59506e5cedfa66f96a89fb03e4ab447c2c168"},
+    {file = "pytest_split-0.8.1.tar.gz", hash = "sha256:2d88bd3dc528689a7a3f58fc12ea165c3aa62e90795e420dfad920afe5612d6d"},
 ]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},

--- a/goth_tests/pyproject.toml
+++ b/goth_tests/pyproject.toml
@@ -21,6 +21,7 @@ python = "^3.8.0"
 pytest = "^6.2"
 pytest-asyncio = "^0.20.2"
 pytest-rerunfailures = "^10.3"
+pytest-split = "^0.8.1"
 goth = "^0.15.0"
 # to use development goth version uncomment below
 # goth =  { git = "https://github.com/golemfactory/goth.git", rev = "d2951a62e2a7cf0712f7f4a66c4a080777841611" }


### PR DESCRIPTION
Break up goth build into two partitions. More partitions does not make sense right now as gothic runners are limited.

Adding new goth tests does not require rerunning timings, the system uses average time for unknown tests.