### PR TITLE
payment: Detect tx overspending

### DIFF
--- a/core/payment/src/error.rs
+++ b/core/payment/src/error.rs
@@ -355,6 +355,10 @@ pub mod processor {
                 "Transaction balance too low (probably tx hash re-used)".to_owned(),
             ))
         }
+
+        pub fn overspending(tx_amount: &BigDecimal, total_amount: &BigDecimal) -> Result<(), Self> {
+            Err(Self::Validation(format!("Transaction for {tx_amount} used for multiple payments amounting to {total_amount}")))
+        }
     }
 
     #[derive(thiserror::Error, Debug)]


### PR DESCRIPTION
A provider will now detect if a transaction will be used for multiple SendPayment instances exceeding the actual tx amount.