### PR TITLE
payment: filter by role in get_for_confirmation

### DIFF
--- a/core/payment/src/dao/payment.rs
+++ b/core/payment/src/dao/payment.rs
@@ -21,6 +21,7 @@ use ya_core_model::payment::local::{DriverName, NetworkName};
 use ya_persistence::executor::{
     do_with_transaction, readonly_transaction, AsDao, ConnType, PoolType,
 };
+use ya_persistence::types::Role;
 
 pub struct PaymentDao<'c> {
     pool: &'c PoolType,
@@ -188,12 +189,17 @@ impl<'c> PaymentDao<'c> {
         .await
     }
 
-    pub async fn get_for_confirmation(&self, details: Vec<u8>) -> DbResult<Vec<Payment>> {
+    pub async fn get_for_confirmation(
+        &self,
+        details: Vec<u8>,
+        role: Role,
+    ) -> DbResult<Vec<Payment>> {
         readonly_transaction(self.pool, "payment_dao_get_for_confirmation", move |conn| {
             let mut result = Vec::new();
 
             let payments: Vec<ReadObj> = dsl::pay_payment
                 .filter(dsl::details.eq(&details))
+                .filter(dsl::role.eq(&role.to_string()))
                 .load(conn)?;
 
             for payment in payments {

--- a/core/payment/src/processor.rs
+++ b/core/payment/src/processor.rs
@@ -27,6 +27,7 @@ use ya_core_model::payment::local::{
 use ya_core_model::payment::public::{SendPayment, BUS_ID};
 use ya_net::RemoteEndpoint;
 use ya_persistence::executor::DbExecutor;
+use ya_persistence::types::Role;
 use ya_service_bus::typed::Endpoint;
 use ya_service_bus::{typed as bus, RpcEndpoint};
 
@@ -626,7 +627,7 @@ impl PaymentProcessor {
         // Verify totals for all agreements and activities with the same confirmation
         let payment_dao: PaymentDao = self.db_executor.as_dao();
         let shared_payments = payment_dao
-            .get_for_confirmation(confirmation.confirmation)
+            .get_for_confirmation(confirmation.confirmation, Role::Provider)
             .await?;
         let other_payment_total = shared_payments
             .iter()


### PR DESCRIPTION
Using the same database for provider and requestor resulted in a false positive in the overspending protection code. This is resolved by filtering the payments by role.