### PR TITLE
Fix yagna net find

### DIFF
--- a/core/net/src/hybrid/cli.rs
+++ b/core/net/src/hybrid/cli.rs
@@ -140,7 +140,11 @@ pub(crate) fn bind_service(base_client: Client) {
                 endpoints: node
                     .endpoints
                     .into_iter()
-                    .map(|ep| ep.address.parse())
+                    .map(|ep| {
+                        ep.address
+                            .parse()
+                            .map(|ip: IpAddr| SocketAddr::new(ip, ep.port as u16))
+                    })
                     .collect::<Result<Vec<_>, _>>()?,
                 seen: node.seen_ts,
                 slot: node.slot,


### PR DESCRIPTION
`yagna net find` reports error when trying to find Node with public IP
```
C:\Users\jalas167>yagna net find 0xb2122afe5f0aae9532e5540be7ce0ef8ac3310b2
[2024-04-08T12:36:55.587+0200 ERROR yagna] Exiting..., error details: invalid socket address syntax
Error: invalid socket address syntax
```

In comparison `yagna net connect` works:
```
C:\Users\jalas167>yagna net connect 0xb2122afe5f0aae9532e5540be7ce0ef8ac3310b2
encryption: []
endpoints:
- 84.10.24.230:11501
identities:
- 0xb2122afe5f0aae9532e5540be7ce0ef8ac3310b2
seen: 2024-04-08 10:35:34 UTC
slot: 8295
```