### PR TITLE
Document app-key create --id

### DIFF
--- a/core/identity/src/cli/appkey.rs
+++ b/core/identity/src/cli/appkey.rs
@@ -15,6 +15,7 @@ pub enum AppKeyCommand {
         name: String,
         #[structopt(skip = model::DEFAULT_ROLE)]
         role: String,
+        /// Select identity for this app-key.
         #[structopt(long)]
         id: Option<String>,
         /// Set cors policy for request made using this app-key.


### PR DESCRIPTION
Note that structopt automatically uses doc-comments as help messages.