### PR TITLE
Replace all handbooks links with docs.golem.network

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
             catch(e) {
               let body = ["By installing & running this software you declare that you have read",
                 "understood and hereby accept the disclaimer and",
-                "privacy warning found at https://handbook.golem.network/see-also/terms"].join("\n");
+                "privacy warning found at https://docs.golem.network/docs/golem/terms"].join("\n");
 
               let release =  await github.request("POST /repos/:owner/:repo/releases", {
                 owner: context.repo.owner,

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Has IT resources available that can be shared with other actors in the network. 
 Builds applications to run for requestors on the network. Golem's potential goes much beyond a singular application. See [Awesome Golem](https://github.com/golemfactory/awesome-golem/blob/main/README.md#%EF%B8%8F-apps) for just a taste of the various types of applications that can be built and run on Golem!
 
 ## Documentation
-For a more in-depth look at how Golem works, head over to our [documentation.](https://handbook.golem.network/)
+For a more in-depth look at how Golem works, head over to our [documentation.](https://docs.golem.network/)
 
 ## Project Layout
 
@@ -77,7 +77,7 @@ Important milestones for Golem development were [Beta I](https://github.com/gole
 * **Production-ready** and **easy to maintain** code base.
 * **Modular architecture** with all the building blocks being replaceable.
 * Small binaries (under 30Mb).
-* [Documentation and SDK](https://handbook.golem.network/) for Golem app developers.
+* [Documentation and SDK](https://docs.golem.network/) for Golem app developers.
 
 ## List of implemented and planned functionality 
 

--- a/agent/provider/readme.md
+++ b/agent/provider/readme.md
@@ -1,7 +1,7 @@
 # ToC
 
 1. [Introduction](#provider-agent)
-2. [Handbook](#handbook)
+2. [Documentation](#documentation)
    1. [ExeUnits](#exeunits)
    2. [Presets](#presets)
    3. [Running](#running-the-provider-agent)
@@ -21,9 +21,9 @@ the Provider Node in the Yagna Network. It includes rules and logic for:
 * ExeUnit instantiation and control
 * Invoice/Debit Note generation
 
-# Handbook
+# Documentation
 
-Please refer https://handbook.golem.network/ for instruction how to use Provider.
+Please refer https://docs.golem.network/docs/providers/provider-installation for instruction how to use Provider.
 
 ### Offer formulation
 

--- a/core/serv/src/main.rs
+++ b/core/serv/src/main.rs
@@ -68,12 +68,12 @@ const FD_METRICS_INTERVAL: Duration = Duration::from_secs(60);
 ///
 /// By running this software you declare that you have read,
 /// understood and hereby accept the disclaimer and
-/// privacy warning found at https://handbook.golem.network/see-also/terms
+/// privacy warning found at https://docs.golem.network/docs/golem/terms
 ///
 /// Use RUST_LOG env variable to change log level.
 struct CliArgs {
     /// Accept the disclaimer and privacy warning found at
-    /// {n}https://handbook.golem.network/see-also/terms
+    /// {n}https://docs.golem.network/docs/golem/terms
     #[structopt(long)]
     #[cfg_attr(not(feature = "tos"), structopt(hidden = true))]
     accept_terms: bool,
@@ -643,7 +643,7 @@ fn prompt_terms() -> Result<()> {
     let header = r#"
 By running this software you declare that you have read, understood
 and hereby accept the disclaimer and privacy warning found at
-https://handbook.golem.network/see-also/terms
+https://docs.golem.network/docs/golem/terms
 
 "#;
 

--- a/debian/core/templates
+++ b/debian/core/templates
@@ -4,7 +4,7 @@ Choices: no, yes
 Description: Do you accept ?
   By installing this software you declare that you have read,
   understood and hereby accept the disclaimer and privacy warning
-  found at https://handbook.golem.network/see-also/terms.
+  found at https://docs.golem.network/docs/golem/terms
 
 Template: golem/gsb-port
 Type: string

--- a/debian/provider/templates
+++ b/debian/provider/templates
@@ -5,7 +5,7 @@ Description: Do you accept ?
   By installing this software you declare that you have read,
   understood and hereby accept the disclaimers and privacy warnings
   found at
-    https://handbook.golem.network/see-also/terms
+    https://docs.golem.network/docs/golem/terms
   and
     https://handbook.golem.network/see-also/provider-subsidy-terms
 

--- a/golem_cli/src/platform.rs
+++ b/golem_cli/src/platform.rs
@@ -39,14 +39,14 @@ pub fn kvm_status() -> Status {
         }
         if path::Path::new("/.dockerenv").exists() {
             return Status::InvalidEnv(Cow::Borrowed(
-                "running inside Docker without access to /dev/kvm. For additional help see: https://handbook.golem.network/troubleshooting/provider-troubleshooting#invalid-vm",
+                "running inside Docker without access to /dev/kvm. For additional help see: https://docs.golem.network/docs/troubleshooting/provider#could-not-access-kvm-kernel-module-no-such-file-or-directory",
             ));
         }
         return Status::Permission(Cow::Borrowed("kvm kernel module is not installed"));
     }
     match nix::unistd::access(dev_kvm, AccessFlags::W_OK | AccessFlags::R_OK) {
         Ok(()) => Status::Valid,
-        Err(_) => Status::Permission(Cow::Borrowed("the user has no access to /dev/kvm. For additional help see: https://handbook.golem.network/troubleshooting/provider-troubleshooting#invalid-vm")),
+        Err(_) => Status::Permission(Cow::Borrowed("the user has no access to /dev/kvm. For additional help see: https://docs.golem.network/docs/troubleshooting/provider#could-not-access-kvm-kernel-module-no-such-file-or-directory")),
     }
 }
 

--- a/goth_tests/pyproject.toml
+++ b/goth_tests/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Framework :: AsyncIO",
 ]
 repository = "https://github.com/golemfactory/yagna"
-documentation = "https://handbook.golem.network"
+documentation = "https://docs.golem.network"
 readme = "README.md"
 
 # Uncomment to enable pulling packages from test.pypi.org


### PR DESCRIPTION
We have now conducted a full switch away from the handbook in favor of the new https://docs.golem.network

For that, I have replaced all current mentions of the handbook in the source code.