### PR TITLE
Initialize more termination reason counters

### DIFF
--- a/.github/workflows/binaries-aarch64.yml
+++ b/.github/workflows/binaries-aarch64.yml
@@ -63,7 +63,7 @@ jobs:
           cp target/aarch64-unknown-linux-musl/release/{yagna,ya-provider,exe-unit,golemsp,gftp} build
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: Yagna linux-aarch64
           path: build

--- a/.github/workflows/integration-test-nightly.yml
+++ b/.github/workflows/integration-test-nightly.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix-json) }}
       fail-fast: false
-    runs-on: [goth2]
+    runs-on: [ goth2 ]
     name: Integration Tests (nightly) @ ${{ matrix.branch }}
     defaults:
       run:
@@ -92,7 +92,7 @@ jobs:
         run: echo "::set-output name=file_name::$(echo '${{ matrix.branch }}' | sed 's/\//-/g')"
 
       - name: Upload test logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: goth-logs_${{ steps.branch_as.outputs.file_name }}

--- a/core/market/src/negotiation/common.rs
+++ b/core/market/src/negotiation/common.rs
@@ -52,6 +52,23 @@ use crate::utils::AgreementLock;
 
 type IsFirst = bool;
 
+pub(crate) const KNOWN_TERMINATION_REASONS: [&str; 14] = [
+    "Cancelled",
+    "ConnectionTimedOut",
+    "DebitNoteNotPaid",
+    "DebitNotesDeadline",
+    "HealthCheckFailed",
+    "Interrupted",
+    "NoActivity",
+    "NoLongerNeeded",
+    "NotSpecified",
+    "ProviderUnreachable",
+    "RequestorUnreachable",
+    "Shutdown",
+    "Success",
+    "UnknownError",
+];
+
 #[derive(Clone)]
 pub struct CommonBroker {
     pub(super) db: DbMixedExecutor,

--- a/core/market/src/negotiation/provider.rs
+++ b/core/market/src/negotiation/provider.rs
@@ -18,7 +18,7 @@ use crate::db::{
 use crate::matcher::store::SubscriptionStore;
 use crate::protocol::negotiation::{error::*, messages::*, provider::NegotiationApi};
 
-use super::common::CommonBroker;
+use super::common::{CommonBroker, KNOWN_TERMINATION_REASONS};
 use super::error::*;
 use super::notifier::EventNotifier;
 use crate::config::Config;
@@ -94,8 +94,9 @@ impl ProviderBroker {
         counter!("market.agreements.provider.approved", 0);
         counter!("market.agreements.provider.proposed", 0);
         counter!("market.agreements.provider.terminated", 0);
-        counter!("market.agreements.provider.terminated.reason", 0, "reason" => "NotSpecified");
-        counter!("market.agreements.provider.terminated.reason", 0, "reason" => "Success");
+        for reason in KNOWN_TERMINATION_REASONS {
+            counter!("market.agreements.provider.terminated.reason", 0, "reason" => reason);
+        }
         counter!("market.agreements.provider.approving", 0);
         counter!("market.agreements.provider.committing", 0);
         counter!("market.agreements.provider.rejected", 0);

--- a/core/market/src/negotiation/requestor.rs
+++ b/core/market/src/negotiation/requestor.rs
@@ -96,8 +96,9 @@ impl RequestorBroker {
         counter!("market.agreements.requestor.created", 0);
         counter!("market.agreements.requestor.rejected", 0);
         counter!("market.agreements.requestor.terminated", 0);
-        counter!("market.agreements.requestor.terminated.reason", 0, "reason" => "NotSpecified");
-        counter!("market.agreements.requestor.terminated.reason", 0, "reason" => "Success");
+        for reason in KNOWN_TERMINATION_REASONS {
+            counter!("market.agreements.requestor.terminated.reason", 0, "reason" => reason);
+        }
         counter!("market.agreements.requestor.committing", 0);
         counter!("market.events.requestor.queried", 0);
         counter!("market.proposals.requestor.countered", 0);


### PR DESCRIPTION
Interestingly enough, we encountered both `RequestorUnreachable` reported both by provider and requestor.
Even more interestingly, we encountered `ProviderUnreachable` reporterd only by provider.