### PR TITLE
payment: Fix poison error due to panic in GSB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8545,6 +8545,7 @@ dependencies = [
 name = "ya-payment"
 version = "0.3.0"
 dependencies = [
+ "actix",
  "actix-rt",
  "actix-web",
  "anyhow",

--- a/core/payment/Cargo.toml
+++ b/core/payment/Cargo.toml
@@ -25,6 +25,7 @@ ya-service-api-interfaces = "0.2"
 ya-service-api-web = "0.2"
 ya-service-bus = "0.6.1"
 
+actix = { version = "0.13", default-features = false }
 actix-web = "4"
 anyhow = "1.0"
 base64 = "0.12"

--- a/core/payment/src/service.rs
+++ b/core/payment/src/service.rs
@@ -655,7 +655,7 @@ mod public {
 
     use crate::error::processor::VerifyPaymentError;
     use crate::error::DbError;
-    use crate::payment_sync::{send_sync_notifs_job, send_sync_requests};
+    use crate::payment_sync::{send_sync_requests, PaymentSyncCron};
     use crate::utils::*;
     use crate::{dao::*, payment_sync::SYNC_NOTIFS_NOTIFY};
 
@@ -685,7 +685,7 @@ mod public {
             .bind_with_processor(sync_payment);
 
         if opts.run_sync_job {
-            send_sync_notifs_job(db.clone());
+            PaymentSyncCron::new(db.clone());
             send_sync_requests(db.clone());
         }
 


### PR DESCRIPTION
Code for payment synchronization wrongly ran GSB futures within tokio LocalPool. This lead to panics in GSB when it attempted to spawn tasks, which in turn caused a deadlock within GSB.