### PR TITLE
Improve default identity generation

### DIFF
--- a/core/identity/src/autoconf.rs
+++ b/core/identity/src/autoconf.rs
@@ -10,7 +10,10 @@ use anyhow::Context;
 
 const ENV_AUTOCONF_APP_KEY: &str = "YAGNA_AUTOCONF_APPKEY";
 
-pub fn identity_from_env(password: Protected, env_name: &str) -> anyhow::Result<Option<IdentityKey>> {
+pub fn identity_from_env(
+    password: Protected,
+    env_name: &str,
+) -> anyhow::Result<Option<IdentityKey>> {
     let secret_hex: Vec<u8> = match env::var(env_name) {
         Ok(v) => v
             .from_hex()

--- a/core/identity/src/autoconf.rs
+++ b/core/identity/src/autoconf.rs
@@ -8,23 +8,21 @@ use ya_core_model::NodeId;
 use crate::id_key::IdentityKey;
 use anyhow::Context;
 
-// autoconfiguration
-const ENV_AUTOCONF_PK: &str = "YAGNA_AUTOCONF_ID_SECRET";
 const ENV_AUTOCONF_APP_KEY: &str = "YAGNA_AUTOCONF_APPKEY";
 
-pub fn preconfigured_identity(password: Protected) -> anyhow::Result<Option<IdentityKey>> {
-    let secret_hex: Vec<u8> = match env::var(ENV_AUTOCONF_PK) {
+pub fn identity_from_env(password: Protected, env_name: &str) -> anyhow::Result<Option<IdentityKey>> {
+    let secret_hex: Vec<u8> = match env::var(env_name) {
         Ok(v) => v
             .from_hex()
-            .with_context(|| format!("Failed to parse identity from {}", ENV_AUTOCONF_PK))?,
+            .with_context(|| format!("Failed to parse identity from {}", env_name))?,
         Err(_) => return Ok(None),
     };
     let secret = SecretKey::from_raw(&secret_hex)?;
     Ok(Some(IdentityKey::from_secret(None, secret, password)))
 }
 
-pub fn preconfigured_node_id() -> anyhow::Result<Option<NodeId>> {
-    let secret_hex: Vec<u8> = match env::var(ENV_AUTOCONF_PK) {
+pub fn preconfigured_node_id(env_name: &str) -> anyhow::Result<Option<NodeId>> {
+    let secret_hex: Vec<u8> = match env::var(env_name) {
         Ok(v) => v.from_hex()?,
         Err(_) => return Ok(None),
     };

--- a/core/identity/src/service/appkey.rs
+++ b/core/identity/src/service/appkey.rs
@@ -94,7 +94,7 @@ pub async fn activate(db: &DbExecutor, gsb: Arc<GsbBindPoints>) -> anyhow::Resul
 
     let create_tx = tx.clone();
     let preconfigured_appkey = crate::autoconf::preconfigured_appkey();
-    let preconfigured_node_id = crate::autoconf::preconfigured_node_id()?;
+    let preconfigured_node_id = crate::autoconf::preconfigured_node_id("YAGNA_AUTOCONF_ID_SECRET")?;
     let start_datetime = Utc::now().naive_utc();
 
     {

--- a/core/identity/src/service/identity.rs
+++ b/core/identity/src/service/identity.rs
@@ -4,7 +4,7 @@ use std::convert::{TryFrom, TryInto};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use anyhow::{bail};
+use anyhow::bail;
 use chrono::Utc;
 use ethsign::{KeyFile, Protected, PublicKey};
 use futures::lock::Mutex;
@@ -14,16 +14,17 @@ use ya_client_model::NodeId;
 use ya_core_model::bus::GsbBindPoints;
 use ya_service_bus::{typed as bus, RpcEndpoint, RpcMessage};
 
-use ya_core_model::identity as model;
-use ya_core_model::identity::event::IdentityEvent;
-use ya_persistence::executor::DbExecutor;
 use crate::dao::identity::Identity;
 use crate::dao::{Error as DaoError, Error, IdentityDao};
 use crate::id_key::{default_password, generate_identity_key, IdentityKey};
+use ya_core_model::identity as model;
+use ya_core_model::identity::event::IdentityEvent;
+use ya_persistence::executor::DbExecutor;
 
-lazy_static! (
-    static ref DEFAULT_IDENTITY_INIT_PRIVATE_KEY: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
-);
+lazy_static! {
+    static ref DEFAULT_IDENTITY_INIT_PRIVATE_KEY: Arc<Mutex<Option<String>>> =
+        Arc::new(Mutex::new(None));
+};
 
 #[derive(Default)]
 struct Subscription {
@@ -95,22 +96,23 @@ impl IdentityService {
             });
         }
 
-        let default_key =
-            if let Some(key) = crate::autoconf::identity_from_env(default_password(), "YAGNA_AUTOCONF_ID_SECRET")? {
-                db.as_dao::<IdentityDao>()
-                    .init_preconfigured(Identity {
-                        identity_id: key.id(),
-                        key_file_json: key.to_key_file()?,
-                        is_default: true,
-                        is_deleted: false,
-                        alias: None,
-                        note: None,
-                        created_date: Utc::now().naive_utc(),
-                    })
-                    .await?
-                    .identity_id
-            } else {
-                db.as_dao::<IdentityDao>()
+        let default_key = if let Some(key) =
+            crate::autoconf::identity_from_env(default_password(), "YAGNA_AUTOCONF_ID_SECRET")?
+        {
+            db.as_dao::<IdentityDao>()
+                .init_preconfigured(Identity {
+                    identity_id: key.id(),
+                    key_file_json: key.to_key_file()?,
+                    is_default: true,
+                    is_deleted: false,
+                    alias: None,
+                    note: None,
+                    created_date: Utc::now().naive_utc(),
+                })
+                .await?
+                .identity_id
+        } else {
+            db.as_dao::<IdentityDao>()
                     .init_default_key(|| {
                         match crate::autoconf::identity_from_env(default_password(), "YAGNA_DEFAULT_SECRET_KEY") {
                             Ok(Some(key)) => {
@@ -146,7 +148,7 @@ impl IdentityService {
                     })
                     .await?
                     .identity_id
-            };
+        };
 
         log::info!("using default identity: {:?}", default_key);
 


### PR DESCRIPTION
Currently used YAGNA_AUTOCONF_ID_SECRET sets private key for yagna for use which is OK. What is not ok is that it overrides all settings and sets identity be default.

Introduced new variable YAGNA_DEFAULT_SECRET_KEY which sets identity ONLY if no identity is set. The created identity behavior is exactly the same as new random identity generated by yagna.


