### PR TITLE
Support Direct Import of Certificates via URL Feature req #3350

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9819,6 +9819,7 @@ dependencies = [
  "predicates 2.1.5",
  "pretty_assertions",
  "regex",
+ "reqwest",
  "semver 0.11.0",
  "serde",
  "serde_json",

--- a/agent/provider/Cargo.toml
+++ b/agent/provider/Cargo.toml
@@ -66,9 +66,11 @@ sys-info = "0.8.0"
 thiserror = "1.0.14"
 tokio = { version = "1", features = ["macros", "process", "signal"] }
 tokio-stream = { version = "0.1.6", features = ["sync"] }
-url = "2.1.1"
+url = "2.5"
 walkdir = "2.3.1"
 yansi = "0.5.0"
+reqwest = { version = "0.11", features = ["blocking"] }
+tempfile = "3.8"
 
 [target.'cfg(target_family = "unix")'.dependencies]
 nix = "0.22.0"

--- a/agent/provider/src/cert_utils.rs
+++ b/agent/provider/src/cert_utils.rs
@@ -1,0 +1,44 @@
+use anyhow::{anyhow, Result};
+use std::path::{Path, PathBuf};
+use url::Url;
+use std::fs;
+
+pub fn download_cert_if_url(cert_source: &PathBuf, temp_dir: &Path) -> Result<PathBuf> {
+    let source_str = cert_source.to_string_lossy();
+    if let Ok(url) = Url::parse(&source_str) {
+        if url.scheme() == "http" || url.scheme() == "https" {
+            download_cert(&source_str, temp_dir)
+        } else {
+            Ok(cert_source.clone())
+        }
+    } else {
+        Ok(cert_source.clone())
+    }
+}
+
+fn download_cert(url: &str, temp_dir: &Path) -> Result<PathBuf> {
+    // Create temp directory if it doesn't exist
+    fs::create_dir_all(temp_dir)?;
+
+    // Generate a unique filename based on the URL
+    let file_name = url
+        .split('/')
+        .last()
+        .ok_or_else(|| anyhow!("Invalid URL format"))?;
+    let temp_path = temp_dir.join(file_name);
+
+    // Download the certificate
+    let response = reqwest::blocking::get(url)?;
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "Failed to download certificate. Status: {}",
+            response.status()
+        ));
+    }
+
+    // Save the certificate to a temporary file
+    let content = response.bytes()?;
+    fs::write(&temp_path, content)?;
+
+    Ok(temp_path)
+}

--- a/agent/provider/src/lib.rs
+++ b/agent/provider/src/lib.rs
@@ -13,6 +13,7 @@ pub mod rules;
 pub mod signal;
 pub mod startup_config;
 pub mod tasks;
+mod cert_utils;
 
 pub use config::globals::GlobalsState;
 pub use startup_config::ReceiverAccount;


### PR DESCRIPTION
Adding the import-cert-url command to import a cert with a url.
Chose to add this as a separate command to keep existing working functionality