### PR TITLE
Stop ya-provider on runtimes test failure

### DIFF
--- a/agent/provider/src/execution/exeunit_instance.rs
+++ b/agent/provider/src/execution/exeunit_instance.rs
@@ -96,6 +96,9 @@ impl ExeUnitInstance {
             })?;
 
         let output = child.wait_with_output().await?;
+        if !output.status.success() {
+            anyhow::bail!(String::from_utf8_lossy(output.stderr.as_slice()).to_string())
+        }
         Ok(String::from_utf8_lossy(output.stdout.as_slice()).to_string())
     }
 

--- a/agent/provider/src/execution/registry.rs
+++ b/agent/provider/src/execution/registry.rs
@@ -307,7 +307,7 @@ impl ExeUnitsRegistry {
             log::info!("Testing runtime [{}]", name);
             test_runtime(desc, &working_dir)
                 .await
-                .map_err(|e| e.context("runtime test failure"))?;
+                .map_err(|e| e.context(format!("Runtime '{name}' test failed")))?;
         }
 
         Ok(())

--- a/agent/provider/src/provider_agent.rs
+++ b/agent/provider/src/provider_agent.rs
@@ -126,7 +126,10 @@ impl ProviderAgent {
         log::info!("Payment accounts: {:#?}", accounts);
         let registry = config.registry()?;
         registry.validate()?;
-        registry.test_runtimes(&data_dir).await?;
+        registry
+            .test_runtimes(&data_dir)
+            .await
+            .inspect_err(|err| log::error!("Runtimes test failed: {err}"))?;
 
         // Generate session id from node name and process id to make sure it's unique.
         let name = args


### PR DESCRIPTION
Does not change user experience only makes debugging easier.
Without it `ya-provider` will fail later, on `offer-template` step.